### PR TITLE
Added Online/Offline for EWC

### DIFF
--- a/src/pyclad/strategies/regularization/ewc.py
+++ b/src/pyclad/strategies/regularization/ewc.py
@@ -78,9 +78,9 @@ class EWCStrategy(ConceptIncrementalStrategy, ConceptAwareStrategy):
             importance_sum = self._importance_sum[name].to(device=param.device, dtype=param.dtype)
             reference_sum = self._reference_sum[name].to(device=param.device, dtype=param.dtype)
             reference_square_sum = self._reference_square_sum[name].to(device=param.device, dtype=param.dtype)
-            penalty = penalty + (
-                importance_sum * param.pow(2) - 2.0 * reference_sum * param + reference_square_sum
-            ).sum()
+            penalty = (
+                penalty + (importance_sum * param.pow(2) - 2.0 * reference_sum * param + reference_square_sum).sum()
+            )
         return penalty
 
     def _update_fisher(self, data: np.ndarray) -> None:

--- a/src/pyclad/strategies/regularization/ewc.py
+++ b/src/pyclad/strategies/regularization/ewc.py
@@ -11,11 +11,14 @@ from pyclad.strategies.strategy import ConceptAwareStrategy, ConceptIncrementalS
 
 class EWCStrategy(ConceptIncrementalStrategy, ConceptAwareStrategy):
     """
-    Elastic Weight Consolidation (online variant).
+    Elastic Weight Consolidation with separate offline and online penalty modes.
 
     After each concept, approximates the diagonal Fisher Information Matrix via squared gradients of the
     reconstruction loss. When learning a new concept, adds a quadratic penalty that slows down changes to parameters
-    that were important for previous concepts. Fisher is accumulated across all seen concepts.
+    that were important for previous concepts.
+
+    By default, stores the contribution from every seen concept. With online=True, keeps the accumulated Fisher
+    anchored to the most recent concept parameters, matching the lightweight latest-concept variant.
 
     Larger fisher_batch_size underestimates the Fisher because it squares the mean gradient instead of averaging
     squared gradients. This shrinks the penalty and weakens protection against forgetting.
@@ -28,15 +31,18 @@ class EWCStrategy(ConceptIncrementalStrategy, ConceptAwareStrategy):
         epochs: int = 20,
         batch_size: int = 32,
         fisher_batch_size: int = 1,
+        online: bool = False,
     ):
         self._model = model
         self._lambda = lambda_ewc
         self._epochs = epochs
         self._batch_size = batch_size
         self._fisher_batch_size = fisher_batch_size
+        self._online = online
 
-        self._fisher: Dict[str, Tensor] = {}
-        self._optimal_params: Dict[str, Tensor] = {}
+        self._importance_sum: Dict[str, Tensor] = {}
+        self._reference_sum: Dict[str, Tensor] = {}
+        self._reference_square_sum: Dict[str, Tensor] = {}
 
     def learn(self, data: np.ndarray, **kwargs) -> None:
         dataset = TensorDataset(torch.tensor(data, dtype=torch.float32))
@@ -52,22 +58,29 @@ class EWCStrategy(ConceptIncrementalStrategy, ConceptAwareStrategy):
         return "EWC"
 
     def additional_info(self) -> Dict[str, Any]:
-        return {"lambda_ewc": self._lambda, "epochs": self._epochs}
+        return {"lambda_ewc": self._lambda, "epochs": self._epochs, "online": self._online}
 
     # ------------------------------------------------------------------
 
     def _compute_loss(self, batch) -> Tensor:
         (x,) = batch
         loss = self._model.compute_loss(x)
-        if self._fisher:
+        if self._importance_sum:
             loss = loss + self._lambda * self._penalty(self._model.get_module())
         return loss
 
     def _penalty(self, module: nn.Module) -> Tensor:
         penalty = torch.zeros((), device=next(module.parameters()).device)
         for name, param in module.named_parameters():
-            if name in self._fisher:
-                penalty = penalty + (self._fisher[name] * (param - self._optimal_params[name]).pow(2)).sum()
+            if not param.requires_grad or name not in self._importance_sum:
+                continue
+
+            importance_sum = self._importance_sum[name].to(device=param.device, dtype=param.dtype)
+            reference_sum = self._reference_sum[name].to(device=param.device, dtype=param.dtype)
+            reference_square_sum = self._reference_square_sum[name].to(device=param.device, dtype=param.dtype)
+            penalty = penalty + (
+                importance_sum * param.pow(2) - 2.0 * reference_sum * param + reference_square_sum
+            ).sum()
         return penalty
 
     def _update_fisher(self, data: np.ndarray) -> None:
@@ -92,12 +105,23 @@ class EWCStrategy(ConceptIncrementalStrategy, ConceptAwareStrategy):
                     new_fisher[name] += param.grad.detach().pow(2) * x.shape[0]
             n_samples += x.shape[0]
 
+        params = dict(module.named_parameters())
         for name in new_fisher:
             new_fisher[name] /= n_samples
-            if name in self._fisher:
-                self._fisher[name] += new_fisher[name]
+            param = params[name].detach()
+            reference = new_fisher[name] * param
+            reference_square = new_fisher[name] * param.pow(2)
+            if name in self._importance_sum:
+                self._importance_sum[name] += new_fisher[name]
+                if self._online:
+                    self._reference_sum[name] = self._importance_sum[name] * param
+                    self._reference_square_sum[name] = self._importance_sum[name] * param.pow(2)
+                else:
+                    self._reference_sum[name] += reference
+                    self._reference_square_sum[name] += reference_square
             else:
-                self._fisher[name] = new_fisher[name]
+                self._importance_sum[name] = new_fisher[name]
+                self._reference_sum[name] = reference
+                self._reference_square_sum[name] = reference_square
 
-        self._optimal_params = {name: param.data.clone() for name, param in module.named_parameters()}
         module.train()


### PR DESCRIPTION
Adds two EWC penalty modes behind the existing online flag. By default, online=False keeps contributions from all seen concepts, while online=True uses the lightweight latest-concept anchor behavior from the previous implementation. 