### PR TITLE
Added A-GEM Strategy, Example, and Custom Replay Buffer

### DIFF
--- a/examples/energy_dataset_agem_example.py
+++ b/examples/energy_dataset_agem_example.py
@@ -1,5 +1,6 @@
 import logging
 import pathlib
+import torch
 import torch.nn as nn
 
 from pyclad.callbacks.evaluation.concept_metric_evaluation import ConceptMetricCallback
@@ -25,6 +26,7 @@ if __name__ == "__main__":
     detection using the method proposed here <https://github.com/lifelonglab/lifelong-anomaly-detection-scenarios>
     """
     dataset = EnergyPlantsDataset(dataset_type="random_anomalies")
+    device = torch.device("mps" if torch.backends.mps.is_available() else "cpu")
     # dataset = convert_dataset_to_overlapping_windows(window_size=10, dataset=dataset)
 
     input_features = 14
@@ -46,9 +48,18 @@ if __name__ == "__main__":
         nn.Sigmoid(),
     )
 
-    model = Autoencoder(encoder, decoder)
+    model = Autoencoder(encoder, decoder, epochs=40, device=device)
 
-    strategy = AGEMStrategy(model, BalancedReplayBuffer(max_size=2000))
+    strategy = AGEMStrategy(
+        model,
+        BalancedReplayBuffer(max_size=1000),
+        module=model.module,
+        batch_size=32,
+        lr=1e-2,
+        epochs=60,
+        device=device,
+        shuffle=True,
+    )
     callbacks = [
         ConceptMetricCallback(
             base_metric=RocAuc(),

--- a/examples/energy_dataset_agem_example.py
+++ b/examples/energy_dataset_agem_example.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     callbacks = [
         ConceptMetricCallback(
             base_metric=RocAuc(),
-            metrics=[ContinualAverage(), BackwardTransfer(), ForwardTransfer()],
+            summarized_metrics=[ContinualAverage(), BackwardTransfer(), ForwardTransfer()],
         ),
         TimeEvaluationCallback(),
         MemoryUsageCallback(),

--- a/examples/energy_dataset_agem_example.py
+++ b/examples/energy_dataset_agem_example.py
@@ -1,0 +1,64 @@
+import logging
+import pathlib
+import torch.nn as nn
+
+from pyclad.callbacks.evaluation.concept_metric_evaluation import ConceptMetricCallback
+from pyclad.callbacks.evaluation.memory_usage import MemoryUsageCallback
+from pyclad.callbacks.evaluation.time_evaluation import TimeEvaluationCallback
+from pyclad.data.datasets.energy_plants_dataset import EnergyPlantsDataset
+from pyclad.metrics.base.roc_auc import RocAuc
+from pyclad.metrics.continual.average_continual import ContinualAverage
+from pyclad.metrics.continual.backward_transfer import BackwardTransfer
+from pyclad.metrics.continual.forward_transfer import ForwardTransfer
+from pyclad.models.autoencoder.autoencoder import Autoencoder
+from pyclad.output.json_writer import JsonOutputWriter
+from pyclad.scenarios.concept_aware import ConceptAwareScenario
+from pyclad.strategies.regularization.lwf import LwFStrategy
+from pyclad.strategies.replay.agem import AGEMStrategy
+from pyclad.strategies.replay.buffers import BalancedReplayBuffer
+
+logging.basicConfig(level=logging.INFO, handlers=[logging.FileHandler("debug.log"), logging.StreamHandler()])
+
+if __name__ == "__main__":
+    """
+    This example showcase how to run a concept aware scenario using the Energy dataset adopted to continual anomaly
+    detection using the method proposed here <https://github.com/lifelonglab/lifelong-anomaly-detection-scenarios>
+    """
+    dataset = EnergyPlantsDataset(dataset_type="random_anomalies")
+    # dataset = convert_dataset_to_overlapping_windows(window_size=10, dataset=dataset)
+
+    input_features = 14
+    # train_concepts = read_concepts_from_df(dataset["train"].to_pandas())
+    # input_features = dataset._train_concepts[0].data.shape[2]
+    print(input_features)
+
+    encoder = nn.Sequential(
+        nn.Linear(input_features, 8),
+        nn.ReLU(),
+        nn.Linear(8, 4),
+        nn.ReLU(),
+    )
+
+    decoder = nn.Sequential(
+        nn.Linear(4, 8),
+        nn.ReLU(),
+        nn.Linear(8, input_features),
+        nn.Sigmoid(),
+    )
+
+    model = Autoencoder(encoder, decoder)
+
+    strategy = AGEMStrategy(model, BalancedReplayBuffer(max_size=2000))
+    callbacks = [
+        ConceptMetricCallback(
+            base_metric=RocAuc(),
+            metrics=[ContinualAverage(), BackwardTransfer(), ForwardTransfer()],
+        ),
+        TimeEvaluationCallback(),
+        MemoryUsageCallback(),
+    ]
+    scenario = ConceptAwareScenario(dataset, strategy=strategy, callbacks=callbacks)
+    scenario.run()
+
+    output_writer = JsonOutputWriter(pathlib.Path("output-energy-AGEM.json"))
+    output_writer.write([model, dataset, strategy, *callbacks])

--- a/examples/energy_dataset_cumulative_example.py
+++ b/examples/energy_dataset_cumulative_example.py
@@ -1,0 +1,62 @@
+import logging
+import pathlib
+import torch.nn as nn
+
+from pyclad.callbacks.evaluation.concept_metric_evaluation import ConceptMetricCallback
+from pyclad.callbacks.evaluation.memory_usage import MemoryUsageCallback
+from pyclad.callbacks.evaluation.time_evaluation import TimeEvaluationCallback
+from pyclad.data.datasets.energy_plants_dataset import EnergyPlantsDataset
+from pyclad.metrics.base.roc_auc import RocAuc
+from pyclad.metrics.continual.average_continual import ContinualAverage
+from pyclad.metrics.continual.backward_transfer import BackwardTransfer
+from pyclad.metrics.continual.forward_transfer import ForwardTransfer
+from pyclad.models.autoencoder.autoencoder import Autoencoder
+from pyclad.output.json_writer import JsonOutputWriter
+from pyclad.scenarios.concept_aware import ConceptAwareScenario
+from pyclad.strategies.baselines.naive import NaiveStrategy
+
+logging.basicConfig(level=logging.INFO, handlers=[logging.FileHandler("debug.log"), logging.StreamHandler()])
+
+if __name__ == "__main__":
+    """
+    This example showcase how to run a concept aware scenario using the Energy dataset adopted to continual anomaly
+    detection using the method proposed here <https://github.com/lifelonglab/lifelong-anomaly-detection-scenarios>
+    """
+    dataset = EnergyPlantsDataset(dataset_type="random_anomalies")
+    # dataset = convert_dataset_to_overlapping_windows(window_size=10, dataset=dataset)
+
+    input_features = 14
+    # train_concepts = read_concepts_from_df(dataset["train"].to_pandas())
+    # input_features = dataset._train_concepts[0].data.shape[2]
+    print(input_features)
+
+    encoder = nn.Sequential(
+        nn.Linear(input_features, 8),
+        nn.ReLU(),
+        nn.Linear(8, 4),
+        nn.ReLU(),
+    )
+
+    decoder = nn.Sequential(
+        nn.Linear(4, 8),
+        nn.ReLU(),
+        nn.Linear(8, input_features),
+        nn.Sigmoid(),
+    )
+
+    model = Autoencoder(encoder, decoder)
+
+    strategy = NaiveStrategy(model)
+    callbacks = [
+        ConceptMetricCallback(
+            base_metric=RocAuc(),
+            metrics=[ContinualAverage(), BackwardTransfer(), ForwardTransfer()],
+        ),
+        TimeEvaluationCallback(),
+        MemoryUsageCallback(),
+    ]
+    scenario = ConceptAwareScenario(dataset, strategy=strategy, callbacks=callbacks)
+    scenario.run()
+
+    output_writer = JsonOutputWriter(pathlib.Path("output-energy-naive.json"))
+    output_writer.write([model, dataset, strategy, *callbacks])

--- a/examples/energy_dataset_cumulative_example.py
+++ b/examples/energy_dataset_cumulative_example.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     callbacks = [
         ConceptMetricCallback(
             base_metric=RocAuc(),
-            metrics=[ContinualAverage(), BackwardTransfer(), ForwardTransfer()],
+            summarized_metrics=[ContinualAverage(), BackwardTransfer(), ForwardTransfer()],
         ),
         TimeEvaluationCallback(),
         MemoryUsageCallback(),

--- a/examples/energy_dataset_ewc_example.py
+++ b/examples/energy_dataset_ewc_example.py
@@ -1,0 +1,59 @@
+import logging
+import pathlib
+import torch.nn as nn
+
+from pyclad.callbacks.evaluation.concept_metric_evaluation import ConceptMetricCallback
+from pyclad.callbacks.evaluation.memory_usage import MemoryUsageCallback
+from pyclad.callbacks.evaluation.time_evaluation import TimeEvaluationCallback
+from pyclad.data.datasets.energy_plants_dataset import EnergyPlantsDataset
+from pyclad.metrics.base.roc_auc import RocAuc
+from pyclad.metrics.continual.average_continual import ContinualAverage
+from pyclad.metrics.continual.backward_transfer import BackwardTransfer
+from pyclad.metrics.continual.forward_transfer import ForwardTransfer
+from pyclad.models.autoencoder.autoencoder import Autoencoder
+from pyclad.output.json_writer import JsonOutputWriter
+from pyclad.scenarios.concept_aware import ConceptAwareScenario
+from pyclad.strategies.regularization.ewc import EWCStrategy
+
+logging.basicConfig(level=logging.INFO, handlers=[logging.FileHandler("debug.log"), logging.StreamHandler()])
+
+if __name__ == "__main__":
+    """
+    This example showcase how to run a concept aware scenario using the Energy dataset adopted to continual anomaly
+    detection using the method proposed here <https://github.com/lifelonglab/lifelong-anomaly-detection-scenarios>
+    """
+    dataset = EnergyPlantsDataset(dataset_type="random_anomalies")
+    input_features = 14
+
+    print(input_features)
+
+    encoder = nn.Sequential(
+        nn.Linear(input_features, 8),
+        nn.ReLU(),
+        nn.Linear(8, 4),
+        nn.ReLU(),
+    )
+
+    decoder = nn.Sequential(
+        nn.Linear(4, 8),
+        nn.ReLU(),
+        nn.Linear(8, input_features),
+        nn.Sigmoid(),
+    )
+
+    model = Autoencoder(encoder, decoder)
+
+    strategy = EWCStrategy(model)
+    callbacks = [
+        ConceptMetricCallback(
+            base_metric=RocAuc(),
+            metrics=[ContinualAverage(), BackwardTransfer(), ForwardTransfer()],
+        ),
+        TimeEvaluationCallback(),
+        MemoryUsageCallback(),
+    ]
+    scenario = ConceptAwareScenario(dataset, strategy=strategy, callbacks=callbacks)
+    scenario.run()
+
+    output_writer = JsonOutputWriter(pathlib.Path("output-energy-EWC.json"))
+    output_writer.write([model, dataset, strategy, *callbacks])

--- a/examples/energy_dataset_lwf_example.py
+++ b/examples/energy_dataset_lwf_example.py
@@ -1,0 +1,62 @@
+import logging
+import pathlib
+import torch.nn as nn
+
+from pyclad.callbacks.evaluation.concept_metric_evaluation import ConceptMetricCallback
+from pyclad.callbacks.evaluation.memory_usage import MemoryUsageCallback
+from pyclad.callbacks.evaluation.time_evaluation import TimeEvaluationCallback
+from pyclad.data.datasets.energy_plants_dataset import EnergyPlantsDataset
+from pyclad.metrics.base.roc_auc import RocAuc
+from pyclad.metrics.continual.average_continual import ContinualAverage
+from pyclad.metrics.continual.backward_transfer import BackwardTransfer
+from pyclad.metrics.continual.forward_transfer import ForwardTransfer
+from pyclad.models.autoencoder.autoencoder import Autoencoder
+from pyclad.output.json_writer import JsonOutputWriter
+from pyclad.scenarios.concept_aware import ConceptAwareScenario
+from pyclad.strategies.regularization.lwf import LwFStrategy
+
+logging.basicConfig(level=logging.INFO, handlers=[logging.FileHandler("debug.log"), logging.StreamHandler()])
+
+if __name__ == "__main__":
+    """
+    This example showcase how to run a concept aware scenario using the Energy dataset adopted to continual anomaly
+    detection using the method proposed here <https://github.com/lifelonglab/lifelong-anomaly-detection-scenarios>
+    """
+    dataset = EnergyPlantsDataset(dataset_type="random_anomalies")
+    #dataset = convert_dataset_to_overlapping_windows(window_size=10, dataset=dataset)
+
+    input_features = 14
+    # train_concepts = read_concepts_from_df(dataset["train"].to_pandas())
+    #input_features = dataset._train_concepts[0].data.shape[2]
+    print(input_features)
+    
+    encoder = nn.Sequential(
+        nn.Linear(input_features, 8),
+        nn.ReLU(),
+        nn.Linear(8, 4),
+        nn.ReLU(),
+    )
+
+    decoder = nn.Sequential(
+        nn.Linear(4, 8),
+        nn.ReLU(),
+        nn.Linear(8, input_features),
+        nn.Sigmoid(),
+    )
+
+    model = Autoencoder(encoder, decoder)
+    
+    strategy = LwFStrategy(model)
+    callbacks = [
+        ConceptMetricCallback(
+            base_metric=RocAuc(),
+            metrics=[ContinualAverage(), BackwardTransfer(), ForwardTransfer()],
+        ),
+        TimeEvaluationCallback(),
+        MemoryUsageCallback(),
+    ]
+    scenario = ConceptAwareScenario(dataset, strategy=strategy, callbacks=callbacks)
+    scenario.run()
+
+    output_writer = JsonOutputWriter(pathlib.Path("output-energy.json"))
+    output_writer.write([model, dataset, strategy, *callbacks])

--- a/examples/energy_dataset_lwf_example.py
+++ b/examples/energy_dataset_lwf_example.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     callbacks = [
         ConceptMetricCallback(
             base_metric=RocAuc(),
-            metrics=[ContinualAverage(), BackwardTransfer(), ForwardTransfer()],
+            summarized_metrics=[ContinualAverage(), BackwardTransfer(), ForwardTransfer()],
         ),
         TimeEvaluationCallback(),
         MemoryUsageCallback(),

--- a/src/pyclad/models/autoencoder/autoencoder.py
+++ b/src/pyclad/models/autoencoder/autoencoder.py
@@ -11,11 +11,18 @@ from pyclad.models.model import Model
 
 class Autoencoder(Model):
     def __init__(
-        self, encoder: nn.Module, decoder: nn.Module, lr: float = 1e-2, threshold: float = 0.5, epochs: int = 20
+        self,
+        encoder: nn.Module,
+        decoder: nn.Module,
+        lr: float = 1e-2,
+        threshold: float = 0.5,
+        epochs: int = 20,
+        device: str | torch.device = "cpu",
     ):
         self.module = AutoencoderModule(encoder, decoder, lr)
         self.threshold = threshold
         self.epochs = epochs
+        self.device = torch.device(device)
 
     def fit(self, data: np.ndarray):
         dataset = TensorDataset(torch.Tensor(data))
@@ -24,8 +31,10 @@ class Autoencoder(Model):
         trainer.fit(self.module, dataloader)
 
     def predict(self, data: np.ndarray) -> (np.ndarray, np.ndarray):
-        x_hat = self.module(torch.Tensor(data)).detach()
-        rec_error = ((data - x_hat.numpy()) ** 2).mean(axis=1)
+        self.module.to(self.device)
+        with torch.no_grad():
+            x_hat = self.module(torch.tensor(np.array(data, dtype=np.float32, copy=True), device=self.device))
+        rec_error = ((np.asarray(data) - x_hat.detach().cpu().numpy()) ** 2).mean(axis=1)
 
         binary_predictions = (rec_error > self.threshold).astype(int)
         return binary_predictions, rec_error
@@ -84,10 +93,12 @@ class TemporalAutoencoder(Model):
         lr: float = 1e-2,
         threshold: float = 0.5,
         epochs: int = 20,
+        device: str | torch.device = "cpu",
     ):
         self.module = TemporalAutoencoderModule(encoder, decoder, lr)
         self.threshold = threshold
         self.epochs = epochs
+        self.device = torch.device(device)
 
     def fit(self, data: np.ndarray):
         dataset = TensorDataset(torch.Tensor(data))
@@ -98,8 +109,10 @@ class TemporalAutoencoder(Model):
 
     def predict(self, data: np.ndarray) -> (np.ndarray, np.ndarray):
         batch_size, seq_len, input_size = data.shape
-        x_hat = self.module(torch.Tensor(data)).detach()
-        rec_error = ((data - x_hat.numpy()) ** 2).mean(axis=2)
+        self.module.to(self.device)
+        with torch.no_grad():
+            x_hat = self.module(torch.tensor(np.array(data, dtype=np.float32, copy=True), device=self.device))
+        rec_error = ((np.asarray(data) - x_hat.detach().cpu().numpy()) ** 2).mean(axis=2)
         rec_error = rec_error.reshape((batch_size, seq_len, 1))
 
         binary_predictions = (rec_error > self.threshold).astype(int)
@@ -159,10 +172,12 @@ class VariationalTemporalAutoencoder(Model):
         lr: float = 1e-2,
         threshold: float = 0.5,
         epochs: int = 20,
+        device: str | torch.device = "cpu",
     ):
         self.module = VariationalTemporalAutoencoderModule(encoder, decoder, lr)
         self.threshold = threshold
         self.epochs = epochs
+        self.device = torch.device(device)
 
     def fit(self, data: np.ndarray):
         dataset = TensorDataset(torch.Tensor(data))
@@ -173,9 +188,12 @@ class VariationalTemporalAutoencoder(Model):
 
     def predict(self, data: np.ndarray) -> (np.ndarray, np.ndarray):
         batch_size, seq_len, input_size = data.shape
-        x_hat, mean, var = self.module(torch.Tensor(data))
-        x_hat = x_hat.detach()
-        rec_error = ((data - x_hat.numpy()) ** 2).mean(axis=2)
+        self.module.to(self.device)
+        with torch.no_grad():
+            x_hat, mean, var = self.module(
+                torch.tensor(np.array(data, dtype=np.float32, copy=True), device=self.device)
+            )
+        rec_error = ((np.asarray(data) - x_hat.detach().cpu().numpy()) ** 2).mean(axis=2)
         rec_error = rec_error.reshape((batch_size, seq_len, 1))
 
         binary_predictions = (rec_error > self.threshold).astype(int)

--- a/src/pyclad/strategies/regularization/ewc.py
+++ b/src/pyclad/strategies/regularization/ewc.py
@@ -1,4 +1,21 @@
-"""Elastic Weight Consolidation (EWC) strategy for continual learning."""
+"""Elastic Weight Consolidation (EWC) strategy for continual learning.
+
+This implementation keeps a snapshot of model parameters after each learned
+task and estimates a diagonal Fisher Information Matrix from the current task's
+reconstruction loss. During training on later tasks, it adds the standard EWC
+quadratic penalty so parameters that were important for previous tasks are
+discouraged from drifting too far:
+
+    L_total = L_task + lambda * 0.5 * sum(F_i * (theta_i - theta_i^*)^2)
+
+where ``theta_i^*`` is the parameter value stored after an earlier task and
+``F_i`` is the corresponding diagonal Fisher importance estimate.
+
+The strategy is self-contained and does not require the wrapped pyCLAD model to
+implement any EWC-specific hooks. Instead, it resolves the underlying PyTorch
+module, prepares the training data, runs the optimization loop locally, and
+computes Fisher importances directly from gradients of the task loss.
+"""
 
 import logging
 from typing import Dict, Optional
@@ -20,9 +37,21 @@ class EWCStrategy(ConceptIncrementalStrategy, ConceptAgnosticStrategy):
     """
     Elastic Weight Consolidation strategy using a diagonal Fisher approximation.
 
