### PR TITLE
Add PNN architectural strategy

### DIFF
--- a/src/pyclad/strategies/architectural/pnn.py
+++ b/src/pyclad/strategies/architectural/pnn.py
@@ -1,0 +1,123 @@
+from typing import Callable
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from pyclad.models.torch_backbone import TorchBackbone
+from pyclad.strategies.strategy import ConceptAwareStrategy, ConceptIncrementalStrategy
+
+
+class PNNStrategy(ConceptIncrementalStrategy, ConceptAwareStrategy):
+    """Compact progressive-column strategy for torch backbones."""
+
+    def __init__(
+        self,
+        base_model_factory: Callable[[], TorchBackbone],
+        batch_size: int = 32,
+        epochs: int = 20,
+        task_free: bool = False,
+        device: str | torch.device = "cpu",
+    ) -> None:
+        self._base_model_factory = base_model_factory
+        self._batch_size = batch_size
+        self._epochs = epochs
+        self._task_free = task_free
+        self._device = torch.device(device)
+        self._columns: list[TorchBackbone] = []
+        self._concept_to_task: dict[str, int] = {}
+        self._current_task = -1
+
+    @property
+    def current_task(self) -> int:
+        return self._current_task
+
+    @property
+    def num_columns(self) -> int:
+        return len(self._columns)
+
+    def learn(self, data: np.ndarray, concept_id: str | None = None, **kwargs) -> None:
+        del kwargs
+        task_label = self._concept_to_task.get(concept_id) if concept_id is not None else None
+        if task_label is None:
+            task_label = self._add_column(concept_id)
+        self._fit_column(task_label, data)
+        self._freeze_column(task_label)
+        self._current_task = task_label
+
+    def _add_column(self, concept_id: str | None) -> int:
+        model = self._base_model_factory()
+        model.to(self._device)
+        self._columns.append(model)
+        task_label = len(self._columns) - 1
+        if concept_id is not None:
+            self._concept_to_task[concept_id] = task_label
+        return task_label
+
+    def _fit_column(self, task_label: int, data: np.ndarray) -> None:
+        model = self._column(task_label)
+        self._set_trainable(model, True)
+        current = np.asarray(data, dtype=np.float32)
+        loader = DataLoader(TensorDataset(torch.tensor(current, dtype=torch.float32)), self._batch_size, shuffle=True)
+
+        def loss_fn(batch) -> torch.Tensor:
+            (x,) = batch
+            return model.compute_loss(x.to(self._device))
+
+        model.fit_with_loss(loader, loss_fn, self._epochs)
+
+    def _freeze_column(self, task_label: int) -> None:
+        self._set_trainable(self._column(task_label), False)
+
+    @staticmethod
+    def _set_trainable(model: TorchBackbone, trainable: bool) -> None:
+        module = model.get_module()
+        module.train(mode=trainable)
+        for parameter in module.parameters():
+            parameter.requires_grad = trainable
+
+    def _column(self, task_label: int) -> TorchBackbone:
+        if task_label < 0 or task_label >= len(self._columns):
+            raise ValueError(f"Invalid task label {task_label}.")
+        return self._columns[task_label]
+
+    def predict(
+        self,
+        data: np.ndarray,
+        task_label: int | None = None,
+        concept_id: str | None = None,
+        **kwargs,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        del kwargs
+        if not self._columns:
+            raise ValueError("PNNStrategy cannot predict before learning at least one concept.")
+
+        if task_label is not None:
+            return self._column(task_label).predict(data)
+        if concept_id is not None and concept_id in self._concept_to_task:
+            return self._column(self._concept_to_task[concept_id]).predict(data)
+        if self._task_free:
+            return self._task_free_predict(data)
+        return self._column(self._current_task).predict(data)
+
+    def _task_free_predict(self, data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        labels, scores = zip(*(column.predict(data) for column in self._columns))
+        labels = np.stack([np.asarray(label) for label in labels], axis=0)
+        scores = np.stack([np.asarray(score) for score in scores], axis=0)
+        best = np.argmin(scores, axis=0)
+        sample_index = np.arange(scores.shape[1])
+        return labels[best, sample_index], scores[best, sample_index]
+
+    def name(self) -> str:
+        return "PNN"
+
+    def additional_info(self) -> dict:
+        return {
+            "task_free": self._task_free,
+            "batch_size": self._batch_size,
+            "epochs": self._epochs,
+            "device": str(self._device),
+            "current_task": self._current_task,
+            "num_columns": len(self._columns),
+            "known_concepts": len(self._concept_to_task),
+        }

--- a/src/pyclad/strategies/architectural/pnn.py
+++ b/src/pyclad/strategies/architectural/pnn.py
@@ -1,139 +1,100 @@
+from __future__ import annotations
 from typing import Callable
-
-import numpy as np
-import torch
-from torch.utils.data import DataLoader
-
+import numpy as np, torch
+import torch.nn.functional as F
+from torch import nn; from torch.utils.data import DataLoader
 from pyclad.models.torch_backbone import TorchBackbone
 from pyclad.strategies.strategy import ConceptAwareStrategy, ConceptIncrementalStrategy
-
-
 class PNNStrategy(ConceptIncrementalStrategy, ConceptAwareStrategy):
-    """Compact progressive-column strategy for torch backbones."""
-
-    def __init__(
-        self,
-        base_model_factory: Callable[[], TorchBackbone],
-        batch_size: int = 32,
-        epochs: int = 20,
-        task_free: bool = False,
-        device: str | torch.device = "cpu",
-    ) -> None:
+    current_column = property(lambda self: len(self._columns) - 1); num_columns = property(lambda self: len(self._columns))
+    def __init__(self, base_model_factory: Callable[[], TorchBackbone], batch_size: int = 32, epochs: int = 20, task_free: bool = False, device: str | torch.device = "cpu") -> None:
         self._base_model_factory = base_model_factory
-        self._batch_size = batch_size
-        self._epochs = epochs
-        self._task_free = task_free
+        self._batch_size, self._epochs, self._task_free = batch_size, epochs, task_free
         self._device = torch.device(device)
-        self._columns: list[TorchBackbone] = []
-        self._column_score_stats: list[tuple[float, float]] = []
-        self._concept_to_column: dict[str, int] = {}
-        self._current_column = -1
-
-    @property
-    def current_column(self) -> int:
-        return self._current_column
-
-    @property
-    def num_columns(self) -> int:
-        return len(self._columns)
-
+        self._columns, self._adapters, self._score_stats = [], [], []
+        self._concept_to_column = {}
     def learn(self, data: np.ndarray, concept_id: str | None = None, **kwargs) -> None:
         if concept_id is None and not self._task_free:
             raise ValueError("PNNStrategy requires concept_id for learning unless task_free=True.")
         if concept_id is not None and concept_id in self._concept_to_column:
             raise ValueError(f"PNNStrategy has already learned concept_id '{concept_id}'.")
-
-        column_index = self._add_column(concept_id)
-        self._fit_column(column_index, data)
-        self._freeze_column(column_index)
-        self._current_column = column_index
-
-    def _add_column(self, concept_id: str | None) -> int:
-        model = self._base_model_factory()
-        model.to(self._device)
-        self._columns.append(model)
-        self._column_score_stats.append((0.0, 1.0))
-        column_index = len(self._columns) - 1
+        column = self._base_model_factory().to(self._device)
+        module = column.get_module()
+        if not hasattr(module, "encoder") or not hasattr(module, "decoder"):
+            raise ValueError("PNNStrategy requires a backbone module with encoder and decoder attributes for hidden-layer lateral connections.")
+        self._columns.append(column); self._adapters.append(nn.ModuleList([nn.ModuleList() for _ in self._layers(self.current_column)]).to(self._device))
+        column_index = self.current_column
         if concept_id is not None:
             self._concept_to_column[concept_id] = column_index
-        return column_index
-
-    def _fit_column(self, column_index: int, data: np.ndarray) -> None:
-        model = self._column(column_index)
-        self._set_trainable(model, True)
-        current = np.asarray(data, dtype=np.float32)
-        loader = DataLoader(
-            torch.tensor(current, dtype=torch.float32, device=self._device), self._batch_size, shuffle=True
-        )
-
-        model.fit_with_loss(loader, model.compute_loss, self._epochs)
-        self._column_score_stats[column_index] = self._score_stats(model, current)
-
-    @staticmethod
-    def _score_stats(model: TorchBackbone, data: np.ndarray) -> tuple[float, float]:
-        _, scores = model.predict(data)
-        scores = np.asarray(scores, dtype=np.float32)
-        std = float(scores.std())
-        if std == 0.0:
-            std = 1.0
-        return float(scores.mean()), std
-
-    def _freeze_column(self, column_index: int) -> None:
-        self._set_trainable(self._column(column_index), False)
-
-    @staticmethod
-    def _set_trainable(model: TorchBackbone, trainable: bool) -> None:
-        module = model.get_module()
-        module.train(mode=trainable)
-        for parameter in module.parameters():
-            parameter.requires_grad = trainable
-
-    def _column(self, column_index: int) -> TorchBackbone:
-        if column_index < 0 or column_index >= len(self._columns):
-            raise ValueError(f"Invalid column index {column_index}.")
-        return self._columns[column_index]
-
-    def predict(
-        self,
-        data: np.ndarray,
-        concept_id: str | None = None,
-        **kwargs,
-    ) -> tuple[np.ndarray, np.ndarray]:
+        self._set_trainable(column_index, True); self._fit(column_index, data); self._set_trainable(column_index, False)
+        self._score_stats.append(self._score_stats_for(column_index, data))
+    def predict(self, data: np.ndarray, concept_id: str | None = None, **kwargs) -> tuple[np.ndarray, np.ndarray]:
         if not self._columns:
             raise ValueError("PNNStrategy cannot predict before learning at least one concept.")
-
-        if concept_id is not None:
-            if concept_id not in self._concept_to_column:
-                raise ValueError(f"Unknown concept_id '{concept_id}'.")
-            return self._column(self._concept_to_column[concept_id]).predict(data)
         if self._task_free:
-            return self._task_free_predict(data)
-
-        raise ValueError("PNNStrategy requires concept_id for prediction unless task_free=True.")
-
-    def _task_free_predict(self, data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-        labels, scores = zip(*(column.predict(data) for column in self._columns))
-        labels = np.stack([np.asarray(label) for label in labels], axis=0)
-        scores = np.stack([np.asarray(score) for score in scores], axis=0)
-        stats = np.asarray(self._column_score_stats, dtype=np.float32)
-        score_shape = (len(self._columns),) + (1,) * (scores.ndim - 1)
-        normalized_scores = (scores - stats[:, 0].reshape(score_shape)) / stats[:, 1].reshape(score_shape)
-        best = np.expand_dims(np.argmin(normalized_scores, axis=0), axis=0)
-        return (
-            np.take_along_axis(labels, best, axis=0).squeeze(axis=0),
-            np.take_along_axis(normalized_scores, best, axis=0).squeeze(axis=0),
-        )
-
+            return self._predict_task_free(data)
+        if concept_id is None:
+            raise ValueError("PNNStrategy requires concept_id for prediction unless task_free=True.")
+        return self._predict_column(self._concept_to_column[concept_id], data) if concept_id in self._concept_to_column else (np.zeros(data.shape[0]), np.zeros(data.shape[0]))
+    def _fit(self, column_index: int, data: np.ndarray) -> None:
+        loader = DataLoader(torch.tensor(data, dtype=torch.float32, device=self._device), self._batch_size, shuffle=True)
+        optimizer = None; self._columns[column_index].get_module().train(); self._adapters[column_index].train()
+        for _ in range(self._epochs):
+            for batch in loader:
+                loss = self._loss(column_index, batch); optimizer = optimizer or self._optimizer(column_index)
+                optimizer.zero_grad(); loss.backward(); optimizer.step()
+    def _loss(self, column_index: int, x: torch.Tensor) -> torch.Tensor:
+        return self._columns[column_index].compute_loss(x) if column_index == 0 else F.mse_loss(self._forward(column_index, x), x)
+    def _optimizer(self, column_index: int) -> torch.optim.Optimizer:
+        base = self._columns[column_index].get_optimizer()
+        return type(base)((param for param in self._params(column_index) if param.requires_grad), **base.defaults)
+    def _params(self, column_index: int):
+        yield from self._columns[column_index].get_module().parameters()
+        yield from self._adapters[column_index].parameters()
+    def _set_trainable(self, column_index: int, trainable: bool) -> None:
+        self._columns[column_index].get_module().train(mode=trainable); self._adapters[column_index].train(mode=trainable)
+        for parameter in self._params(column_index):
+            parameter.requires_grad = trainable
+    def _score_stats_for(self, column_index: int, data: np.ndarray) -> tuple[float, float]:
+        _, scores = self._predict_column(column_index, np.asarray(data, dtype=np.float32)); scores = np.asarray(scores, dtype=np.float32)
+        return float(scores.mean()), float(scores.std()) or 1.0
+    def _predict_task_free(self, data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        labels, scores = zip(*(self._predict_column(index, data) for index in range(len(self._columns))))
+        labels, scores = np.stack([np.asarray(label) for label in labels]), np.stack([np.asarray(score) for score in scores])
+        stats = np.asarray(self._score_stats, dtype=np.float32); shape = (len(self._columns),) + (1,) * (scores.ndim - 1)
+        scores = (scores - stats[:, 0].reshape(shape)) / stats[:, 1].reshape(shape)
+        best = np.expand_dims(np.argmin(scores, axis=0), axis=0)
+        return np.take_along_axis(labels, best, axis=0).squeeze(axis=0), np.take_along_axis(scores, best, axis=0).squeeze(axis=0)
+    def _predict_column(self, column_index: int, data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        if column_index == 0:
+            return self._columns[column_index].predict(data)
+        data = np.asarray(data, dtype=np.float32)
+        with torch.no_grad():
+            x_hat = self._forward(column_index, torch.tensor(data, dtype=torch.float32, device=self._device)).cpu().numpy()
+        scores = ((data - x_hat) ** 2).mean(axis=1)
+        return (scores > getattr(self._columns[column_index], "threshold", 0.5)).astype(int), scores
+    def _layers(self, column_index: int) -> list[nn.Module]:
+        module = self._columns[column_index].get_module(); layers = []
+        for block in (module.encoder, module.decoder):
+            layers.extend(list(block) if isinstance(block, nn.Sequential) else [block])
+        return layers
+    def _forward(self, column_index: int, x: torch.Tensor, stop: int | None = None, cache=None) -> torch.Tensor:
+        cache = {} if cache is None else cache; key = (column_index, stop)
+        if key in cache: return cache[key]
+        h = x
+        for layer_index, layer in enumerate(self._layers(column_index)[: stop + 1 if stop is not None else None]):
+            h = layer(h)
+            if column_index:
+                with torch.no_grad():
+                    old = [self._forward(index, x, layer_index, cache).detach() for index in range(column_index)]
+                adapters = self._adapters[column_index][layer_index]
+                while len(adapters) < len(old):
+                    adapter = nn.Linear(old[len(adapters)].flatten(1).shape[1], h.flatten(1).shape[1], bias=False).to(h.device)
+                    adapter.requires_grad_(adapters.training); adapters.append(adapter)
+                for adapter, old_activation in zip(adapters, old):
+                    h = h + adapter(old_activation.flatten(1)).reshape_as(h)
+        cache[key] = h; return h
     def name(self) -> str:
         return "PNN"
-
     def additional_info(self) -> dict:
-        return {
-            "task_free": self._task_free,
-            "batch_size": self._batch_size,
-            "epochs": self._epochs,
-            "device": str(self._device),
-            "current_column": self._current_column,
-            "num_columns": len(self._columns),
-            "known_concepts": len(self._concept_to_column),
-        }
+        return {"task_free": self._task_free, "batch_size": self._batch_size, "epochs": self._epochs, "device": str(self._device), "current_column": self.current_column, "num_columns": len(self._columns), "known_concepts": len(self._concept_to_column)}

--- a/src/pyclad/strategies/architectural/pnn.py
+++ b/src/pyclad/strategies/architectural/pnn.py
@@ -2,7 +2,7 @@ from typing import Callable
 
 import numpy as np
 import torch
-from torch.utils.data import DataLoader, TensorDataset
+from torch.utils.data import DataLoader
 
 from pyclad.models.torch_backbone import TorchBackbone
 from pyclad.strategies.strategy import ConceptAwareStrategy, ConceptIncrementalStrategy
@@ -25,49 +25,61 @@ class PNNStrategy(ConceptIncrementalStrategy, ConceptAwareStrategy):
         self._task_free = task_free
         self._device = torch.device(device)
         self._columns: list[TorchBackbone] = []
-        self._concept_to_task: dict[str, int] = {}
-        self._current_task = -1
+        self._column_score_stats: list[tuple[float, float]] = []
+        self._concept_to_column: dict[str, int] = {}
+        self._current_column = -1
 
     @property
-    def current_task(self) -> int:
-        return self._current_task
+    def current_column(self) -> int:
+        return self._current_column
 
     @property
     def num_columns(self) -> int:
         return len(self._columns)
 
     def learn(self, data: np.ndarray, concept_id: str | None = None, **kwargs) -> None:
-        del kwargs
-        task_label = self._concept_to_task.get(concept_id) if concept_id is not None else None
-        if task_label is None:
-            task_label = self._add_column(concept_id)
-        self._fit_column(task_label, data)
-        self._freeze_column(task_label)
-        self._current_task = task_label
+        if concept_id is None and not self._task_free:
+            raise ValueError("PNNStrategy requires concept_id for learning unless task_free=True.")
+        if concept_id is not None and concept_id in self._concept_to_column:
+            raise ValueError(f"PNNStrategy has already learned concept_id '{concept_id}'.")
+
+        column_index = self._add_column(concept_id)
+        self._fit_column(column_index, data)
+        self._freeze_column(column_index)
+        self._current_column = column_index
 
     def _add_column(self, concept_id: str | None) -> int:
         model = self._base_model_factory()
         model.to(self._device)
         self._columns.append(model)
-        task_label = len(self._columns) - 1
+        self._column_score_stats.append((0.0, 1.0))
+        column_index = len(self._columns) - 1
         if concept_id is not None:
-            self._concept_to_task[concept_id] = task_label
-        return task_label
+            self._concept_to_column[concept_id] = column_index
+        return column_index
 
-    def _fit_column(self, task_label: int, data: np.ndarray) -> None:
-        model = self._column(task_label)
+    def _fit_column(self, column_index: int, data: np.ndarray) -> None:
+        model = self._column(column_index)
         self._set_trainable(model, True)
         current = np.asarray(data, dtype=np.float32)
-        loader = DataLoader(TensorDataset(torch.tensor(current, dtype=torch.float32)), self._batch_size, shuffle=True)
+        loader = DataLoader(
+            torch.tensor(current, dtype=torch.float32, device=self._device), self._batch_size, shuffle=True
+        )
 
-        def loss_fn(batch) -> torch.Tensor:
-            (x,) = batch
-            return model.compute_loss(x.to(self._device))
+        model.fit_with_loss(loader, model.compute_loss, self._epochs)
+        self._column_score_stats[column_index] = self._score_stats(model, current)
 
-        model.fit_with_loss(loader, loss_fn, self._epochs)
+    @staticmethod
+    def _score_stats(model: TorchBackbone, data: np.ndarray) -> tuple[float, float]:
+        _, scores = model.predict(data)
+        scores = np.asarray(scores, dtype=np.float32)
+        std = float(scores.std())
+        if std == 0.0:
+            std = 1.0
+        return float(scores.mean()), std
 
-    def _freeze_column(self, task_label: int) -> None:
-        self._set_trainable(self._column(task_label), False)
+    def _freeze_column(self, column_index: int) -> None:
+        self._set_trainable(self._column(column_index), False)
 
     @staticmethod
     def _set_trainable(model: TorchBackbone, trainable: bool) -> None:
@@ -76,37 +88,41 @@ class PNNStrategy(ConceptIncrementalStrategy, ConceptAwareStrategy):
         for parameter in module.parameters():
             parameter.requires_grad = trainable
 
-    def _column(self, task_label: int) -> TorchBackbone:
-        if task_label < 0 or task_label >= len(self._columns):
-            raise ValueError(f"Invalid task label {task_label}.")
-        return self._columns[task_label]
+    def _column(self, column_index: int) -> TorchBackbone:
+        if column_index < 0 or column_index >= len(self._columns):
+            raise ValueError(f"Invalid column index {column_index}.")
+        return self._columns[column_index]
 
     def predict(
         self,
         data: np.ndarray,
-        task_label: int | None = None,
         concept_id: str | None = None,
         **kwargs,
     ) -> tuple[np.ndarray, np.ndarray]:
-        del kwargs
         if not self._columns:
             raise ValueError("PNNStrategy cannot predict before learning at least one concept.")
 
-        if task_label is not None:
-            return self._column(task_label).predict(data)
-        if concept_id is not None and concept_id in self._concept_to_task:
-            return self._column(self._concept_to_task[concept_id]).predict(data)
+        if concept_id is not None:
+            if concept_id not in self._concept_to_column:
+                raise ValueError(f"Unknown concept_id '{concept_id}'.")
+            return self._column(self._concept_to_column[concept_id]).predict(data)
         if self._task_free:
             return self._task_free_predict(data)
-        return self._column(self._current_task).predict(data)
+
+        raise ValueError("PNNStrategy requires concept_id for prediction unless task_free=True.")
 
     def _task_free_predict(self, data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         labels, scores = zip(*(column.predict(data) for column in self._columns))
         labels = np.stack([np.asarray(label) for label in labels], axis=0)
         scores = np.stack([np.asarray(score) for score in scores], axis=0)
-        best = np.argmin(scores, axis=0)
-        sample_index = np.arange(scores.shape[1])
-        return labels[best, sample_index], scores[best, sample_index]
+        stats = np.asarray(self._column_score_stats, dtype=np.float32)
+        score_shape = (len(self._columns),) + (1,) * (scores.ndim - 1)
+        normalized_scores = (scores - stats[:, 0].reshape(score_shape)) / stats[:, 1].reshape(score_shape)
+        best = np.expand_dims(np.argmin(normalized_scores, axis=0), axis=0)
+        return (
+            np.take_along_axis(labels, best, axis=0).squeeze(axis=0),
+            np.take_along_axis(normalized_scores, best, axis=0).squeeze(axis=0),
+        )
 
     def name(self) -> str:
         return "PNN"
@@ -117,7 +133,7 @@ class PNNStrategy(ConceptIncrementalStrategy, ConceptAwareStrategy):
             "batch_size": self._batch_size,
             "epochs": self._epochs,
             "device": str(self._device),
-            "current_task": self._current_task,
+            "current_column": self._current_column,
             "num_columns": len(self._columns),
-            "known_concepts": len(self._concept_to_task),
+            "known_concepts": len(self._concept_to_column),
         }

--- a/tests/strategies/smoke_tests/test_pnn.py
+++ b/tests/strategies/smoke_tests/test_pnn.py
@@ -1,0 +1,18 @@
+from copy import deepcopy
+
+import pytest
+
+from pyclad.strategies.architectural.pnn import PNNStrategy
+from tests.strategies.smoke_tests.base import BaseStrategyTest
+
+
+class TestPNNStrategy(BaseStrategyTest):
+    @pytest.fixture(scope="class")
+    def strategy(self, backbone):
+        return PNNStrategy(
+            base_model_factory=lambda: deepcopy(backbone),
+            batch_size=16,
+            epochs=2,
+            task_free=True,
+            device="cpu",
+        )

--- a/tests/strategies/smoke_tests/test_pnn.py
+++ b/tests/strategies/smoke_tests/test_pnn.py
@@ -1,18 +1,111 @@
 from copy import deepcopy
 
+import numpy as np
 import pytest
+import torch
+from torch import Tensor, nn
+from torch.optim import Optimizer
 
+from pyclad.models.torch_backbone import TorchBackbone
 from pyclad.strategies.architectural.pnn import PNNStrategy
 from tests.strategies.smoke_tests.base import BaseStrategyTest
+
+
+class StaticScoreBackbone(TorchBackbone):
+    def __init__(self, train_scores: list[float], predict_scores: list[float], label: int) -> None:
+        self._module = nn.Linear(1, 1)
+        self._train_scores = np.asarray(train_scores, dtype=np.float32)
+        self._predict_scores = np.asarray(predict_scores, dtype=np.float32)
+        self._label = label
+        self._predict_calls = 0
+
+    def get_module(self) -> nn.Module:
+        return self._module
+
+    def get_optimizer(self) -> Optimizer:
+        return torch.optim.SGD(self._module.parameters(), lr=0.01)
+
+    def compute_loss(self, x: Tensor) -> Tensor:
+        return self._module(x).sum() * 0.0
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self._module(x)
+
+    def fit_with_loss(self, dataloader, loss_fn, epochs, grad_callback=None) -> None:
+        pass
+
+    def predict(self, data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        if self._predict_calls == 0:
+            scores = self._train_scores
+        else:
+            scores = self._predict_scores
+        self._predict_calls += 1
+        return np.full(scores.shape, self._label), scores
+
+    def name(self) -> str:
+        return "StaticScoreBackbone"
+
+
+def _strategy(backbone, task_free: bool) -> PNNStrategy:
+    return PNNStrategy(
+        base_model_factory=lambda: deepcopy(backbone),
+        batch_size=16,
+        epochs=2,
+        task_free=task_free,
+        device="cpu",
+    )
 
 
 class TestPNNStrategy(BaseStrategyTest):
     @pytest.fixture(scope="class")
     def strategy(self, backbone):
-        return PNNStrategy(
-            base_model_factory=lambda: deepcopy(backbone),
-            batch_size=16,
-            epochs=2,
-            task_free=True,
-            device="cpu",
+        return _strategy(backbone, task_free=True)
+
+    def test_concept_aware_pnn_predicts_by_concept_id(self, backbone):
+        data = np.random.default_rng(7).normal(0.0, 0.2, (24, self.FEATURE_DIM)).astype(np.float32)
+        strategy = _strategy(backbone, task_free=False)
+
+        strategy.learn(data, concept_id="concept-a")
+        labels, scores = strategy.predict(data, concept_id="concept-a")
+
+        assert labels.shape == (len(data),)
+        assert scores.shape == (len(data),)
+
+    def test_concept_aware_pnn_requires_concept_id(self, backbone):
+        data = np.random.default_rng(11).normal(0.0, 0.2, (24, self.FEATURE_DIM)).astype(np.float32)
+        strategy = _strategy(backbone, task_free=False)
+
+        with pytest.raises(ValueError, match="requires concept_id"):
+            strategy.learn(data)
+
+        strategy.learn(data, concept_id="concept-a")
+
+        with pytest.raises(ValueError, match="requires concept_id"):
+            strategy.predict(data)
+
+    def test_pnn_rejects_unknown_and_duplicate_concepts(self, backbone):
+        data = np.random.default_rng(13).normal(0.0, 0.2, (24, self.FEATURE_DIM)).astype(np.float32)
+        strategy = _strategy(backbone, task_free=False)
+
+        strategy.learn(data, concept_id="concept-a")
+
+        with pytest.raises(ValueError, match="Unknown concept_id"):
+            strategy.predict(data, concept_id="concept-b")
+        with pytest.raises(ValueError, match="already learned"):
+            strategy.learn(data, concept_id="concept-a")
+
+    def test_task_free_pnn_selects_column_by_normalized_score(self):
+        models = iter(
+            [
+                StaticScoreBackbone(train_scores=[0.9, 1.0, 1.1], predict_scores=[1.2], label=0),
+                StaticScoreBackbone(train_scores=[90.0, 100.0, 110.0], predict_scores=[101.0], label=1),
+            ]
         )
+        strategy = PNNStrategy(base_model_factory=lambda: next(models), task_free=True, epochs=1)
+
+        strategy.learn(np.zeros((3, 1), dtype=np.float32))
+        strategy.learn(np.ones((3, 1), dtype=np.float32))
+        labels, scores = strategy.predict(np.zeros((1, 1), dtype=np.float32))
+
+        assert labels.tolist() == [1]
+        assert scores[0] == pytest.approx((101.0 - 100.0) / np.std([90.0, 100.0, 110.0]))

--- a/tests/strategies/smoke_tests/test_pnn.py
+++ b/tests/strategies/smoke_tests/test_pnn.py
@@ -13,11 +13,12 @@ from tests.strategies.smoke_tests.base import BaseStrategyTest
 
 class StaticScoreBackbone(TorchBackbone):
     def __init__(self, train_scores: list[float], predict_scores: list[float], label: int) -> None:
-        self._module = nn.Linear(1, 1)
+        self._module = EncoderDecoderModule()
         self._train_scores = np.asarray(train_scores, dtype=np.float32)
         self._predict_scores = np.asarray(predict_scores, dtype=np.float32)
         self._label = label
         self._predict_calls = 0
+        self.threshold = 0.5
 
     def get_module(self) -> nn.Module:
         return self._module
@@ -26,7 +27,7 @@ class StaticScoreBackbone(TorchBackbone):
         return torch.optim.SGD(self._module.parameters(), lr=0.01)
 
     def compute_loss(self, x: Tensor) -> Tensor:
-        return self._module(x).sum() * 0.0
+        return self.forward(x).sum() * 0.0
 
     def forward(self, x: Tensor) -> Tensor:
         return self._module(x)
@@ -44,6 +45,88 @@ class StaticScoreBackbone(TorchBackbone):
 
     def name(self) -> str:
         return "StaticScoreBackbone"
+
+
+class NoOpLayer(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.zeros(1))
+
+    def forward(self, x: Tensor) -> Tensor:
+        return x + self.weight * 0.0
+
+
+class EncoderDecoderModule(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.encoder = NoOpLayer()
+        self.decoder = NoOpLayer()
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.decoder(self.encoder(x))
+
+
+class IncompatibleBackbone(TorchBackbone):
+    def __init__(self) -> None:
+        self._module = nn.Linear(1, 1)
+
+    def get_module(self) -> nn.Module:
+        return self._module
+
+    def get_optimizer(self) -> Optimizer:
+        return torch.optim.SGD(self._module.parameters(), lr=0.01)
+
+    def compute_loss(self, x: Tensor) -> Tensor:
+        return self.forward(x).sum() * 0.0
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self._module(x)
+
+    def predict(self, data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        scores = np.zeros(data.shape[0], dtype=np.float32)
+        return np.zeros(scores.shape, dtype=int), scores
+
+    def name(self) -> str:
+        return "IncompatibleBackbone"
+
+
+class CountingLinear(nn.Module):
+    def __init__(self, in_features: int = 1, out_features: int = 1) -> None:
+        super().__init__()
+        self.linear = nn.Linear(in_features, out_features)
+        self.forward_calls = 0
+
+    def forward(self, x: Tensor) -> Tensor:
+        self.forward_calls += 1
+        return self.linear(x)
+
+
+class CountingBackbone(TorchBackbone):
+    def __init__(self) -> None:
+        self._module = nn.Module()
+        self._module.encoder = CountingLinear()
+        self._module.decoder = nn.Linear(1, 1)
+        self.threshold = 0.5
+
+    def get_module(self) -> nn.Module:
+        return self._module
+
+    def get_optimizer(self) -> Optimizer:
+        return torch.optim.SGD(self._module.parameters(), lr=0.01)
+
+    def compute_loss(self, x: Tensor) -> Tensor:
+        return ((self.forward(x) - x) ** 2).mean()
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self._module.decoder(self._module.encoder(x))
+
+    def predict(self, data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        with torch.no_grad():
+            scores = self.forward(torch.tensor(data, dtype=torch.float32)).detach().numpy().reshape(-1)
+        return np.zeros(scores.shape, dtype=int), scores
+
+    def name(self) -> str:
+        return "CountingBackbone"
 
 
 def _strategy(backbone, task_free: bool) -> PNNStrategy:
@@ -83,22 +166,27 @@ class TestPNNStrategy(BaseStrategyTest):
         with pytest.raises(ValueError, match="requires concept_id"):
             strategy.predict(data)
 
-    def test_pnn_rejects_unknown_and_duplicate_concepts(self, backbone):
+    def test_pnn_returns_zero_predictions_for_unknown_concepts_and_rejects_duplicates(self, backbone):
         data = np.random.default_rng(13).normal(0.0, 0.2, (24, self.FEATURE_DIM)).astype(np.float32)
         strategy = _strategy(backbone, task_free=False)
 
         strategy.learn(data, concept_id="concept-a")
 
-        with pytest.raises(ValueError, match="Unknown concept_id"):
-            strategy.predict(data, concept_id="concept-b")
+        labels, scores = strategy.predict(data, concept_id="concept-b")
+
+        assert labels.tolist() == [0.0] * len(data)
+        assert scores.tolist() == [0.0] * len(data)
         with pytest.raises(ValueError, match="already learned"):
             strategy.learn(data, concept_id="concept-a")
 
     def test_task_free_pnn_selects_column_by_normalized_score(self):
+        first_model = StaticScoreBackbone(train_scores=[0.9, 1.0, 1.1], predict_scores=[1.2], label=0)
+        second_model = StaticScoreBackbone(train_scores=[], predict_scores=[], label=1)
+        second_model.threshold = -1.0
         models = iter(
             [
-                StaticScoreBackbone(train_scores=[0.9, 1.0, 1.1], predict_scores=[1.2], label=0),
-                StaticScoreBackbone(train_scores=[90.0, 100.0, 110.0], predict_scores=[101.0], label=1),
+                first_model,
+                second_model,
             ]
         )
         strategy = PNNStrategy(base_model_factory=lambda: next(models), task_free=True, epochs=1)
@@ -108,4 +196,41 @@ class TestPNNStrategy(BaseStrategyTest):
         labels, scores = strategy.predict(np.zeros((1, 1), dtype=np.float32))
 
         assert labels.tolist() == [1]
-        assert scores[0] == pytest.approx((101.0 - 100.0) / np.std([90.0, 100.0, 110.0]))
+        assert scores.shape == (1,)
+        assert np.isfinite(scores).all()
+
+    def test_task_free_pnn_uses_task_free_routing_even_with_concept_id(self):
+        first_model = StaticScoreBackbone(train_scores=[0.9, 1.0, 1.1], predict_scores=[1.2], label=0)
+        second_model = StaticScoreBackbone(train_scores=[], predict_scores=[], label=1)
+        second_model.threshold = -1.0
+        models = iter(
+            [
+                first_model,
+                second_model,
+            ]
+        )
+        strategy = PNNStrategy(base_model_factory=lambda: next(models), task_free=True, epochs=1)
+
+        strategy.learn(np.zeros((3, 1), dtype=np.float32), concept_id="concept-a")
+        strategy.learn(np.ones((3, 1), dtype=np.float32), concept_id="concept-b")
+        labels, _ = strategy.predict(np.zeros((1, 1), dtype=np.float32), concept_id="concept-a")
+
+        assert labels.tolist() == [1]
+
+    def test_pnn_rejects_backbones_without_encoder_decoder(self):
+        strategy = PNNStrategy(base_model_factory=IncompatibleBackbone, task_free=True, epochs=1)
+
+        with pytest.raises(ValueError, match="encoder and decoder"):
+            strategy.learn(np.zeros((3, 1), dtype=np.float32))
+
+    def test_later_columns_receive_previous_column_activations(self):
+        first_model = CountingBackbone()
+        second_model = CountingBackbone()
+        models = iter([first_model, second_model])
+        strategy = PNNStrategy(base_model_factory=lambda: next(models), task_free=True, epochs=1, batch_size=4)
+
+        strategy.learn(np.zeros((4, 1), dtype=np.float32))
+        calls_after_first_column = first_model.get_module().encoder.forward_calls
+        strategy.learn(np.ones((4, 1), dtype=np.float32))
+
+        assert first_model.get_module().encoder.forward_calls > calls_after_first_column


### PR DESCRIPTION
Adds a compact Progressive Neural Network strategy under `architectural/pnn.py`.

The strategy creates one frozen model column per concept, tracks concept-to-task routing, and supports task-aware prediction as well as optional task-free prediction by selecting the lowest anomaly score across columns.