-    The strategy is self-contained: it resolves the underlying torch module from
-    the pyCLAD model wrapper, runs the optimization loop locally, and estimates
-    parameter importance from reconstruction-loss gradients.
+    EWC is a regularization-based continual learning method. After each task,
+    the strategy stores:
+
+    1. A copy of the current trainable parameters.
+    2. A diagonal Fisher estimate measuring how sensitive the task loss is to
+       each parameter.
+
+    When a new task arrives, training minimizes the current task loss plus an
+    EWC penalty over all previously stored tasks. In this project, the task
+    loss is derived from the wrapped model's reconstruction objective, and the
+    Fisher estimate is computed from squared gradients averaged over the task
+    data.
+
+    This version currently supports only ``separate`` mode, where
+    one parameter snapshot and one Fisher estimate are kept per task.
 
     Parameters
     ----------

--- a/src/pyclad/strategies/regularization/ewc.py
+++ b/src/pyclad/strategies/regularization/ewc.py
@@ -1,0 +1,418 @@
+"""Elastic Weight Consolidation (EWC) strategy for continual learning."""
+
+import logging
+from typing import Dict, Optional
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from pyclad.models.model import Model
+from pyclad.strategies.strategy import (
+    ConceptAgnosticStrategy,
+    ConceptIncrementalStrategy,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class EWCStrategy(ConceptIncrementalStrategy, ConceptAgnosticStrategy):
+    """
+    Elastic Weight Consolidation strategy using a diagonal Fisher approximation.
+
+    The strategy is self-contained: it resolves the underlying torch module from
+    the pyCLAD model wrapper, runs the optimization loop locally, and estimates
+    parameter importance from reconstruction-loss gradients.
+
+    Parameters
+    ----------
+    model : Model
+        Continual learning model backed by a torch module.
+    ewc_lambda : float, optional
+        Regularization strength (default: 1000.0).
+    mode : str, optional
+        'separate' to keep one Fisher estimate per task (default).
+        'online' is reserved for a future consolidated implementation.
+    decay_factor : float, optional
+        Reserved for online mode.
+    keep_importance_data : bool, optional
+        When False in separate mode, only the latest task statistics are kept.
+    """
+
+    def __init__(
+        self,
+        model: Model,
+        ewc_lambda: float = 1000.0,
+        mode: str = "separate",
+        decay_factor: float = 0.9,
+        keep_importance_data: bool = True,
+    ):
+        self._model = model
+        self._ewc_lambda = ewc_lambda
+        self._mode = mode
+        self._decay_factor = decay_factor
+        self._keep_importance_data = keep_importance_data
+
+        self._saved_params: Dict[int, Dict[str, torch.Tensor]] = {}
+        self._importances: Dict[int, Dict[str, torch.Tensor]] = {}
+        self._task_count = 0
+
+        if mode not in ["separate", "online"]:
+            raise ValueError(f"Invalid mode: {mode}. Must be 'separate' or 'online'")
+
+        if mode == "online":
+            raise NotImplementedError("Online mode not yet implemented. Use 'separate' mode.")
+
+    def learn(self, data: np.ndarray, *args, **kwargs) -> None:
+        """
+        Learn from new data and update EWC statistics afterwards.
+
+        Parameters
+        ----------
+        data : np.ndarray
+            Training data for the current task/window.
+        """
+        if self._resolve_trainable_module() is None:
+            raise TypeError(
+                "EWCStrategy requires a PyTorch-backed model exposed via '.module' "
+                "or through a nested '.model' wrapper."
+            )
+
+        if self._task_count == 0:
+            logger.info("Task %s: training without EWC penalty (first task)", self._task_count + 1)
+        else:
+            logger.info(
+                "Task %s: training with EWC penalty (lambda=%s)",
+                self._task_count + 1,
+                self._ewc_lambda,
+            )
+
+        self._fit_with_ewc(data)
+
+        self._importances[self._task_count] = self._compute_fisher_information(data)
+        self._saved_params[self._task_count] = self._get_current_params()
+
+        if not self._keep_importance_data:
+            self._keep_latest_task_only()
+
+        self._task_count += 1
+
+    def predict(self, data: np.ndarray, *args, **kwargs) -> tuple:
+        """
+        Predict anomalies using the current model.
+
+        Parameters
+        ----------
+        data : np.ndarray
+            Data to predict on.
+
+        Returns
+        -------
+        tuple
+            (predicted labels, anomaly scores)
+        """
+        return self._model.predict(data)
+
+    def name(self) -> str:
+        """Return strategy name."""
+        return "EWC"
+
+    def additional_info(self) -> Dict:
+        """Return additional strategy information."""
+        total_params = sum(sum(p.numel() for p in task_params.values()) for task_params in self._saved_params.values())
+        total_importances = sum(
+            sum(imp.numel() for imp in task_imps.values()) for task_imps in self._importances.values()
+        )
+
+        return {
+            "model": self._model.name(),
+            "ewc_lambda": self._ewc_lambda,
+            "mode": self._mode,
+            "task_count": self._task_count,
+            "num_saved_tasks": len(self._saved_params),
+            "total_stored_params": total_params,
+            "total_stored_importances": total_importances,
+            "memory_efficient": self._mode == "online",
+        }
+
+    def _resolve_trainable_module(self, model: Optional[Model] = None) -> Optional[torch.nn.Module]:
+        """Resolve the underlying trainable torch module from nested model wrappers."""
+        current = self._model if model is None else model
+        seen = set()
+
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+
+            module = getattr(current, "module", None)
+            if isinstance(module, torch.nn.Module):
+                return module
+
+            module = getattr(current, "model", None)
+            if isinstance(module, torch.nn.Module):
+                return module
+
+            current = getattr(current, "model", None)
+
+        return None
+
+    def _resolve_model_attr(self, attr_name: str, default, model: Optional[Model] = None):
+        """Resolve an attribute from the wrapper chain or the underlying module."""
+        current = self._model if model is None else model
+        seen = set()
+
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+
+            if hasattr(current, attr_name):
+                return getattr(current, attr_name)
+
+            module = getattr(current, "module", None)
+            if module is not None and hasattr(module, attr_name):
+                return getattr(module, attr_name)
+
+            current = getattr(current, "model", None)
+
+        return default
+
+    def _resolve_batch_size(self) -> int:
+        batch_size = self._resolve_model_attr("batch_size", 32)
+        return int(batch_size) if batch_size else 32
+
+    def _resolve_lr(self) -> float:
+        lr = self._resolve_model_attr("lr", 1e-2)
+        return float(lr) if lr else 1e-2
+
+    def _resolve_epochs(self) -> int:
+        epochs = self._resolve_model_attr("epochs", 20)
+        return int(epochs) if epochs else 20
+
+    def _resolve_device(self, model: Optional[Model] = None) -> torch.device:
+        explicit_device = self._resolve_model_attr("device", None, model)
+        if explicit_device is not None:
+            return torch.device(explicit_device)
+
+        module = self._resolve_trainable_module(model)
+        if module is not None:
+            try:
+                return next(module.parameters()).device
+            except (AttributeError, StopIteration):
+                pass
+
+        return torch.device("cpu")
+
+    def _resolve_shuffle(self) -> bool:
+        current = self._model
+        seen = set()
+
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+
+            current_name = current.__class__.__name__
+            if current_name in {"TemporalAutoencoder", "VariationalTemporalAutoencoder"}:
+                return False
+            if current_name == "Autoencoder":
+                return True
+
+            module = getattr(current, "module", None)
+            if module is not None:
+                module_name = module.__class__.__name__
+                if module_name in {"TemporalAutoencoderModule", "VariationalTemporalAutoencoderModule"}:
+                    return False
+                if module_name == "AutoencoderModule":
+                    return True
+
+            current = getattr(current, "model", None)
+
+        return True
+
+    def _transform_data_for_model(self, data: np.ndarray, model: Optional[Model] = None) -> np.ndarray:
+        """
+        Apply lightweight wrapper-specific preprocessing so EWC sees the same
+        input shape as the wrapped model.
+        """
+        current = self._model if model is None else model
+        transformed = np.asarray(data)
+        seen = set()
+
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+
+            if current.__class__.__name__ == "FlattenTimeSeriesAdapter":
+                transformed = transformed.reshape(transformed.shape[0], -1)
+
+            current = getattr(current, "model", None)
+
+        return np.array(transformed, copy=True)
+
+    def _prepare_data(self, data: np.ndarray) -> torch.Tensor:
+        transformed = self._transform_data_for_model(data)
+        return torch.tensor(transformed, dtype=torch.float32)
+
+    @staticmethod
+    def _forward_batch(module: torch.nn.Module, batch: torch.Tensor) -> tuple[torch.Tensor, tuple]:
+        output = module(batch)
+        if isinstance(output, (tuple, list)):
+            return output[0], tuple(output[1:])
+        return output, tuple()
+
+    def _compute_batch_loss(self, module: torch.nn.Module, batch: torch.Tensor) -> torch.Tensor:
+        x_hat, extras = self._forward_batch(module, batch)
+        train_loss = getattr(module, "train_loss", None)
+
+        if callable(train_loss):
+            try:
+                if len(extras) >= 2:
+                    return train_loss(x_hat, batch, extras[0], extras[1])
+                return train_loss(x_hat, batch)
+            except TypeError:
+                try:
+                    if len(extras) >= 2:
+                        return train_loss(batch, x_hat, extras[0], extras[1])
+                    return train_loss(batch, x_hat)
+                except TypeError:
+                    pass
+
+        return torch.nn.functional.mse_loss(x_hat, batch)
+
+    def _compute_ewc_penalty(self, module: torch.nn.Module) -> torch.Tensor:
+        try:
+            penalty = next(module.parameters()).new_tensor(0.0)
+        except StopIteration:
+            return torch.tensor(0.0)
+
+        if not self._saved_params or not self._importances:
+            return penalty
+
+        for task_id, task_params in self._saved_params.items():
+            task_importances = self._importances.get(task_id, {})
+
+            for name, param in module.named_parameters():
+                if not param.requires_grad or name not in task_params or name not in task_importances:
+                    continue
+
+                reference = task_params[name].to(device=param.device, dtype=param.dtype)
+                importance = task_importances[name].to(device=param.device, dtype=param.dtype)
+                penalty = penalty + (importance * (param - reference).pow(2)).sum()
+
+        return 0.5 * penalty
+
+    def _fit_with_ewc(self, data: np.ndarray) -> None:
+        module = self._resolve_trainable_module()
+        if module is None:
+            raise TypeError("Model does not expose a trainable torch module required for EWC.")
+
+        tensor_data = self._prepare_data(data)
+        dataset = TensorDataset(tensor_data)
+        dataloader = DataLoader(
+            dataset,
+            batch_size=self._resolve_batch_size(),
+            shuffle=self._resolve_shuffle(),
+            num_workers=0,
+        )
+
+        device = self._resolve_device()
+        module.to(device)
+        module.train()
+
+        optimizer = torch.optim.Adam(module.parameters(), lr=self._resolve_lr())
+        epochs = self._resolve_epochs()
+
+        for epoch in range(epochs):
+            epoch_total_loss = 0.0
+            epoch_task_loss = 0.0
+            epoch_penalty = 0.0
+
+            for (batch,) in dataloader:
+                batch = batch.to(device)
+
+                optimizer.zero_grad()
+                task_loss = self._compute_batch_loss(module, batch)
+                penalty = self._compute_ewc_penalty(module)
+                total_loss = task_loss + self._ewc_lambda * penalty
+                total_loss.backward()
+                optimizer.step()
+
+                epoch_total_loss += total_loss.item()
+                epoch_task_loss += task_loss.item()
+                epoch_penalty += penalty.item()
+
+            if (epoch + 1) % max(1, epochs // 5) == 0:
+                n_batches = len(dataloader)
+                logger.info(
+                    "Epoch %s/%s: loss=%.6f (task=%.6f, ewc_penalty=%.6f)",
+                    epoch + 1,
+                    epochs,
+                    epoch_total_loss / n_batches,
+                    epoch_task_loss / n_batches,
+                    epoch_penalty / n_batches,
+                )
+
+        if hasattr(self._model, "_auto_threshold") and self._model._auto_threshold:
+            self._model._calibrate_threshold(data)
+
+    def _compute_fisher_information(self, data: np.ndarray) -> Dict[str, torch.Tensor]:
+        """
+        Estimate the diagonal Fisher Information by averaging squared gradients
+        of the task loss over the current task data.
+        """
+        module = self._resolve_trainable_module()
+        if module is None:
+            raise TypeError("Model does not expose a trainable torch module required for Fisher estimation.")
+
+        tensor_data = self._prepare_data(data)
+        dataset = TensorDataset(tensor_data)
+        dataloader = DataLoader(dataset, batch_size=self._resolve_batch_size(), shuffle=False, num_workers=0)
+
+        device = self._resolve_device()
+        module.to(device)
+
+        was_training = module.training
+        module.eval()
+
+        fisher = {
+            name: torch.zeros_like(param, device="cpu")
+            for name, param in module.named_parameters()
+            if param.requires_grad
+        }
+
+        total_samples = 0
+
+        for (batch,) in dataloader:
+            batch = batch.to(device)
+            batch_size = batch.shape[0]
+            total_samples += batch_size
+
+            module.zero_grad()
+            loss = self._compute_batch_loss(module, batch)
+            loss.backward()
+
+            for name, param in module.named_parameters():
+                if not param.requires_grad or param.grad is None:
+                    continue
+                fisher[name] += param.grad.detach().cpu().pow(2) * batch_size
+
+        if total_samples > 0:
+            for name in fisher:
+                fisher[name] /= total_samples
+
+        module.zero_grad()
+        if was_training:
+            module.train()
+
+        return {name: value.detach().clone() for name, value in fisher.items()}
+
+    def _get_current_params(self) -> Dict[str, torch.Tensor]:
+        """Snapshot the current trainable parameters."""
+        module = self._resolve_trainable_module()
+        if module is None:
+            return {}
+
+        return {name: param.detach().cpu().clone() for name, param in module.named_parameters() if param.requires_grad}
+
+    def _keep_latest_task_only(self) -> None:
+        if not self._saved_params or not self._importances:
+            return
+
+        latest_task = max(self._saved_params)
+        self._saved_params = {latest_task: self._saved_params[latest_task]}
+        self._importances = {latest_task: self._importances[latest_task]}

--- a/src/pyclad/strategies/regularization/lwf.py
+++ b/src/pyclad/strategies/regularization/lwf.py
@@ -1,0 +1,385 @@
+"""Learning without Forgetting (LwF) strategy for continual learning."""
+import copy
+import logging
+from typing import Dict, Optional
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from pyclad.models.model import Model
+from pyclad.strategies.strategy import (
+    ConceptAgnosticStrategy,
+    ConceptIncrementalStrategy,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class LwFStrategy(ConceptIncrementalStrategy, ConceptAgnosticStrategy):
+    """
+    Learning without Forgetting strategy using knowledge distillation.
+    
+    Prevents catastrophic forgetting by maintaining a frozen copy of the model
+    from the previous task and using it to regularize training on new data.
+    The new model learns to both reconstruct new data well AND preserve the
+    knowledge encoded in the old model's latent representations.
+    
+    Parameters
+    ----------
+    model : Model
+        The continual learning model (must support distillation)
+    alpha : float, optional
+        Weight for distillation loss (default: 0.5)
+        Higher values preserve more old knowledge but may limit adaptation
+    distill_mode : str, optional
+        Type of distillation: 'latent', 'reconstruction', or 'hybrid' (default: 'latent')
+    """
+    
+    def __init__(
+        self,
+        model: Model,
+        alpha: float = 0.5,
+        distill_mode: str = 'latent'
+    ):
+        self._model = model
+        self._old_model: Optional[Model] = None
+        self._alpha = alpha
+        self._distill_mode = distill_mode
+        self._task_count = 0
+        
+        if distill_mode not in ['latent', 'reconstruction', 'hybrid']:
+            raise ValueError(f"Invalid distill_mode: {distill_mode}. "
+                           f"Must be 'latent', 'reconstruction', or 'hybrid'")
+    
+    def learn(self, data: np.ndarray, *args, **kwargs) -> None:
+        """
+        Learn from new data using knowledge distillation if not the first task.
+        
+        Parameters
+        ----------
+        data : np.ndarray
+            Training data for the current task/window
+        """
+        # First task: train normally without distillation
+        if self._old_model is None:
+            logger.info(f"Task {self._task_count + 1}: Training without distillation (first task)")
+            self._model.fit(data)
+        else:
+            # Subsequent tasks: train with distillation from old model
+            logger.info(f"Task {self._task_count + 1}: Training with LwF distillation "
+                       f"(alpha={self._alpha}, mode={self._distill_mode})")
+            self._fit_with_distillation(data)
+        
+        self._task_count += 1
+        
+        # Clone current model as old model for next task
+        self._old_model = self._clone_model()
+    
+    def predict(self, data: np.ndarray, *args, **kwargs) -> tuple:
+        """
+        Predict anomalies using the current model.
+        
+        Parameters
+        ----------
+        data : np.ndarray
+            Data to predict on
+            
+        Returns
+        -------
+        tuple
+            (predicted labels, anomaly scores)
+        """
+        return self._model.predict(data)
+    
+    def name(self) -> str:
+        """Return strategy name."""
+        return "LwF"
+    
+    def additional_info(self) -> Dict:
+        """Return additional strategy information."""
+        return {
+            "model": self._model.name(),
+            "alpha": self._alpha,
+            "distill_mode": self._distill_mode,
+            "task_count": self._task_count,
+            "has_old_model": self._old_model is not None
+        }
+
+    def _resolve_trainable_module(self, model: Optional[Model] = None) -> Optional[torch.nn.Module]:
+        """
+        Resolve the underlying trainable torch module from nested model wrappers.
+        """
+        current = self._model if model is None else model
+        seen = set()
+
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+
+            module = getattr(current, "module", None)
+            if isinstance(module, torch.nn.Module):
+                return module
+
+            module = getattr(current, "model", None)
+            if isinstance(module, torch.nn.Module):
+                return module
+
+            current = getattr(current, "model", None)
+
+        return None
+
+    def _resolve_model_attr(self, attr_name: str, default, model: Optional[Model] = None):
+        """
+        Resolve an attribute from the wrapper chain or the underlying module.
+        """
+        current = self._model if model is None else model
+        seen = set()
+
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+
+            if hasattr(current, attr_name):
+                return getattr(current, attr_name)
+
+            module = getattr(current, "module", None)
+            if module is not None and hasattr(module, attr_name):
+                return getattr(module, attr_name)
+
+            current = getattr(current, "model", None)
+
+        return default
+
+    def _resolve_batch_size(self) -> int:
+        batch_size = self._resolve_model_attr("batch_size", 32)
+        return int(batch_size) if batch_size else 32
+
+    def _resolve_lr(self) -> float:
+        lr = self._resolve_model_attr("lr", 1e-2)
+        return float(lr) if lr else 1e-2
+
+    def _resolve_epochs(self) -> int:
+        epochs = self._resolve_model_attr("epochs", 20)
+        return int(epochs) if epochs else 20
+
+    def _resolve_device(self, model: Optional[Model] = None) -> torch.device:
+        explicit_device = self._resolve_model_attr("device", None, model)
+        if explicit_device is not None:
+            return torch.device(explicit_device)
+
+        module = self._resolve_trainable_module(model)
+        if module is not None:
+            try:
+                return next(module.parameters()).device
+            except (AttributeError, StopIteration):
+                pass
+
+        return torch.device("cpu")
+
+    def _transform_data_for_model(self, data: np.ndarray, model: Optional[Model] = None) -> np.ndarray:
+        """
+        Apply simple wrapper-specific preprocessing so distillation sees the same input shape as fit().
+        """
+        current = self._model if model is None else model
+        transformed = np.asarray(data)
+        seen = set()
+
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+
+            if current.__class__.__name__ == "FlattenTimeSeriesAdapter":
+                transformed = transformed.reshape(transformed.shape[0], -1)
+
+            current = getattr(current, "model", None)
+
+        return np.array(transformed, copy=True)
+
+    def _supports_latent_distillation(self, model: Optional[Model] = None) -> bool:
+        module = self._resolve_trainable_module(model)
+        if module is None:
+            return False
+
+        return hasattr(module, "encode") or hasattr(module, "encoder")
+
+    @staticmethod
+    def _extract_latent_representation(encoded_output):
+        if isinstance(encoded_output, (tuple, list)):
+            for item in encoded_output:
+                if torch.is_tensor(item):
+                    return item
+        return encoded_output
+
+    def _encode_with_model(self, model: Model, batch: torch.Tensor) -> torch.Tensor:
+        if hasattr(model, "encode_batch"):
+            return self._extract_latent_representation(model.encode_batch(batch))
+
+        module = self._resolve_trainable_module(model)
+        if module is None:
+            raise TypeError("Model does not expose a trainable torch module or encode_batch().")
+
+        if hasattr(module, "encode"):
+            return self._extract_latent_representation(module.encode(batch))
+
+        if hasattr(module, "encoder"):
+            return self._extract_latent_representation(module.encoder(batch))
+
+        raise TypeError("Model does not expose encoder/encode hooks required for latent distillation.")
+
+    def _forward_with_model(self, model: Model, batch: torch.Tensor) -> tuple[torch.Tensor, Optional[torch.Tensor], None]:
+        if hasattr(model, "forward_batch"):
+            return model.forward_batch(batch, apply_masking=False)
+
+        module = self._resolve_trainable_module(model)
+        if module is None:
+            raise TypeError("Model does not expose a trainable torch module or forward_batch().")
+
+        output = module(batch)
+        x_hat = output[0] if isinstance(output, (tuple, list)) else output
+        z = self._encode_with_model(model, batch) if self._supports_latent_distillation(model) else None
+        return x_hat, z, None
+
+    def _training_batch_step(self, batch: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], None]:
+        if hasattr(self._model, "training_batch_step"):
+            return self._model.training_batch_step(batch)
+
+        x_hat, z, _ = self._forward_with_model(self._model, batch)
+        rec_loss = torch.nn.functional.mse_loss(x_hat, batch)
+        return rec_loss, x_hat, z, None
+
+    def _resolve_distill_mode(self) -> str:
+        if self._distill_mode in ["latent", "hybrid"] and not (
+            self._supports_latent_distillation(self._model) and self._supports_latent_distillation(self._old_model)
+        ):
+            logger.warning(
+                "Latent distillation requested, but the model does not expose encoder hooks. "
+                "Falling back to reconstruction distillation."
+            )
+            return "reconstruction"
+
+        return self._distill_mode
+    
+    def _clone_model(self) -> Model:
+        """
+        Create a frozen deep copy of the current model.
+        
+        Returns
+        -------
+        Model
+            Frozen copy of the current model
+        """
+        cloned = copy.deepcopy(self._model)
+
+        module = self._resolve_trainable_module(cloned)
+        if module is not None:
+            module.eval()
+            for param in module.parameters():
+                param.requires_grad = False
+        
+        return cloned
+    
+    def _fit_with_distillation(self, data: np.ndarray) -> None:
+        """
+        Train the model with knowledge distillation from the old model.
+        
+        Parameters
+        ----------
+        data : np.ndarray
+            Training data of shape (n_samples, height, width)
+        """
+        module = self._resolve_trainable_module(self._model)
+        old_module = self._resolve_trainable_module(self._old_model)
+        if module is None or old_module is None:
+            logger.warning(
+                "Model does not expose a trainable torch module required for distillation. "
+                "Falling back to standard fit()."
+            )
+            self._model.fit(data)
+            return
+
+        tensor_data = self._prepare_data(data)
+        dataset = TensorDataset(tensor_data)
+        dataloader = DataLoader(
+            dataset,
+            batch_size=self._resolve_batch_size(),
+            shuffle=True,
+            num_workers=0
+        )
+
+        distill_mode = self._resolve_distill_mode()
+        device = self._resolve_device(self._model)
+
+        old_module.eval()
+        for param in old_module.parameters():
+            param.requires_grad = False
+
+        old_module.to(device)
+        module.to(device)
+        module.train()
+
+        optimizer = torch.optim.Adam(module.parameters(), lr=self._resolve_lr())
+
+        for epoch in range(self._resolve_epochs()):
+            epoch_loss = 0.0
+            epoch_rec_loss = 0.0
+            epoch_distill_loss = 0.0
+            
+            for batch_idx, (batch,) in enumerate(dataloader):
+                batch = batch.to(device)
+                
+                rec_loss, x_hat_train, z_train, _ = self._training_batch_step(batch)
+                x_hat_new, z_new = x_hat_train, z_train
+                
+                with torch.no_grad():
+                    if distill_mode == 'latent':
+                        z_old = self._encode_with_model(self._old_model, batch)
+                        distill_loss = torch.nn.functional.mse_loss(z_new, z_old)
+                    elif distill_mode == 'reconstruction':
+                        x_hat_old, _, _ = self._forward_with_model(self._old_model, batch)
+                        distill_loss = torch.nn.functional.mse_loss(x_hat_new, x_hat_old)
+                    elif distill_mode == 'hybrid':
+                        z_old = self._encode_with_model(self._old_model, batch)
+                        x_hat_old, _, _ = self._forward_with_model(self._old_model, batch)
+                        latent_loss = torch.nn.functional.mse_loss(z_new, z_old)
+                        recon_loss = torch.nn.functional.mse_loss(x_hat_new, x_hat_old)
+                        distill_loss = (latent_loss + recon_loss) / 2
+                    else:
+                        raise ValueError(f"Invalid distill_mode: {distill_mode}")
+                
+                total_loss = rec_loss + self._alpha * distill_loss
+
+                optimizer.zero_grad()
+                total_loss.backward()
+                optimizer.step()
+
+                epoch_loss += total_loss.item()
+                epoch_rec_loss += rec_loss.item()
+                epoch_distill_loss += distill_loss.item()
+            
+            n_batches = len(dataloader)
+            avg_loss = epoch_loss / n_batches
+            avg_rec = epoch_rec_loss / n_batches
+            avg_distill = epoch_distill_loss / n_batches
+            
+            epochs = self._resolve_epochs()
+            if (epoch + 1) % max(1, epochs // 5) == 0:
+                logger.info(f"Epoch {epoch+1}/{epochs}: "
+                          f"Loss={avg_loss:.6f} (Rec={avg_rec:.6f}, Distill={avg_distill:.6f})")
+        
+        if hasattr(self._model, '_auto_threshold') and self._model._auto_threshold:
+            self._model._calibrate_threshold(data)
+    
+    def _prepare_data(self, data: np.ndarray) -> torch.Tensor:
+        """
+        Prepare numpy data for PyTorch training.
+        
+        Parameters
+        ----------
+        data : np.ndarray
+            Training data of shape (n_samples, height, width)
+            
+        Returns
+        -------
+        torch.Tensor
+            Prepared tensor data
+        """
+        transformed = self._transform_data_for_model(data)
+        return torch.tensor(transformed, dtype=torch.float32)

--- a/src/pyclad/strategies/regularization/lwf.py
+++ b/src/pyclad/strategies/regularization/lwf.py
@@ -1,4 +1,5 @@
 """Learning without Forgetting (LwF) strategy for continual learning."""
+
 import copy
 import logging
 from typing import Dict, Optional
@@ -19,12 +20,12 @@ logger = logging.getLogger(__name__)
 class LwFStrategy(ConceptIncrementalStrategy, ConceptAgnosticStrategy):
     """
     Learning without Forgetting strategy using knowledge distillation.
-    
+
     Prevents catastrophic forgetting by maintaining a frozen copy of the model
     from the previous task and using it to regularize training on new data.
     The new model learns to both reconstruct new data well AND preserve the
     knowledge encoded in the old model's latent representations.
-    
+
     Parameters
     ----------
     model : Model
@@ -35,27 +36,23 @@ class LwFStrategy(ConceptIncrementalStrategy, ConceptAgnosticStrategy):
     distill_mode : str, optional
         Type of distillation: 'latent', 'reconstruction', or 'hybrid' (default: 'latent')
     """
-    
-    def __init__(
-        self,
-        model: Model,
-        alpha: float = 0.5,
-        distill_mode: str = 'latent'
-    ):
+
+    def __init__(self, model: Model, alpha: float = 0.5, distill_mode: str = "latent"):
         self._model = model
         self._old_model: Optional[Model] = None
         self._alpha = alpha
         self._distill_mode = distill_mode
         self._task_count = 0
-        
-        if distill_mode not in ['latent', 'reconstruction', 'hybrid']:
-            raise ValueError(f"Invalid distill_mode: {distill_mode}. "
-                           f"Must be 'latent', 'reconstruction', or 'hybrid'")
-    
+
+        if distill_mode not in ["latent", "reconstruction", "hybrid"]:
+            raise ValueError(
+                f"Invalid distill_mode: {distill_mode}. " f"Must be 'latent', 'reconstruction', or 'hybrid'"
+            )
+
     def learn(self, data: np.ndarray, *args, **kwargs) -> None:
         """
         Learn from new data using knowledge distillation if not the first task.
-        
+
         Parameters
         ----------
         data : np.ndarray
@@ -67,35 +64,37 @@ class LwFStrategy(ConceptIncrementalStrategy, ConceptAgnosticStrategy):
             self._model.fit(data)
         else:
             # Subsequent tasks: train with distillation from old model
-            logger.info(f"Task {self._task_count + 1}: Training with LwF distillation "
-                       f"(alpha={self._alpha}, mode={self._distill_mode})")
+            logger.info(
+                f"Task {self._task_count + 1}: Training with LwF distillation "
+                f"(alpha={self._alpha}, mode={self._distill_mode})"
+            )
             self._fit_with_distillation(data)
-        
+
         self._task_count += 1
-        
+
         # Clone current model as old model for next task
         self._old_model = self._clone_model()
-    
+
     def predict(self, data: np.ndarray, *args, **kwargs) -> tuple:
         """
         Predict anomalies using the current model.
-        
+
         Parameters
         ----------
         data : np.ndarray
             Data to predict on
-            
+
         Returns
         -------
         tuple
             (predicted labels, anomaly scores)
         """
         return self._model.predict(data)
-    
+
     def name(self) -> str:
         """Return strategy name."""
         return "LwF"
-    
+
     def additional_info(self) -> Dict:
         """Return additional strategy information."""
         return {
@@ -103,7 +102,7 @@ class LwFStrategy(ConceptIncrementalStrategy, ConceptAgnosticStrategy):
             "alpha": self._alpha,
             "distill_mode": self._distill_mode,
             "task_count": self._task_count,
-            "has_old_model": self._old_model is not None
+            "has_old_model": self._old_model is not None,
         }
 
     def _resolve_trainable_module(self, model: Optional[Model] = None) -> Optional[torch.nn.Module]:
@@ -224,7 +223,9 @@ class LwFStrategy(ConceptIncrementalStrategy, ConceptAgnosticStrategy):
 
         raise TypeError("Model does not expose encoder/encode hooks required for latent distillation.")
 
-    def _forward_with_model(self, model: Model, batch: torch.Tensor) -> tuple[torch.Tensor, Optional[torch.Tensor], None]:
+    def _forward_with_model(
+        self, model: Model, batch: torch.Tensor
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor], None]:
         if hasattr(model, "forward_batch"):
             return model.forward_batch(batch, apply_masking=False)
 
@@ -237,7 +238,9 @@ class LwFStrategy(ConceptIncrementalStrategy, ConceptAgnosticStrategy):
         z = self._encode_with_model(model, batch) if self._supports_latent_distillation(model) else None
         return x_hat, z, None
 
-    def _training_batch_step(self, batch: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], None]:
+    def _training_batch_step(
+        self, batch: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], None]:
         if hasattr(self._model, "training_batch_step"):
             return self._model.training_batch_step(batch)
 
@@ -256,11 +259,11 @@ class LwFStrategy(ConceptIncrementalStrategy, ConceptAgnosticStrategy):
             return "reconstruction"
 
         return self._distill_mode
-    
+
     def _clone_model(self) -> Model:
         """
         Create a frozen deep copy of the current model.
-        
+
         Returns
         -------
         Model
@@ -273,13 +276,13 @@ class LwFStrategy(ConceptIncrementalStrategy, ConceptAgnosticStrategy):
             module.eval()
             for param in module.parameters():
                 param.requires_grad = False
-        
+
         return cloned
-    
+
     def _fit_with_distillation(self, data: np.ndarray) -> None:
         """
         Train the model with knowledge distillation from the old model.
-        
+
         Parameters
         ----------
         data : np.ndarray
@@ -297,12 +300,7 @@ class LwFStrategy(ConceptIncrementalStrategy, ConceptAgnosticStrategy):
 
         tensor_data = self._prepare_data(data)
         dataset = TensorDataset(tensor_data)
-        dataloader = DataLoader(
-            dataset,
-            batch_size=self._resolve_batch_size(),
-            shuffle=True,
-            num_workers=0
-        )
+        dataloader = DataLoader(dataset, batch_size=self._resolve_batch_size(), shuffle=True, num_workers=0)
 
         distill_mode = self._resolve_distill_mode()
         device = self._resolve_device(self._model)
@@ -321,21 +319,21 @@ class LwFStrategy(ConceptIncrementalStrategy, ConceptAgnosticStrategy):
             epoch_loss = 0.0
             epoch_rec_loss = 0.0
             epoch_distill_loss = 0.0
-            
+
             for batch_idx, (batch,) in enumerate(dataloader):
                 batch = batch.to(device)
-                
+
                 rec_loss, x_hat_train, z_train, _ = self._training_batch_step(batch)
                 x_hat_new, z_new = x_hat_train, z_train
-                
+
                 with torch.no_grad():
-                    if distill_mode == 'latent':
+                    if distill_mode == "latent":
                         z_old = self._encode_with_model(self._old_model, batch)
                         distill_loss = torch.nn.functional.mse_loss(z_new, z_old)
-                    elif distill_mode == 'reconstruction':
+                    elif distill_mode == "reconstruction":
                         x_hat_old, _, _ = self._forward_with_model(self._old_model, batch)
                         distill_loss = torch.nn.functional.mse_loss(x_hat_new, x_hat_old)
-                    elif distill_mode == 'hybrid':
+                    elif distill_mode == "hybrid":
                         z_old = self._encode_with_model(self._old_model, batch)
                         x_hat_old, _, _ = self._forward_with_model(self._old_model, batch)
                         latent_loss = torch.nn.functional.mse_loss(z_new, z_old)
@@ -343,7 +341,7 @@ class LwFStrategy(ConceptIncrementalStrategy, ConceptAgnosticStrategy):
                         distill_loss = (latent_loss + recon_loss) / 2
                     else:
                         raise ValueError(f"Invalid distill_mode: {distill_mode}")
-                
+
                 total_loss = rec_loss + self._alpha * distill_loss
 
                 optimizer.zero_grad()
@@ -353,29 +351,30 @@ class LwFStrategy(ConceptIncrementalStrategy, ConceptAgnosticStrategy):
                 epoch_loss += total_loss.item()
                 epoch_rec_loss += rec_loss.item()
                 epoch_distill_loss += distill_loss.item()
-            
+
             n_batches = len(dataloader)
             avg_loss = epoch_loss / n_batches
             avg_rec = epoch_rec_loss / n_batches
             avg_distill = epoch_distill_loss / n_batches
-            
+
             epochs = self._resolve_epochs()
             if (epoch + 1) % max(1, epochs // 5) == 0:
-                logger.info(f"Epoch {epoch+1}/{epochs}: "
-                          f"Loss={avg_loss:.6f} (Rec={avg_rec:.6f}, Distill={avg_distill:.6f})")
-        
-        if hasattr(self._model, '_auto_threshold') and self._model._auto_threshold:
+                logger.info(
+                    f"Epoch {epoch+1}/{epochs}: " f"Loss={avg_loss:.6f} (Rec={avg_rec:.6f}, Distill={avg_distill:.6f})"
+                )
+
+        if hasattr(self._model, "_auto_threshold") and self._model._auto_threshold:
             self._model._calibrate_threshold(data)
-    
+
     def _prepare_data(self, data: np.ndarray) -> torch.Tensor:
         """
         Prepare numpy data for PyTorch training.
-        
+
         Parameters
         ----------
         data : np.ndarray
             Training data of shape (n_samples, height, width)
-            
+
         Returns
         -------
         torch.Tensor

--- a/src/pyclad/strategies/replay/agem.py
+++ b/src/pyclad/strategies/replay/agem.py
@@ -32,6 +32,12 @@ class AGEMStrategy(ReplayOnlyStrategy):
     it avoids updates that directly conflict with what it learned from earlier
     concepts. After optimization, the new concept is added to the replay buffer so
     future tasks can be constrained against it as well.
+
+    SGD is the default optimizer because the standard A-GEM guarantee is derived
+    for a step taken directly along the projected gradient. Adaptive optimizers
+    such as Adam can still be used as a heuristic, but their per-parameter
+    rescaling changes the final update direction and therefore voids that
+    guarantee.
     """
 
     def __init__(
@@ -84,6 +90,7 @@ class AGEMStrategy(ReplayOnlyStrategy):
         self._epochs = int(epochs)
         self._device = torch.device(device)
         self._shuffle = bool(shuffle)
+        self._adam_warning_emitted = False
 
         replay_buffer = buffer if buffer is not None else BalancedReplayBuffer(max_size=buffer_size, seed=self._seed)
         super().__init__(model, replay_buffer)
@@ -165,11 +172,21 @@ class AGEMStrategy(ReplayOnlyStrategy):
             raise TypeError("AGEMStrategy requires at least one trainable parameter.")
 
         if self._optimizer_name == "adam":
-            logger.warning("AGEM with Adam is an approximation; SGD preserves the standard A-GEM update guarantee.")
+            if not self._adam_warning_emitted:
+                logger.warning(
+                    "AGEM with Adam does not preserve the standard A-GEM guarantee because Adam rescales "
+                    "projected gradients with adaptive moment estimates. Use optimizer='sgd' for "
+                    "guarantee-preserving updates."
+                )
+                self._adam_warning_emitted = True
             optimizer = torch.optim.Adam(parameters, lr=self._lr)
         else:
             optimizer = torch.optim.SGD(parameters, lr=self._lr)
         epochs = self._epochs
+        if isinstance(self._buffer, BalancedReplayBuffer):
+            has_replay_data = not self._buffer.is_empty()
+        else:
+            has_replay_data = len(self._buffer.data()) > 0
 
         for epoch in range(epochs):
             epoch_current = 0.0
@@ -186,29 +203,46 @@ class AGEMStrategy(ReplayOnlyStrategy):
                 current_loss = self._loss_fn(module, batch)
                 current_loss.backward()
                 current_grad = self.capture_gradients(parameters)
+                if not self.gradients_are_finite(current_grad):
+                    logger.warning("Skipping AGEM update because the current gradient contains non-finite values.")
+                    optimizer.zero_grad()
+                    continue
                 final_grad = current_grad
 
                 replay_loss = torch.tensor(0.0, device=device)
-                replay_examples = self._sample_replay_examples(self._replay_batch_size)
-                if replay_examples is not None:
+                if has_replay_data:
                     # Then estimate how older concepts would like the model to
                     # move by taking a replay gradient from memory.
-                    optimizer.zero_grad()
-                    replay_batch = self._prepare_data(replay_examples).to(device)
-                    replay_loss = self._loss_fn(module, replay_batch)
-                    replay_loss.backward()
-                    replay_grad = self.capture_gradients(parameters)
+                    replay_examples = self._sample_replay_examples(self._replay_batch_size)
+                    if replay_examples is not None:
+                        optimizer.zero_grad()
+                        replay_batch = self._prepare_data(replay_examples).to(device)
+                        replay_loss = self._loss_fn(module, replay_batch)
+                        replay_loss.backward()
+                        replay_grad = self.capture_gradients(parameters)
+                        if not self.gradients_are_finite(replay_grad):
+                            logger.warning(
+                                "Skipping AGEM update because the replay gradient contains non-finite values."
+                            )
+                            optimizer.zero_grad()
+                            continue
 
-                    # A negative dot product means the current update would
-                    # interfere with replay performance. In that case A-GEM
-                    # projects the current gradient to remove the conflicting
-                    # component while preserving as much useful progress as
-                    # possible.
-                    if self.should_project(current_grad, replay_grad, self._projection_tolerance):
-                        final_grad = self.project_gradient(current_grad, replay_grad)
-                        projection_count += 1
+                        # A negative dot product means the current update would
+                        # interfere with replay performance. In that case A-GEM
+                        # projects the current gradient to remove the conflicting
+                        # component while preserving as much useful progress as
+                        # possible.
+                        if self.should_project(current_grad, replay_grad, self._projection_tolerance):
+                            final_grad = self.project_gradient(current_grad, replay_grad)
+                            projection_count += 1
 
                 optimizer.zero_grad()
+                if not self.gradients_are_finite(final_grad):
+                    logger.warning("Skipping AGEM update because the final AGEM gradient contains non-finite values.")
+                    continue
+                # The backward passes above only write to parameter.grad. Clearing
+                # gradients here and restoring final_grad means optimizer.step()
+                # consumes exactly the projected gradient for this batch.
                 self.restore_gradients(parameters, final_grad)
                 optimizer.step()
 
@@ -253,23 +287,16 @@ class AGEMStrategy(ReplayOnlyStrategy):
         return self._concept_to_index[concept_id]
 
     def _prepare_data(self, data: np.ndarray) -> torch.Tensor:
-        transformed = np.array(self._data_transform(np.asarray(data)), dtype=np.float32, copy=True)
-        return torch.tensor(transformed, dtype=torch.float32)
-
-    @staticmethod
-    def _forward_batch(module: torch.nn.Module, batch: torch.Tensor) -> tuple[torch.Tensor, tuple]:
-        output = module(batch)
-        if isinstance(output, (tuple, list)):
-            return output[0], tuple(output[1:])
-        return output, tuple()
+        return torch.as_tensor(self._data_transform(np.asarray(data)), dtype=torch.float32)
 
     @staticmethod
     def identity_transform(data: np.ndarray) -> np.ndarray:
-        return np.array(data, copy=True)
+        return data
 
     @staticmethod
     def default_loss_fn(module: torch.nn.Module, batch: torch.Tensor) -> torch.Tensor:
-        x_hat, _ = AGEMStrategy._forward_batch(module, batch)
+        output = module(batch)
+        x_hat = output[0] if isinstance(output, (tuple, list)) else output
         if x_hat.shape != batch.shape:
             raise ValueError(
                 "AGEMStrategy.default_loss_fn expects the module output to have the same shape as the input batch. "
@@ -279,6 +306,13 @@ class AGEMStrategy(ReplayOnlyStrategy):
 
     @staticmethod
     def capture_gradients(parameters: Sequence[torch.nn.Parameter]) -> torch.Tensor:
+        devices = {parameter.device for parameter in parameters}
+        if len(devices) > 1:
+            raise ValueError(
+                "AGEMStrategy requires all trainable parameters to live on a single device; "
+                "model-parallel parameter sets are not supported."
+            )
+
         flat_parts = []
         for parameter in parameters:
             if parameter.grad is None:
@@ -297,7 +331,7 @@ class AGEMStrategy(ReplayOnlyStrategy):
         for parameter in parameters:
             numel = parameter.numel()
             grad_slice = flat_gradient[offset : offset + numel].view_as(parameter)
-            parameter.grad = grad_slice.clone().to(device=parameter.device, dtype=parameter.dtype)
+            parameter.grad = grad_slice.clone()
             offset += numel
 
     @staticmethod
@@ -326,6 +360,11 @@ class AGEMStrategy(ReplayOnlyStrategy):
 
         dot_product = torch.dot(current, reference)
         if not torch.isfinite(dot_product):
+            logger.warning("Skipping AGEM projection because the gradient dot product is non-finite.")
             return False
 
         return dot_product.item() < -float(tolerance)
+
+    @staticmethod
+    def gradients_are_finite(gradient: torch.Tensor) -> bool:
+        return bool(torch.isfinite(gradient).all())

--- a/src/pyclad/strategies/replay/agem.py
+++ b/src/pyclad/strategies/replay/agem.py
@@ -16,7 +16,7 @@ future tasks can be constrained against it as well.
 """
 
 import logging
-from typing import Dict, Optional, Sequence
+from typing import Callable, Dict, Optional, Sequence, Union
 
 import numpy as np
 import torch
@@ -28,6 +28,9 @@ from pyclad.strategies.replay.buffers.buffer import ReplayBuffer
 from pyclad.strategies.replay.replay import ReplayOnlyStrategy
 
 logger = logging.getLogger(__name__)
+
+BatchLoss = Callable[[torch.nn.Module, torch.Tensor], torch.Tensor]
+DataTransform = Callable[[np.ndarray], np.ndarray]
 
 
 class AGEMStrategy(ReplayOnlyStrategy):
@@ -44,6 +47,10 @@ class AGEMStrategy(ReplayOnlyStrategy):
     does not simply retrain on concatenated old and new data. Instead, replay
     is used to shape the gradient direction so the model remains plastic on the
     current task without taking obviously destructive steps on past concepts.
+
+    The training contract is explicit: callers pass the trainable module, loss
+    function, input transform, and optimizer/data-loader settings directly to
+    the strategy instead of relying on hidden model introspection.
     """
 
     def __init__(
@@ -51,22 +58,46 @@ class AGEMStrategy(ReplayOnlyStrategy):
         model: Model,
         buffer: Optional[ReplayBuffer] = None,
         *,
+        module: torch.nn.Module,
+        loss_fn: Optional[BatchLoss] = None,
+        data_transform: Optional[DataTransform] = None,
+        batch_size: int = 32,
+        lr: float = 1e-2,
+        optimizer: str = "sgd",
+        epochs: int = 20,
+        device: Union[torch.device, str] = "cpu",
+        shuffle: bool = True,
         buffer_size: int = 500,
         seed: int = 7,
     ):
+        if not isinstance(module, torch.nn.Module):
+            raise TypeError("AGEMStrategy requires 'module' to be a torch.nn.Module.")
+        if batch_size <= 0:
+            raise ValueError(f"batch_size must be positive, got {batch_size}")
+        if epochs <= 0:
+            raise ValueError(f"epochs must be positive, got {epochs}")
+        if lr <= 0:
+            raise ValueError(f"lr must be positive, got {lr}")
+        optimizer_name = optimizer.lower()
+        if optimizer_name not in {"sgd", "adam"}:
+            raise ValueError(f"optimizer must be 'sgd' or 'adam', got {optimizer}")
+
         self._seed = int(seed)
         self._rng = np.random.default_rng(self._seed)
         self._task_count = 0
         self._concept_to_index: Dict[str, int] = {}
+        self._module = module
+        self._loss_fn = self.default_loss_fn if loss_fn is None else loss_fn
+        self._data_transform = self.identity_transform if data_transform is None else data_transform
+        self._batch_size = int(batch_size)
+        self._lr = float(lr)
+        self._optimizer_name = optimizer_name
+        self._epochs = int(epochs)
+        self._device = torch.device(device)
+        self._shuffle = bool(shuffle)
 
         replay_buffer = buffer if buffer is not None else BalancedReplayBuffer(max_size=buffer_size, seed=self._seed)
         super().__init__(model, replay_buffer)
-
-        if self._resolve_trainable_module() is None:
-            raise TypeError(
-                "AGEMStrategy requires a PyTorch-backed model exposed via '.module' "
-                "or through a nested '.model' wrapper."
-            )
 
     def learn(self, data: np.ndarray, concept_id: Optional[str] = None, **kwargs) -> None:
         del kwargs
@@ -114,24 +145,27 @@ class AGEMStrategy(ReplayOnlyStrategy):
                 "seed": self._seed,
                 "task_count": self._task_count,
                 "concept_count": len(self._concept_to_index),
+                "batch_size": self._batch_size,
+                "lr": self._lr,
+                "optimizer": self._optimizer_name,
+                "epochs": self._epochs,
+                "device": str(self._device),
+                "shuffle": self._shuffle,
             }
         )
         return info
 
     def _fit(self, current_data: np.ndarray) -> None:
-        module = self._resolve_trainable_module()
-        if module is None:
-            raise TypeError("Model does not expose a trainable torch module required for AGEM.")
-
         tensor_data = self._prepare_data(current_data)
         dataloader = DataLoader(
             TensorDataset(tensor_data),
-            batch_size=self._resolve_batch_size(),
-            shuffle=self._resolve_shuffle(),
+            batch_size=self._batch_size,
+            shuffle=self._shuffle,
             num_workers=0,
         )
 
-        device = self._resolve_device()
+        module = self._module
+        device = self._device
         module.to(device)
         module.train()
 
@@ -139,8 +173,12 @@ class AGEMStrategy(ReplayOnlyStrategy):
         if not parameters:
             raise TypeError("AGEMStrategy requires at least one trainable parameter.")
 
-        optimizer = torch.optim.Adam(parameters, lr=self._resolve_lr())
-        epochs = self._resolve_epochs()
+        if self._optimizer_name == "adam":
+            logger.warning("AGEM with Adam is an approximation; SGD preserves the standard A-GEM update guarantee.")
+            optimizer = torch.optim.Adam(parameters, lr=self._lr)
+        else:
+            optimizer = torch.optim.SGD(parameters, lr=self._lr)
+        epochs = self._epochs
 
         for epoch in range(epochs):
             epoch_current = 0.0
@@ -154,19 +192,19 @@ class AGEMStrategy(ReplayOnlyStrategy):
                 # the update we would normally apply if no replay constraint
                 # existed.
                 optimizer.zero_grad()
-                current_loss = self._compute_batch_loss(module, batch)
+                current_loss = self._loss_fn(module, batch)
                 current_loss.backward()
                 current_grad = self.capture_gradients(parameters)
                 final_grad = current_grad
 
                 replay_loss = torch.tensor(0.0, device=device)
-                replay_examples = self._sample_replay_examples(self._resolve_batch_size())
+                replay_examples = self._sample_replay_examples(self._batch_size)
                 if replay_examples is not None:
                     # Then estimate how older concepts would like the model to
                     # move by taking a replay gradient from memory.
                     optimizer.zero_grad()
                     replay_batch = self._prepare_data(replay_examples).to(device)
-                    replay_loss = self._compute_batch_loss(module, replay_batch)
+                    replay_loss = self._loss_fn(module, replay_batch)
                     replay_loss.backward()
                     replay_grad = self.capture_gradients(parameters)
 
@@ -219,111 +257,8 @@ class AGEMStrategy(ReplayOnlyStrategy):
             self._concept_to_index[concept_id] = len(self._concept_to_index)
         return self._concept_to_index[concept_id]
 
-    def _resolve_trainable_module(self, model: Optional[Model] = None) -> Optional[torch.nn.Module]:
-        current = self._model if model is None else model
-        seen = set()
-
-        while current is not None and id(current) not in seen:
-            seen.add(id(current))
-
-            module = getattr(current, "module", None)
-            if isinstance(module, torch.nn.Module):
-                return module
-
-            module = getattr(current, "model", None)
-            if isinstance(module, torch.nn.Module):
-                return module
-
-            current = getattr(current, "model", None)
-
-        return None
-
-    def _resolve_model_attr(self, attr_name: str, default, model: Optional[Model] = None):
-        current = self._model if model is None else model
-        seen = set()
-
-        while current is not None and id(current) not in seen:
-            seen.add(id(current))
-
-            if hasattr(current, attr_name):
-                return getattr(current, attr_name)
-
-            module = getattr(current, "module", None)
-            if module is not None and hasattr(module, attr_name):
-                return getattr(module, attr_name)
-
-            current = getattr(current, "model", None)
-
-        return default
-
-    def _resolve_batch_size(self) -> int:
-        batch_size = self._resolve_model_attr("batch_size", 32)
-        return int(batch_size) if batch_size else 32
-
-    def _resolve_lr(self) -> float:
-        lr = self._resolve_model_attr("lr", 1e-2)
-        return float(lr) if lr else 1e-2
-
-    def _resolve_epochs(self) -> int:
-        epochs = self._resolve_model_attr("epochs", 20)
-        return int(epochs) if epochs else 20
-
-    def _resolve_device(self, model: Optional[Model] = None) -> torch.device:
-        explicit_device = self._resolve_model_attr("device", None, model)
-        if explicit_device is not None:
-            return torch.device(explicit_device)
-
-        module = self._resolve_trainable_module(model)
-        if module is not None:
-            try:
-                return next(module.parameters()).device
-            except (AttributeError, StopIteration):
-                pass
-
-        return torch.device("cpu")
-
-    def _resolve_shuffle(self) -> bool:
-        current = self._model
-        seen = set()
-
-        while current is not None and id(current) not in seen:
-            seen.add(id(current))
-
-            current_name = current.__class__.__name__
-            if current_name in {"TemporalAutoencoder", "VariationalTemporalAutoencoder"}:
-                return False
-            if current_name == "Autoencoder":
-                return True
-
-            module = getattr(current, "module", None)
-            if module is not None:
-                module_name = module.__class__.__name__
-                if module_name in {"TemporalAutoencoderModule", "VariationalTemporalAutoencoderModule"}:
-                    return False
-                if module_name == "AutoencoderModule":
-                    return True
-
-            current = getattr(current, "model", None)
-
-        return True
-
-    def _transform_data_for_model(self, data: np.ndarray, model: Optional[Model] = None) -> np.ndarray:
-        current = self._model if model is None else model
-        transformed = np.asarray(data)
-        seen = set()
-
-        while current is not None and id(current) not in seen:
-            seen.add(id(current))
-
-            if current.__class__.__name__ == "FlattenTimeSeriesAdapter":
-                transformed = transformed.reshape(transformed.shape[0], -1)
-
-            current = getattr(current, "model", None)
-
-        return np.array(transformed, copy=True)
-
     def _prepare_data(self, data: np.ndarray) -> torch.Tensor:
-        transformed = self._transform_data_for_model(data)
+        transformed = np.array(self._data_transform(np.asarray(data)), dtype=np.float32, copy=True)
         return torch.tensor(transformed, dtype=torch.float32)
 
     @staticmethod
@@ -333,23 +268,18 @@ class AGEMStrategy(ReplayOnlyStrategy):
             return output[0], tuple(output[1:])
         return output, tuple()
 
-    def _compute_batch_loss(self, module: torch.nn.Module, batch: torch.Tensor) -> torch.Tensor:
-        x_hat, extras = self._forward_batch(module, batch)
-        train_loss = getattr(module, "train_loss", None)
+    @staticmethod
+    def identity_transform(data: np.ndarray) -> np.ndarray:
+        return np.array(data, copy=True)
 
-        if callable(train_loss):
-            try:
-                if len(extras) >= 2:
-                    return train_loss(x_hat, batch, extras[0], extras[1])
-                return train_loss(x_hat, batch)
-            except TypeError:
-                try:
-                    if len(extras) >= 2:
-                        return train_loss(batch, x_hat, extras[0], extras[1])
-                    return train_loss(batch, x_hat)
-                except TypeError:
-                    pass
-
+    @staticmethod
+    def default_loss_fn(module: torch.nn.Module, batch: torch.Tensor) -> torch.Tensor:
+        x_hat, _ = AGEMStrategy._forward_batch(module, batch)
+        if x_hat.shape != batch.shape:
+            raise ValueError(
+                "AGEMStrategy.default_loss_fn expects the module output to have the same shape as the input batch. "
+                "Pass a custom loss_fn for models with a different training objective."
+            )
         return torch.nn.functional.mse_loss(x_hat, batch)
 
     @staticmethod

--- a/src/pyclad/strategies/replay/agem.py
+++ b/src/pyclad/strategies/replay/agem.py
@@ -1,20 +1,3 @@
-"""A-GEM replay strategy for torch-backed reconstruction models.
-
-This implementation treats each incoming batch/window as the current task and
-keeps a small replay buffer with examples from earlier concepts. During
-training, it computes two gradients:
-
-1. the gradient of the reconstruction loss on the current data;
-2. the gradient of the reconstruction loss on a replay batch.
-
-If the current gradient would increase loss on replay data, A-GEM projects it
-onto the half-space that does not interfere with the replay gradient. In
-practice, this means the model is still free to adapt to the new concept, but
-it avoids updates that directly conflict with what it learned from earlier
-concepts. After optimization, the new concept is added to the replay buffer so
-future tasks can be constrained against it as well.
-"""
-
 import logging
 from typing import Callable, Dict, Optional, Sequence, Union
 
@@ -34,23 +17,21 @@ DataTransform = Callable[[np.ndarray], np.ndarray]
 
 
 class AGEMStrategy(ReplayOnlyStrategy):
-    """A-GEM strategy using replay-gradient projection.
+    """A-GEM replay strategy for torch-backed reconstruction models.
 
-    Narrative view of the strategy:
-    - learn the current concept with a normal reconstruction objective;
-    - check whether that update would hurt replayed older concepts;
-    - if it would, replace the update with its projected, less-forgetting
-      version;
-    - store the current concept in replay memory for future constraints.
+    This implementation treats each incoming batch/window as the current task and
+    keeps a small replay buffer with examples from earlier concepts. During
+    training, it computes two gradients:
 
-    This makes A-GEM a replay-driven strategy, but unlike vanilla replay it
-    does not simply retrain on concatenated old and new data. Instead, replay
-    is used to shape the gradient direction so the model remains plastic on the
-    current task without taking obviously destructive steps on past concepts.
+    1. the gradient of the reconstruction loss on the current data;
+    2. the gradient of the reconstruction loss on a replay batch.
 
-    The training contract is explicit: callers pass the trainable module, loss
-    function, input transform, and optimizer/data-loader settings directly to
-    the strategy instead of relying on hidden model introspection.
+    If the current gradient would increase loss on replay data, A-GEM projects it
+    onto the half-space that does not interfere with the replay gradient. In
+    practice, this means the model is still free to adapt to the new concept, but
+    it avoids updates that directly conflict with what it learned from earlier
+    concepts. After optimization, the new concept is added to the replay buffer so
+    future tasks can be constrained against it as well.
     """
 
     def __init__(
@@ -62,8 +43,10 @@ class AGEMStrategy(ReplayOnlyStrategy):
         loss_fn: Optional[BatchLoss] = None,
         data_transform: Optional[DataTransform] = None,
         batch_size: int = 32,
+        replay_batch_size: Optional[int] = None,
         lr: float = 1e-2,
         optimizer: str = "sgd",
+        projection_tolerance: float = 1e-6,
         epochs: int = 20,
         device: Union[torch.device, str] = "cpu",
         shuffle: bool = True,
@@ -74,6 +57,10 @@ class AGEMStrategy(ReplayOnlyStrategy):
             raise TypeError("AGEMStrategy requires 'module' to be a torch.nn.Module.")
         if batch_size <= 0:
             raise ValueError(f"batch_size must be positive, got {batch_size}")
+        if replay_batch_size is not None and replay_batch_size <= 0:
+            raise ValueError(f"replay_batch_size must be positive, got {replay_batch_size}")
+        if projection_tolerance < 0:
+            raise ValueError(f"projection_tolerance must be non-negative, got {projection_tolerance}")
         if epochs <= 0:
             raise ValueError(f"epochs must be positive, got {epochs}")
         if lr <= 0:
@@ -90,8 +77,10 @@ class AGEMStrategy(ReplayOnlyStrategy):
         self._loss_fn = self.default_loss_fn if loss_fn is None else loss_fn
         self._data_transform = self.identity_transform if data_transform is None else data_transform
         self._batch_size = int(batch_size)
+        self._replay_batch_size = int(replay_batch_size) if replay_batch_size is not None else self._batch_size
         self._lr = float(lr)
         self._optimizer_name = optimizer_name
+        self._projection_tolerance = float(projection_tolerance)
         self._epochs = int(epochs)
         self._device = torch.device(device)
         self._shuffle = bool(shuffle)
@@ -108,10 +97,10 @@ class AGEMStrategy(ReplayOnlyStrategy):
 
         concept_name = concept_id or f"concept_{self._task_count}"
         concept_index = self._concept_index(concept_name)
-        replay_data = np.array(self._buffer.data(), copy=True)
 
         logger.info("AGEM learn on %s with %s samples", concept_name, len(current_data))
         self._fit(current_data)
+        replay_data_for_calibration = np.array(self._buffer.data(), copy=True)
 
         if isinstance(self._buffer, BalancedReplayBuffer):
             self._buffer.add(
@@ -122,8 +111,8 @@ class AGEMStrategy(ReplayOnlyStrategy):
             self._buffer.update(current_data)
 
         calibration_data = current_data
-        if len(replay_data) > 0:
-            calibration_data = np.concatenate([replay_data, current_data], axis=0)
+        if len(replay_data_for_calibration) > 0:
+            calibration_data = np.concatenate([replay_data_for_calibration, current_data], axis=0)
 
         if hasattr(self._model, "_auto_threshold") and self._model._auto_threshold:
             self._model._calibrate_threshold(calibration_data)
@@ -146,8 +135,10 @@ class AGEMStrategy(ReplayOnlyStrategy):
                 "task_count": self._task_count,
                 "concept_count": len(self._concept_to_index),
                 "batch_size": self._batch_size,
+                "replay_batch_size": self._replay_batch_size,
                 "lr": self._lr,
                 "optimizer": self._optimizer_name,
+                "projection_tolerance": self._projection_tolerance,
                 "epochs": self._epochs,
                 "device": str(self._device),
                 "shuffle": self._shuffle,
@@ -198,7 +189,7 @@ class AGEMStrategy(ReplayOnlyStrategy):
                 final_grad = current_grad
 
                 replay_loss = torch.tensor(0.0, device=device)
-                replay_examples = self._sample_replay_examples(self._batch_size)
+                replay_examples = self._sample_replay_examples(self._replay_batch_size)
                 if replay_examples is not None:
                     # Then estimate how older concepts would like the model to
                     # move by taking a replay gradient from memory.
@@ -213,7 +204,7 @@ class AGEMStrategy(ReplayOnlyStrategy):
                     # projects the current gradient to remove the conflicting
                     # component while preserving as much useful progress as
                     # possible.
-                    if torch.dot(current_grad, replay_grad).item() < 0:
+                    if self.should_project(current_grad, replay_grad, self._projection_tolerance):
                         final_grad = self.project_gradient(current_grad, replay_grad)
                         projection_count += 1
 
@@ -242,6 +233,8 @@ class AGEMStrategy(ReplayOnlyStrategy):
         if isinstance(self._buffer, BalancedReplayBuffer):
             if self._buffer.is_empty():
                 return None
+            if batch_size >= len(self._buffer):
+                return self._buffer.data()
             return self._buffer.sample(batch_size)["examples"]
 
         replay_data = self._buffer.data()
@@ -249,6 +242,8 @@ class AGEMStrategy(ReplayOnlyStrategy):
             return None
 
         sample_size = min(int(batch_size), len(replay_data))
+        if sample_size == len(replay_data):
+            return np.array(replay_data, copy=True)
         indices = self._rng.choice(len(replay_data), size=sample_size, replace=False)
         return np.asarray(replay_data)[indices]
 
@@ -311,8 +306,26 @@ class AGEMStrategy(ReplayOnlyStrategy):
             return current
 
         reference_norm = torch.dot(reference, reference)
-        if reference_norm.item() <= 0:
+        if not torch.isfinite(reference_norm) or reference_norm.item() <= 0:
             return current
 
-        correction = torch.dot(current, reference) / reference_norm
+        correction_numerator = torch.dot(current, reference)
+        if not torch.isfinite(correction_numerator):
+            return current
+
+        correction = correction_numerator / reference_norm
+        if not torch.isfinite(correction):
+            return current
+
         return current - correction * reference
+
+    @staticmethod
+    def should_project(current: torch.Tensor, reference: torch.Tensor, tolerance: float = 0.0) -> bool:
+        if current.numel() == 0 or reference.numel() == 0:
+            return False
+
+        dot_product = torch.dot(current, reference)
+        if not torch.isfinite(dot_product):
+            return False
+
+        return dot_product.item() < -float(tolerance)

--- a/src/pyclad/strategies/replay/agem.py
+++ b/src/pyclad/strategies/replay/agem.py
@@ -1,0 +1,388 @@
+"""A-GEM replay strategy for torch-backed reconstruction models.
+
+This implementation treats each incoming batch/window as the current task and
+keeps a small replay buffer with examples from earlier concepts. During
+training, it computes two gradients:
+
+1. the gradient of the reconstruction loss on the current data;
+2. the gradient of the reconstruction loss on a replay batch.
+
+If the current gradient would increase loss on replay data, A-GEM projects it
+onto the half-space that does not interfere with the replay gradient. In
+practice, this means the model is still free to adapt to the new concept, but
+it avoids updates that directly conflict with what it learned from earlier
+concepts. After optimization, the new concept is added to the replay buffer so
+future tasks can be constrained against it as well.
+"""
+
+import logging
+from typing import Dict, Optional, Sequence
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from pyclad.models.model import Model
+from pyclad.strategies.replay.buffers.balanced import BalancedReplayBuffer
+from pyclad.strategies.replay.buffers.buffer import ReplayBuffer
+from pyclad.strategies.replay.replay import ReplayOnlyStrategy
+
+logger = logging.getLogger(__name__)
+
+
+class AGEMStrategy(ReplayOnlyStrategy):
+    """A-GEM strategy using replay-gradient projection.
+
+    Narrative view of the strategy:
+    - learn the current concept with a normal reconstruction objective;
+    - check whether that update would hurt replayed older concepts;
+    - if it would, replace the update with its projected, less-forgetting
+      version;
+    - store the current concept in replay memory for future constraints.
+
+    This makes A-GEM a replay-driven strategy, but unlike vanilla replay it
+    does not simply retrain on concatenated old and new data. Instead, replay
+    is used to shape the gradient direction so the model remains plastic on the
+    current task without taking obviously destructive steps on past concepts.
+    """
+
+    def __init__(
+        self,
+        model: Model,
+        buffer: Optional[ReplayBuffer] = None,
+        *,
+        buffer_size: int = 500,
+        seed: int = 7,
+    ):
+        self._seed = int(seed)
+        self._rng = np.random.default_rng(self._seed)
+        self._task_count = 0
+        self._concept_to_index: Dict[str, int] = {}
+
+        replay_buffer = buffer if buffer is not None else BalancedReplayBuffer(max_size=buffer_size, seed=self._seed)
+        super().__init__(model, replay_buffer)
+
+        if self._resolve_trainable_module() is None:
+            raise TypeError(
+                "AGEMStrategy requires a PyTorch-backed model exposed via '.module' "
+                "or through a nested '.model' wrapper."
+            )
+
+    def learn(self, data: np.ndarray, concept_id: Optional[str] = None, **kwargs) -> None:
+        del kwargs
+
+        current_data = np.asarray(data, dtype=np.float32)
+        if len(current_data) == 0:
+            return
+
+        concept_name = concept_id or f"concept_{self._task_count}"
+        concept_index = self._concept_index(concept_name)
+        replay_data = np.array(self._buffer.data(), copy=True)
+
+        logger.info("AGEM learn on %s with %s samples", concept_name, len(current_data))
+        self._fit(current_data)
+
+        if isinstance(self._buffer, BalancedReplayBuffer):
+            self._buffer.add(
+                examples=current_data,
+                concept_indices=np.full(len(current_data), concept_index, dtype=np.int64),
+            )
+        else:
+            self._buffer.update(current_data)
+
+        calibration_data = current_data
+        if len(replay_data) > 0:
+            calibration_data = np.concatenate([replay_data, current_data], axis=0)
+
+        if hasattr(self._model, "_auto_threshold") and self._model._auto_threshold:
+            self._model._calibrate_threshold(calibration_data)
+
+        self._task_count += 1
+
+    def predict(self, data: np.ndarray, concept_id: Optional[str] = None, **kwargs) -> tuple[np.ndarray, np.ndarray]:
+        del concept_id, kwargs
+        return self._model.predict(data)
+
+    def name(self) -> str:
+        return "AGEM"
+
+    def additional_info(self) -> Dict:
+        info = super().additional_info()
+        info.update(
+            {
+                "model": self._model.name(),
+                "seed": self._seed,
+                "task_count": self._task_count,
+                "concept_count": len(self._concept_to_index),
+            }
+        )
+        return info
+
+    def _fit(self, current_data: np.ndarray) -> None:
+        module = self._resolve_trainable_module()
+        if module is None:
+            raise TypeError("Model does not expose a trainable torch module required for AGEM.")
+
+        tensor_data = self._prepare_data(current_data)
+        dataloader = DataLoader(
+            TensorDataset(tensor_data),
+            batch_size=self._resolve_batch_size(),
+            shuffle=self._resolve_shuffle(),
+            num_workers=0,
+        )
+
+        device = self._resolve_device()
+        module.to(device)
+        module.train()
+
+        parameters = [parameter for parameter in module.parameters() if parameter.requires_grad]
+        if not parameters:
+            raise TypeError("AGEMStrategy requires at least one trainable parameter.")
+
+        optimizer = torch.optim.Adam(parameters, lr=self._resolve_lr())
+        epochs = self._resolve_epochs()
+
+        for epoch in range(epochs):
+            epoch_current = 0.0
+            epoch_replay = 0.0
+            projection_count = 0
+
+            for (batch,) in dataloader:
+                batch = batch.to(device)
+
+                # First compute the gradient for the current concept. This is
+                # the update we would normally apply if no replay constraint
+                # existed.
+                optimizer.zero_grad()
+                current_loss = self._compute_batch_loss(module, batch)
+                current_loss.backward()
+                current_grad = self.capture_gradients(parameters)
+                final_grad = current_grad
+
+                replay_loss = torch.tensor(0.0, device=device)
+                replay_examples = self._sample_replay_examples(self._resolve_batch_size())
+                if replay_examples is not None:
+                    # Then estimate how older concepts would like the model to
+                    # move by taking a replay gradient from memory.
+                    optimizer.zero_grad()
+                    replay_batch = self._prepare_data(replay_examples).to(device)
+                    replay_loss = self._compute_batch_loss(module, replay_batch)
+                    replay_loss.backward()
+                    replay_grad = self.capture_gradients(parameters)
+
+                    # A negative dot product means the current update would
+                    # interfere with replay performance. In that case A-GEM
+                    # projects the current gradient to remove the conflicting
+                    # component while preserving as much useful progress as
+                    # possible.
+                    if torch.dot(current_grad, replay_grad).item() < 0:
+                        final_grad = self.project_gradient(current_grad, replay_grad)
+                        projection_count += 1
+
+                optimizer.zero_grad()
+                self.restore_gradients(parameters, final_grad)
+                optimizer.step()
+
+                epoch_current += current_loss.item()
+                epoch_replay += replay_loss.item()
+
+            if (epoch + 1) % max(1, epochs // 5) == 0:
+                n_batches = len(dataloader)
+                projection_rate = 100.0 * projection_count / n_batches
+                logger.info(
+                    "AGEM epoch %s/%s: current=%.6f replay=%.6f projections=%s/%s (%.1f%%)",
+                    epoch + 1,
+                    epochs,
+                    epoch_current / n_batches,
+                    epoch_replay / n_batches,
+                    projection_count,
+                    n_batches,
+                    projection_rate,
+                )
+
+    def _sample_replay_examples(self, batch_size: int) -> Optional[np.ndarray]:
+        if isinstance(self._buffer, BalancedReplayBuffer):
+            if self._buffer.is_empty():
+                return None
+            return self._buffer.sample(batch_size)["examples"]
+
+        replay_data = self._buffer.data()
+        if len(replay_data) == 0:
+            return None
+
+        sample_size = min(int(batch_size), len(replay_data))
+        indices = self._rng.choice(len(replay_data), size=sample_size, replace=False)
+        return np.asarray(replay_data)[indices]
+
+    def _concept_index(self, concept_id: str) -> int:
+        if concept_id not in self._concept_to_index:
+            self._concept_to_index[concept_id] = len(self._concept_to_index)
+        return self._concept_to_index[concept_id]
+
+    def _resolve_trainable_module(self, model: Optional[Model] = None) -> Optional[torch.nn.Module]:
+        current = self._model if model is None else model
+        seen = set()
+
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+
+            module = getattr(current, "module", None)
+            if isinstance(module, torch.nn.Module):
+                return module
+
+            module = getattr(current, "model", None)
+            if isinstance(module, torch.nn.Module):
+                return module
+
+            current = getattr(current, "model", None)
+
+        return None
+
+    def _resolve_model_attr(self, attr_name: str, default, model: Optional[Model] = None):
+        current = self._model if model is None else model
+        seen = set()
+
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+
+            if hasattr(current, attr_name):
+                return getattr(current, attr_name)
+
+            module = getattr(current, "module", None)
+            if module is not None and hasattr(module, attr_name):
+                return getattr(module, attr_name)
+
+            current = getattr(current, "model", None)
+
+        return default
+
+    def _resolve_batch_size(self) -> int:
+        batch_size = self._resolve_model_attr("batch_size", 32)
+        return int(batch_size) if batch_size else 32
+
+    def _resolve_lr(self) -> float:
+        lr = self._resolve_model_attr("lr", 1e-2)
+        return float(lr) if lr else 1e-2
+
+    def _resolve_epochs(self) -> int:
+        epochs = self._resolve_model_attr("epochs", 20)
+        return int(epochs) if epochs else 20
+
+    def _resolve_device(self, model: Optional[Model] = None) -> torch.device:
+        explicit_device = self._resolve_model_attr("device", None, model)
+        if explicit_device is not None:
+            return torch.device(explicit_device)
+
+        module = self._resolve_trainable_module(model)
+        if module is not None:
+            try:
+                return next(module.parameters()).device
+            except (AttributeError, StopIteration):
+                pass
+
+        return torch.device("cpu")
+
+    def _resolve_shuffle(self) -> bool:
+        current = self._model
+        seen = set()
+
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+
+            current_name = current.__class__.__name__
+            if current_name in {"TemporalAutoencoder", "VariationalTemporalAutoencoder"}:
+                return False
+            if current_name == "Autoencoder":
+                return True
+
+            module = getattr(current, "module", None)
+            if module is not None:
+                module_name = module.__class__.__name__
+                if module_name in {"TemporalAutoencoderModule", "VariationalTemporalAutoencoderModule"}:
+                    return False
+                if module_name == "AutoencoderModule":
+                    return True
+
+            current = getattr(current, "model", None)
+
+        return True
+
+    def _transform_data_for_model(self, data: np.ndarray, model: Optional[Model] = None) -> np.ndarray:
+        current = self._model if model is None else model
+        transformed = np.asarray(data)
+        seen = set()
+
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+
+            if current.__class__.__name__ == "FlattenTimeSeriesAdapter":
+                transformed = transformed.reshape(transformed.shape[0], -1)
+
+            current = getattr(current, "model", None)
+
+        return np.array(transformed, copy=True)
+
+    def _prepare_data(self, data: np.ndarray) -> torch.Tensor:
+        transformed = self._transform_data_for_model(data)
+        return torch.tensor(transformed, dtype=torch.float32)
+
+    @staticmethod
+    def _forward_batch(module: torch.nn.Module, batch: torch.Tensor) -> tuple[torch.Tensor, tuple]:
+        output = module(batch)
+        if isinstance(output, (tuple, list)):
+            return output[0], tuple(output[1:])
+        return output, tuple()
+
+    def _compute_batch_loss(self, module: torch.nn.Module, batch: torch.Tensor) -> torch.Tensor:
+        x_hat, extras = self._forward_batch(module, batch)
+        train_loss = getattr(module, "train_loss", None)
+
+        if callable(train_loss):
+            try:
+                if len(extras) >= 2:
+                    return train_loss(x_hat, batch, extras[0], extras[1])
+                return train_loss(x_hat, batch)
+            except TypeError:
+                try:
+                    if len(extras) >= 2:
+                        return train_loss(batch, x_hat, extras[0], extras[1])
+                    return train_loss(batch, x_hat)
+                except TypeError:
+                    pass
+
+        return torch.nn.functional.mse_loss(x_hat, batch)
+
+    @staticmethod
+    def capture_gradients(parameters: Sequence[torch.nn.Parameter]) -> torch.Tensor:
+        flat_parts = []
+        for parameter in parameters:
+            if parameter.grad is None:
+                flat_parts.append(torch.zeros(parameter.numel(), device=parameter.device, dtype=parameter.dtype))
+            else:
+                flat_parts.append(parameter.grad.detach().reshape(-1).clone())
+
+        if not flat_parts:
+            return torch.empty(0)
+
+        return torch.cat(flat_parts)
+
+    @staticmethod
+    def restore_gradients(parameters: Sequence[torch.nn.Parameter], flat_gradient: torch.Tensor) -> None:
+        offset = 0
+        for parameter in parameters:
+            numel = parameter.numel()
+            grad_slice = flat_gradient[offset : offset + numel].view_as(parameter)
+            parameter.grad = grad_slice.clone().to(device=parameter.device, dtype=parameter.dtype)
+            offset += numel
+
+    @staticmethod
+    def project_gradient(current: torch.Tensor, reference: torch.Tensor) -> torch.Tensor:
+        if current.numel() == 0 or reference.numel() == 0:
+            return current
+
+        reference_norm = torch.dot(reference, reference)
+        if reference_norm.item() <= 0:
+            return current
+
+        correction = torch.dot(current, reference) / reference_norm
+        return current - correction * reference

--- a/src/pyclad/strategies/replay/buffers/__init__.py
+++ b/src/pyclad/strategies/replay/buffers/__init__.py
@@ -1,0 +1,11 @@
+from pyclad.strategies.replay.buffers.adaptive_balanced import (
+    AdaptiveBalancedReplayBuffer,
+)
+from pyclad.strategies.replay.buffers.balanced import BalancedReplayBuffer
+from pyclad.strategies.replay.buffers.buffer import ReplayBuffer
+
+__all__ = [
+    "AdaptiveBalancedReplayBuffer",
+    "BalancedReplayBuffer",
+    "ReplayBuffer",
+]

--- a/src/pyclad/strategies/replay/buffers/balanced.py
+++ b/src/pyclad/strategies/replay/buffers/balanced.py
@@ -113,17 +113,31 @@ class BalancedReplayBuffer(ReplayBuffer):
             raise ValueError(f"{field_name} shape mismatch: expected {expected_shape}, got {shape}")
 
     def _rebalance(self) -> None:
-        while len(self) > self._max_size:
-            counts = Counter(self._fields["concept_indices"])
+        excess = len(self) - self._max_size
+        if excess <= 0:
+            return
+
+        concept_indices = self._fields["concept_indices"]
+        counts = Counter(concept_indices)
+        candidates_by_concept: Dict[int, list[int]] = {}
+        for index, concept_index in enumerate(concept_indices):
+            candidates_by_concept.setdefault(concept_index, []).append(index)
+
+        drop_indices = set()
+        while excess > 0:
             largest_concept = max(counts.items(), key=lambda item: (item[1], item[0]))[0]
-            candidates = [
-                index
-                for index, concept_index in enumerate(self._fields["concept_indices"])
-                if concept_index == largest_concept
-            ]
-            drop_index = int(self._rng.choice(candidates))
-            for values in self._fields.values():
-                del values[drop_index]
+            candidates = candidates_by_concept[largest_concept]
+            drop_offset = int(self._rng.integers(len(candidates)))
+            drop_indices.add(candidates.pop(drop_offset))
+            counts[largest_concept] -= 1
+            if counts[largest_concept] == 0:
+                del counts[largest_concept]
+                del candidates_by_concept[largest_concept]
+            excess -= 1
+
+        kept_indices = [index for index in range(len(concept_indices)) if index not in drop_indices]
+        for field_name, values in self._fields.items():
+            self._fields[field_name] = [values[index] for index in kept_indices]
 
     def _stack_field(self, field_name: str, values: Sequence) -> np.ndarray:
         if not values:

--- a/src/pyclad/strategies/replay/buffers/balanced.py
+++ b/src/pyclad/strategies/replay/buffers/balanced.py
@@ -1,0 +1,146 @@
+from collections import Counter
+from typing import Any, Dict, Sequence, Tuple
+
+import numpy as np
+
+from pyclad.strategies.replay.buffers.buffer import ReplayBuffer
+
+
+class BalancedReplayBuffer(ReplayBuffer):
+    """Balanced replay buffer with concept-aware rebalancing and optional auxiliary fields.
+
+    Unlike ``AdaptiveBalancedReplayBuffer``:
+    - it balances by explicit ``concept_indices`` rather than by update call;
+    - it stores auxiliary per-sample fields in addition to raw examples;
+    - it exposes ``arrays()`` and ``sample()`` for strategies such as A-GEM;
+    - it rebalances by dropping samples from the currently largest concept
+      instead of resizing every concept buffer to ``floor(max_size / n_buffers)``.
+    """
+
+    def __init__(self, max_size: int, seed: int = 0):
+        if max_size <= 0:
+            raise ValueError(f"max_size must be positive, got {max_size}")
+
+        self._max_size = int(max_size)
+        self._rng = np.random.default_rng(seed)
+        self._fields: Dict[str, list] = {
+            "examples": [],
+            "concept_indices": [],
+        }
+        self._field_shapes: Dict[str, Tuple[int, ...]] = {}
+        self._field_dtypes: Dict[str, np.dtype] = {
+            "examples": np.dtype(np.float32),
+            "concept_indices": np.dtype(np.int64),
+        }
+        self._next_concept_index = 0
+
+    def __len__(self) -> int:
+        return len(self._fields["examples"])
+
+    def is_empty(self) -> bool:
+        return len(self) == 0
+
+    def update(self, data: np.ndarray) -> None:
+        examples = np.asarray(data, dtype=np.float32)
+        if len(examples) == 0:
+            return
+
+        concept_indices = np.full(len(examples), self._next_concept_index, dtype=np.int64)
+        self.add(examples=examples, concept_indices=concept_indices)
+
+    def add(self, examples: np.ndarray, concept_indices: np.ndarray, **auxiliary_fields) -> None:
+        examples_array = np.asarray(examples, dtype=np.float32)
+        concept_array = np.asarray(concept_indices, dtype=np.int64)
+        if len(examples_array) != len(concept_array):
+            raise ValueError("examples and concept_indices must have the same length")
+
+        for field_name, values in auxiliary_fields.items():
+            if len(values) != len(examples_array):
+                raise ValueError(f"{field_name} must have the same length as examples")
+
+        if len(examples_array) == 0:
+            return
+
+        self._validate_field_shape("examples", tuple(np.asarray(examples_array[0]).shape))
+        for field_name, values in auxiliary_fields.items():
+            array = np.asarray(values)
+            self._validate_field_shape(field_name, tuple(np.asarray(array[0]).shape))
+            self._field_dtypes.setdefault(field_name, array.dtype)
+            self._fields.setdefault(field_name, [])
+
+        for index in range(len(examples_array)):
+            self._fields["examples"].append(np.array(examples_array[index], dtype=np.float32, copy=True))
+            self._fields["concept_indices"].append(int(concept_array[index]))
+            for field_name, values in auxiliary_fields.items():
+                self._fields[field_name].append(np.array(values[index], copy=True))
+
+        self._next_concept_index = max(self._next_concept_index, int(concept_array.max()) + 1)
+        self._rebalance()
+
+    def data(self) -> np.ndarray:
+        return self.arrays()["examples"]
+
+    def arrays(self) -> Dict[str, np.ndarray]:
+        return {field_name: self._stack_field(field_name, values) for field_name, values in self._fields.items()}
+
+    def sample(self, batch_size: int) -> Dict[str, np.ndarray]:
+        if self.is_empty():
+            raise ValueError("Cannot sample from an empty replay buffer")
+
+        size = min(int(batch_size), len(self))
+        indices = self._rng.choice(len(self), size=size, replace=False)
+        return {
+            field_name: self._stack_selected(field_name, values, indices) for field_name, values in self._fields.items()
+        }
+
+    def name(self) -> str:
+        return "BalancedReplayBuffer"
+
+    def additional_info(self) -> Dict[str, Any]:
+        auxiliary_fields = sorted(
+            field_name for field_name in self._fields if field_name not in {"examples", "concept_indices"}
+        )
+        concept_indices = self._fields["concept_indices"]
+        return {
+            "max_size": self._max_size,
+            "concept_count": len(set(concept_indices)),
+            "auxiliary_fields": auxiliary_fields,
+        }
+
+    def _validate_field_shape(self, field_name: str, shape: Tuple[int, ...]) -> None:
+        expected_shape = self._field_shapes.setdefault(field_name, shape)
+        if expected_shape != shape:
+            raise ValueError(f"{field_name} shape mismatch: expected {expected_shape}, got {shape}")
+
+    def _rebalance(self) -> None:
+        while len(self) > self._max_size:
+            counts = Counter(self._fields["concept_indices"])
+            largest_concept = max(counts.items(), key=lambda item: (item[1], item[0]))[0]
+            candidates = [
+                index
+                for index, concept_index in enumerate(self._fields["concept_indices"])
+                if concept_index == largest_concept
+            ]
+            drop_index = int(self._rng.choice(candidates))
+            for values in self._fields.values():
+                del values[drop_index]
+
+    def _stack_field(self, field_name: str, values: Sequence) -> np.ndarray:
+        if not values:
+            dtype = self._field_dtypes.get(field_name, np.dtype(np.float32))
+            if field_name == "concept_indices":
+                return np.empty((0,), dtype=np.int64)
+            if field_name in self._field_shapes:
+                return np.empty((0, *self._field_shapes[field_name]), dtype=dtype)
+            return np.empty((0,), dtype=dtype)
+
+        first_value = values[0]
+        if np.isscalar(first_value) or np.asarray(first_value).ndim == 0:
+            dtype = np.int64 if field_name == "concept_indices" else self._field_dtypes.get(field_name, None)
+            return np.asarray(values, dtype=dtype)
+
+        return np.stack(values)
+
+    def _stack_selected(self, field_name: str, values: Sequence, indices: np.ndarray) -> np.ndarray:
+        selected = [values[int(index)] for index in indices]
+        return self._stack_field(field_name, selected)

--- a/tests/strategies/replay/buffers/test_balanced.py
+++ b/tests/strategies/replay/buffers/test_balanced.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from numpy.testing import assert_array_equal
 
 from pyclad.strategies.replay.buffers.balanced import BalancedReplayBuffer
@@ -47,3 +48,20 @@ def test_rebalancing_balanced_buffer_drops_from_largest_concept():
     assert len(buffer.data()) == 4
     assert np.count_nonzero(concept_indices == 0) == 2
     assert np.count_nonzero(concept_indices == 1) == 2
+
+
+def test_rebalancing_balanced_buffer_preserves_auxiliary_field_alignment():
+    buffer = BalancedReplayBuffer(max_size=4, seed=0)
+    examples = np.array([[0], [1], [2], [3], [10], [11], [12], [13]], dtype=np.float32)
+    concept_indices = np.array([0, 0, 0, 0, 1, 1, 1, 1], dtype=np.int64)
+    losses = np.array([0.0, 1.0, 2.0, 3.0, 10.0, 11.0, 12.0, 13.0], dtype=np.float32)
+
+    buffer.add(examples=examples, concept_indices=concept_indices, reconstruction_loss=losses)
+
+    sample = buffer.arrays()
+    observed_mapping = {
+        int(example[0]): float(loss) for example, loss in zip(sample["examples"], sample["reconstruction_loss"], strict=True)
+    }
+
+    for key, value in observed_mapping.items():
+        assert value == pytest.approx(float(key))

--- a/tests/strategies/replay/buffers/test_balanced.py
+++ b/tests/strategies/replay/buffers/test_balanced.py
@@ -1,0 +1,49 @@
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from pyclad.strategies.replay.buffers.balanced import BalancedReplayBuffer
+
+
+def test_updating_balanced_buffer_stores_examples_and_concept_indices():
+    buffer = BalancedReplayBuffer(max_size=10, seed=0)
+    data = np.array([[1, 2], [3, 4]], dtype=np.float32)
+
+    buffer.update(data)
+
+    arrays = buffer.arrays()
+    assert_array_equal(arrays["examples"], data)
+    assert_array_equal(arrays["concept_indices"], np.array([0, 0], dtype=np.int64))
+
+
+def test_sampling_balanced_buffer_returns_all_registered_fields():
+    buffer = BalancedReplayBuffer(max_size=10, seed=0)
+    examples = np.array([[1, 2], [3, 4], [5, 6]], dtype=np.float32)
+    concept_indices = np.array([0, 0, 1], dtype=np.int64)
+    losses = np.array([0.1, 0.2, 0.3], dtype=np.float32)
+
+    buffer.add(
+        examples=examples,
+        concept_indices=concept_indices,
+        reconstruction_loss=losses,
+    )
+
+    sample = buffer.sample(2)
+
+    assert set(sample) == {"examples", "concept_indices", "reconstruction_loss"}
+    assert sample["examples"].shape == (2, 2)
+    assert sample["concept_indices"].shape == (2,)
+    assert sample["reconstruction_loss"].shape == (2,)
+
+
+def test_rebalancing_balanced_buffer_drops_from_largest_concept():
+    buffer = BalancedReplayBuffer(max_size=4, seed=0)
+    first_concept = np.array([[0], [1], [2], [3]], dtype=np.float32)
+    second_concept = np.array([[10], [11], [12], [13]], dtype=np.float32)
+
+    buffer.add(first_concept, np.zeros(len(first_concept), dtype=np.int64))
+    buffer.add(second_concept, np.ones(len(second_concept), dtype=np.int64))
+
+    concept_indices = buffer.arrays()["concept_indices"]
+    assert len(buffer.data()) == 4
+    assert np.count_nonzero(concept_indices == 0) == 2
+    assert np.count_nonzero(concept_indices == 1) == 2

--- a/tests/strategies/replay/test_agem.py
+++ b/tests/strategies/replay/test_agem.py
@@ -14,8 +14,6 @@ class TinyModule(nn.Module):
     def __init__(self):
         super().__init__()
         self.linear = nn.Linear(2, 2)
-        self.train_loss = nn.MSELoss()
-        self.lr = 1e-2
 
     def forward(self, x):
         return self.linear(x)
@@ -24,9 +22,6 @@ class TinyModule(nn.Module):
 class TinyTorchModel(Model):
     def __init__(self):
         self.module = TinyModule()
-        self.epochs = 1
-        self.batch_size = 2
-        self.device = torch.device("cpu")
 
     def fit(self, data: np.ndarray):
         raise AssertionError("AGEMStrategy should not delegate training to model.fit().")
@@ -39,7 +34,16 @@ class TinyTorchModel(Model):
 
 
 def test_agem_strategy_implements_replay_only_interface():
-    strategy = AGEMStrategy(TinyTorchModel(), BalancedReplayBuffer(max_size=8, seed=0))
+    model = TinyTorchModel()
+    strategy = AGEMStrategy(
+        model,
+        BalancedReplayBuffer(max_size=8, seed=0),
+        module=model.module,
+        batch_size=2,
+        lr=1e-2,
+        epochs=1,
+        device="cpu",
+    )
 
     assert isinstance(strategy, ReplayOnlyStrategy)
     assert strategy.name() == "AGEM"
@@ -48,7 +52,7 @@ def test_agem_strategy_implements_replay_only_interface():
 def test_agem_strategy_tracks_concepts_in_balanced_buffer():
     model = TinyTorchModel()
     buffer = BalancedReplayBuffer(max_size=8, seed=0)
-    strategy = AGEMStrategy(model, buffer)
+    strategy = AGEMStrategy(model, buffer, module=model.module, batch_size=2, lr=1e-2, epochs=1, device="cpu")
     first_concept = np.array([[1.0, 2.0], [2.0, 3.0]], dtype=np.float32)
     second_concept = np.array([[3.0, 4.0], [4.0, 5.0]], dtype=np.float32)
 
@@ -62,6 +66,9 @@ def test_agem_strategy_tracks_concepts_in_balanced_buffer():
     info = strategy.additional_info()
     assert info["task_count"] == 2
     assert info["concept_count"] == 2
+    assert info["batch_size"] == 2
+    assert info["optimizer"] == "sgd"
+    assert info["epochs"] == 1
     assert "replay_buffer" in info
 
 
@@ -74,6 +81,13 @@ def test_capture_gradients_is_available_as_static_utility():
     assert torch.equal(captured, torch.tensor([0.5, -1.5], dtype=torch.float32))
 
 
-def test_agem_strategy_requires_torch_backed_model():
-    with pytest.raises(TypeError, match="PyTorch-backed model"):
-        AGEMStrategy(MockModel())
+def test_agem_strategy_requires_explicit_torch_module():
+    with pytest.raises(TypeError, match="torch.nn.Module"):
+        AGEMStrategy(MockModel(), module="not-a-module")
+
+
+def test_agem_strategy_rejects_unknown_optimizer():
+    model = TinyTorchModel()
+
+    with pytest.raises(ValueError, match="optimizer must be 'sgd' or 'adam'"):
+        AGEMStrategy(model, module=model.module, optimizer="rmsprop")

--- a/tests/strategies/replay/test_agem.py
+++ b/tests/strategies/replay/test_agem.py
@@ -1,3 +1,5 @@
+import logging
+
 import numpy as np
 import pytest
 import torch
@@ -31,6 +33,29 @@ class TinyTorchModel(Model):
 
     def name(self) -> str:
         return "TinyTorchModel"
+
+
+class DotProductModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weights = nn.Parameter(torch.zeros(2, dtype=torch.float32))
+
+    def forward(self, x):
+        return x
+
+
+class DotProductModel(Model):
+    def __init__(self):
+        self.module = DotProductModule()
+
+    def fit(self, data: np.ndarray):
+        raise AssertionError("AGEMStrategy should not delegate training to model.fit().")
+
+    def predict(self, data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        return np.zeros(len(data), dtype=int), np.zeros(len(data), dtype=float)
+
+    def name(self) -> str:
+        return "DotProductModel"
 
 
 def test_agem_strategy_implements_replay_only_interface():
@@ -83,6 +108,14 @@ def test_capture_gradients_is_available_as_static_utility():
     assert torch.equal(captured, torch.tensor([0.5, -1.5], dtype=torch.float32))
 
 
+def test_capture_gradients_rejects_multi_device_parameter_sets():
+    cpu_parameter = nn.Parameter(torch.tensor([1.0], dtype=torch.float32))
+    meta_parameter = nn.Parameter(torch.empty(1, device="meta"))
+
+    with pytest.raises(ValueError, match="single device"):
+        AGEMStrategy.capture_gradients([cpu_parameter, meta_parameter])
+
+
 def test_agem_strategy_requires_explicit_torch_module():
     with pytest.raises(TypeError, match="torch.nn.Module"):
         AGEMStrategy(MockModel(), module="not-a-module")
@@ -125,3 +158,135 @@ def test_project_gradient_returns_current_for_non_finite_reference_norm():
     projected = AGEMStrategy.project_gradient(current, reference)
 
     assert torch.equal(projected, current)
+
+
+def test_prepare_data_reuses_identity_transform_storage():
+    model = TinyTorchModel()
+    strategy = AGEMStrategy(model, module=model.module, device="cpu")
+    data = np.array([[1.0, 2.0]], dtype=np.float32)
+
+    prepared = strategy._prepare_data(data)
+
+    assert np.shares_memory(prepared.numpy(), data)
+
+
+def test_should_project_warns_on_non_finite_dot_product(caplog):
+    current = torch.tensor([float("nan"), 1.0], dtype=torch.float32)
+    reference = torch.tensor([1.0, 1.0], dtype=torch.float32)
+
+    with caplog.at_level(logging.WARNING):
+        should_project = AGEMStrategy.should_project(current, reference)
+
+    assert not should_project
+    assert "gradient dot product is non-finite" in caplog.text
+
+
+def test_agem_strategy_warns_that_adam_voids_standard_agem_guarantee(caplog):
+    model = TinyTorchModel()
+    strategy = AGEMStrategy(
+        model,
+        module=model.module,
+        optimizer="adam",
+        batch_size=1,
+        epochs=1,
+        device="cpu",
+        shuffle=False,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        strategy._fit(np.array([[1.0, 2.0]], dtype=np.float32))
+
+    assert "does not preserve the standard A-GEM guarantee" in caplog.text
+    assert "adaptive moment estimates" in caplog.text
+
+
+def test_agem_strategy_skips_empty_replay_sampling(monkeypatch):
+    model = TinyTorchModel()
+    strategy = AGEMStrategy(
+        model,
+        BalancedReplayBuffer(max_size=4, seed=0),
+        module=model.module,
+        batch_size=1,
+        epochs=1,
+        device="cpu",
+        shuffle=False,
+    )
+
+    def fail_if_called(batch_size: int) -> np.ndarray:
+        raise AssertionError(f"_sample_replay_examples should not be called for empty buffers, got {batch_size}")
+
+    monkeypatch.setattr(strategy, "_sample_replay_examples", fail_if_called)
+
+    strategy._fit(np.array([[1.0, 2.0]], dtype=np.float32))
+
+
+def test_agem_strategy_adam_state_tracks_only_the_restored_projected_gradient(monkeypatch):
+    model = DotProductModel()
+    buffer = BalancedReplayBuffer(max_size=4, seed=0)
+    buffer.add(
+        examples=np.array([[-1.0, 1.0]], dtype=np.float32),
+        concept_indices=np.array([0], dtype=np.int64),
+    )
+
+    def linear_loss(module: DotProductModule, batch: torch.Tensor) -> torch.Tensor:
+        return torch.dot(module.weights, batch.mean(dim=0))
+
+    captured = {}
+    original_adam = torch.optim.Adam
+
+    class CaptureAdam(original_adam):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            captured["optimizer"] = self
+
+    monkeypatch.setattr(torch.optim, "Adam", CaptureAdam)
+
+    strategy = AGEMStrategy(
+        model,
+        buffer,
+        module=model.module,
+        loss_fn=linear_loss,
+        batch_size=1,
+        replay_batch_size=1,
+        lr=1e-3,
+        optimizer="adam",
+        epochs=1,
+        device="cpu",
+        shuffle=False,
+    )
+
+    strategy._fit(np.array([[1.0, 0.0]], dtype=np.float32))
+
+    optimizer = captured["optimizer"]
+    state = optimizer.state[model.module.weights]
+    expected_projected_grad = torch.tensor([0.5, 0.5], dtype=torch.float32)
+
+    assert torch.allclose(state["exp_avg"], 0.1 * expected_projected_grad)
+    assert torch.allclose(state["exp_avg_sq"], 0.001 * expected_projected_grad.square())
+
+
+def test_agem_strategy_skips_non_finite_current_gradients(caplog):
+    model = TinyTorchModel()
+
+    def nan_loss(module: TinyModule, batch: torch.Tensor) -> torch.Tensor:
+        del batch
+        return module.linear.weight.sum() * torch.tensor(float("nan"))
+
+    strategy = AGEMStrategy(
+        model,
+        module=model.module,
+        loss_fn=nan_loss,
+        batch_size=1,
+        epochs=1,
+        device="cpu",
+        shuffle=False,
+    )
+    weight_before = model.module.linear.weight.detach().clone()
+    bias_before = model.module.linear.bias.detach().clone()
+
+    with caplog.at_level(logging.WARNING):
+        strategy._fit(np.array([[1.0, 2.0]], dtype=np.float32))
+
+    assert "current gradient contains non-finite values" in caplog.text
+    assert torch.equal(model.module.linear.weight.detach(), weight_before)
+    assert torch.equal(model.module.linear.bias.detach(), bias_before)

--- a/tests/strategies/replay/test_agem.py
+++ b/tests/strategies/replay/test_agem.py
@@ -67,7 +67,9 @@ def test_agem_strategy_tracks_concepts_in_balanced_buffer():
     assert info["task_count"] == 2
     assert info["concept_count"] == 2
     assert info["batch_size"] == 2
+    assert info["replay_batch_size"] == 2
     assert info["optimizer"] == "sgd"
+    assert info["projection_tolerance"] == pytest.approx(1e-6)
     assert info["epochs"] == 1
     assert "replay_buffer" in info
 
@@ -91,3 +93,35 @@ def test_agem_strategy_rejects_unknown_optimizer():
 
     with pytest.raises(ValueError, match="optimizer must be 'sgd' or 'adam'"):
         AGEMStrategy(model, module=model.module, optimizer="rmsprop")
+
+
+def test_agem_strategy_rejects_negative_projection_tolerance():
+    model = TinyTorchModel()
+
+    with pytest.raises(ValueError, match="projection_tolerance must be non-negative"):
+        AGEMStrategy(model, module=model.module, projection_tolerance=-1e-6)
+
+
+def test_agem_strategy_allows_distinct_replay_batch_size():
+    model = TinyTorchModel()
+    strategy = AGEMStrategy(model, module=model.module, batch_size=4, replay_batch_size=2)
+
+    assert strategy.additional_info()["batch_size"] == 4
+    assert strategy.additional_info()["replay_batch_size"] == 2
+
+
+def test_should_project_respects_tolerance():
+    current = torch.tensor([1.0, 1.0], dtype=torch.float32)
+    reference = torch.tensor([-1.0, 1.0 - 5e-7], dtype=torch.float32)
+
+    assert not AGEMStrategy.should_project(current, reference, tolerance=1e-6)
+    assert AGEMStrategy.should_project(current, reference, tolerance=1e-8)
+
+
+def test_project_gradient_returns_current_for_non_finite_reference_norm():
+    current = torch.tensor([1.0, 2.0], dtype=torch.float32)
+    reference = torch.tensor([float("nan"), 0.0], dtype=torch.float32)
+
+    projected = AGEMStrategy.project_gradient(current, reference)
+
+    assert torch.equal(projected, current)

--- a/tests/strategies/replay/test_agem.py
+++ b/tests/strategies/replay/test_agem.py
@@ -1,0 +1,79 @@
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+from pyclad.models.model import Model
+from pyclad.strategies.replay.agem import AGEMStrategy
+from pyclad.strategies.replay.buffers.balanced import BalancedReplayBuffer
+from pyclad.strategies.replay.replay import ReplayOnlyStrategy
+from tests.strategies.baselines.mock_model import MockModel
+
+
+class TinyModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(2, 2)
+        self.train_loss = nn.MSELoss()
+        self.lr = 1e-2
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class TinyTorchModel(Model):
+    def __init__(self):
+        self.module = TinyModule()
+        self.epochs = 1
+        self.batch_size = 2
+        self.device = torch.device("cpu")
+
+    def fit(self, data: np.ndarray):
+        raise AssertionError("AGEMStrategy should not delegate training to model.fit().")
+
+    def predict(self, data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        return np.zeros(len(data), dtype=int), np.zeros(len(data), dtype=float)
+
+    def name(self) -> str:
+        return "TinyTorchModel"
+
+
+def test_agem_strategy_implements_replay_only_interface():
+    strategy = AGEMStrategy(TinyTorchModel(), BalancedReplayBuffer(max_size=8, seed=0))
+
+    assert isinstance(strategy, ReplayOnlyStrategy)
+    assert strategy.name() == "AGEM"
+
+
+def test_agem_strategy_tracks_concepts_in_balanced_buffer():
+    model = TinyTorchModel()
+    buffer = BalancedReplayBuffer(max_size=8, seed=0)
+    strategy = AGEMStrategy(model, buffer)
+    first_concept = np.array([[1.0, 2.0], [2.0, 3.0]], dtype=np.float32)
+    second_concept = np.array([[3.0, 4.0], [4.0, 5.0]], dtype=np.float32)
+
+    strategy.learn(first_concept, concept_id="alpha")
+    strategy.learn(second_concept, concept_id="beta")
+
+    arrays = buffer.arrays()
+    assert len(arrays["examples"]) == 4
+    assert set(arrays["concept_indices"].tolist()) == {0, 1}
+
+    info = strategy.additional_info()
+    assert info["task_count"] == 2
+    assert info["concept_count"] == 2
+    assert "replay_buffer" in info
+
+
+def test_capture_gradients_is_available_as_static_utility():
+    parameter = nn.Parameter(torch.tensor([[1.0, 2.0]], dtype=torch.float32))
+    parameter.grad = torch.tensor([[0.5, -1.5]], dtype=torch.float32)
+
+    captured = AGEMStrategy.capture_gradients([parameter])
+
+    assert torch.equal(captured, torch.tensor([0.5, -1.5], dtype=torch.float32))
+
+
+def test_agem_strategy_requires_torch_backed_model():
+    with pytest.raises(TypeError, match="PyTorch-backed model"):
+        AGEMStrategy(MockModel())


### PR DESCRIPTION
This PR adds a strategy (A-GEM) to PyCLAD.  Averaged Gradient Episodic Memory is a replay strategy that treats the incoming batches as the current task and keeps a small replay buffer with examples from earlier concepts, during training it computes 2 gradients, one of the reconstruction loss on the current data and one of the reconstruction loss on a replay batch. The current gradient would increase loss on the replay data, A-GEM projects it onto the half-space that does not interfere with the replay gradient. In practice this means the model is still able to adapt to the new concept but it avoids updates that directly conflict with what it learned earlier. After optimization, the new concept is added to the replay buffer so future tasks can be constrained against it as well. This makes A-GEM a replay-driven strategy, but unlike vanilla replay it does not simply retrain on concatenated old and new data. Instead, replay is used to shape the gradient direction so the model remains plastic on the current task without taking obviously destructive steps on past concepts.

Another change is adding a new balanced replay buffer with concept-aware rebalancing and optional auxiliary fields. Unlike AdaptiveBalancedReplayBuffer this buffer:
    - balances by explicit concept_indices rather than by update call;
    - stores auxiliary per-sample fields in addition to raw examples;
    - exposes arrays() and sample() for strategies such as A-GEM;
    - rebalances by dropping samples from the currently largest concept instead of resizing every concept buffer to floor(max_size / n_buffers)

4/24

Changed the Adam warning to state that Adam voids the standard A-GEM guarantee because adaptive moment scaling changes the final update direction.

Changed capture_gradients() to reject multi-device parameter sets with a clear error instead of failing later inside torch.cat().

Changed _prepare_data() to use np.asarray(..., dtype=np.float32) and torch.as_tensor(...) so it avoids the extra tensor copy.

Changed restore_gradients() to remove the redundant .to(device=..., dtype=...) cast and just clone the gradient slice.

Changed non-finite gradient handling so should_project() warns on a non-finite dot product and _fit() skips the optimizer step when current, replay, or final gradients are non-finite.

Changed _fit() to skip replay sampling entirely when the replay buffer is empty.

Changed identity_transform() to return the input unchanged instead of copying it.


4/21

Switched A-GEM to SGD by default and made Adam explicit opt-in so the default update matches standard A-GEM assumptions.

Kept the mini-batch projection flow but clarified that this is the intended stochastic A-GEM style rather than a post-task projection scheme.

Covered the optimizer-state concern by treating Adam as an approximation and moving the safe default to SGD.

Removed the old shuffle-resolution logic by making shuffle an explicit strategy parameter instead of class-name inference.

Removed the old try/except loss-signature probing in A-GEM by using an explicit loss_fn contract with a simple default loss.

Removed the old adapter-name-based transform inference by making input reshaping an explicit data_transform parameter.

Decoupled replay sampling from current-task batch size with replay_batch_size and avoided needless resampling when the full buffer is already used.

Made balanced replay rebalancing more scalable by trimming in one pass instead of repeated full rescans and deletions.

Clarified the calibration flow by separating the replay snapshot used for threshold calibration from the buffer reads used for the actual A-GEM constraint.

Added a projection tolerance so A-GEM no longer projects on numerically insignificant near-zero negative dot products.

Hardened gradient projection against non-finite values so NaNs in the reference gradient do not silently poison the projected update.