### PR TITLE
Add FastFlow model with example and update vision model structure

### DIFF
--- a/examples/models/vision/fastflow_torch_example.py
+++ b/examples/models/vision/fastflow_torch_example.py
@@ -1,0 +1,85 @@
+import logging
+import pathlib
+
+from pyclad.callbacks.evaluation.concept_metric_evaluation import ConceptMetricCallback
+from pyclad.callbacks.evaluation.time_evaluation import TimeEvaluationCallback
+from pyclad.scenarios.concept_incremental import ConceptIncrementalScenario
+from pyclad.vision.callbacks.vision_pixel_concept_metric_callback import VisionPixelConceptMetricCallback
+from pyclad.vision.data.readers.vision_reader import read_vision_dataset
+from pyclad.metrics.base.average_precision import AveragePrecision
+from pyclad.metrics.base.f1_score import F1Score
+from pyclad.metrics.base.roc_auc import RocAuc
+from pyclad.metrics.continual.average_continual import ContinualAverage
+from pyclad.metrics.continual.backward_transfer import BackwardTransfer
+from pyclad.metrics.continual.forward_transfer import ForwardTransfer
+from pyclad.vision.metrics.pixel_aupro import PixelAUPRO
+from pyclad.vision.metrics.pixel_average_precision import PixelAveragePrecision
+from pyclad.vision.metrics.pixel_dice_score import PixelDiceScore
+from pyclad.vision.metrics.pixel_f1_score import PixelF1Score
+from pyclad.vision.metrics.pixel_iou import PixelIoU
+from pyclad.vision.metrics.pixel_roc_auc import PixelRocAuc
+from pyclad.vision.models.fastflow.config import FastFlowConfig
+from pyclad.vision.models.fastflow.fastflow import FastFlow
+from pyclad.output.json_writer import JsonOutputWriter
+from pyclad.strategies.replay.buffers.adaptive_balanced import AdaptiveBalancedReplayBuffer
+from pyclad.strategies.replay.replay import ReplayEnhancedStrategy
+from pyclad.strategies.replay.selection.random import RandomSelection
+
+logging.basicConfig(level=logging.INFO)
+
+if __name__ == "__main__":
+    """
+    This example showcases how to use the FastFlow model for continual vision anomaly detection.
+    """
+    dataset = read_vision_dataset(
+        root=pathlib.Path("../../resources/vision/BTech_Dataset_transformed"),
+        benchmark="btech",
+        resize_to=(256, 256),
+        data_mode="numpy",
+        color_mode="rgb",
+        # max_train_samples_per_category=150,
+        # max_test_samples_per_category=150,
+    )
+
+    model_config = FastFlowConfig(
+        input_size=(256, 256),
+        backbone_name="resnet18",
+        pretrained_backbone=True,
+        freeze_backbone=True,
+        flow_steps=8,
+        conv3x3_only=False,
+        hidden_ratio=1.0,
+        batch_size=16,
+        epochs=2,
+        learning_rate=1e-3,
+        score_mode="max",
+        threshold_quantile=0.99,
+        show_training_progress=True,
+    )
+    model = FastFlow(model_config)
+
+    replay_buffer = AdaptiveBalancedReplayBuffer(selection_method=RandomSelection(), max_size=100)
+    strategy = ReplayEnhancedStrategy(model, replay_buffer)
+
+    summarized_metrics = [ContinualAverage(), BackwardTransfer(), ForwardTransfer()]
+
+    callbacks = [
+        # Image-level
+        ConceptMetricCallback(base_metric=RocAuc(), summarized_metrics=summarized_metrics),
+        ConceptMetricCallback(base_metric=F1Score(), summarized_metrics=summarized_metrics),
+        ConceptMetricCallback(base_metric=AveragePrecision(), summarized_metrics=summarized_metrics),
+        # Pixel-level
+        VisionPixelConceptMetricCallback(base_metric=PixelRocAuc(), summarized_metrics=summarized_metrics),
+        VisionPixelConceptMetricCallback(base_metric=PixelAveragePrecision(), summarized_metrics=summarized_metrics),
+        VisionPixelConceptMetricCallback(base_metric=PixelAUPRO(), summarized_metrics=summarized_metrics),
+        VisionPixelConceptMetricCallback(base_metric=PixelF1Score(), summarized_metrics=summarized_metrics),
+        VisionPixelConceptMetricCallback(base_metric=PixelDiceScore(), summarized_metrics=summarized_metrics),
+        VisionPixelConceptMetricCallback(base_metric=PixelIoU(), summarized_metrics=summarized_metrics),
+        TimeEvaluationCallback(),
+    ]
+
+    scenario = ConceptIncrementalScenario(dataset=dataset, strategy=strategy, callbacks=callbacks)
+    scenario.run()
+
+    output_writer = JsonOutputWriter(pathlib.Path("output.json"))
+    output_writer.write([model, dataset, strategy, *callbacks])

--- a/src/pyclad/vision/metrics/pixel_dice_score.py
+++ b/src/pyclad/vision/metrics/pixel_dice_score.py
@@ -1,13 +1,10 @@
 from pyclad.vision.metrics.pixel_metric import PixelMetric
-from pyclad.vision.metrics.pixel_threshold_utils import (
-    binary_confusion,
-    threshold_pixel_scores,
-)
+from pyclad.vision.metrics.pixel_threshold_utils import binary_confusion
 
 
 class PixelDiceScore(PixelMetric):
     def compute(self, anomaly_scores, y_pred, y_true) -> float:
-        y_pred_binary = threshold_pixel_scores(anomaly_scores, self._threshold)
+        y_pred_binary = self._binarize(anomaly_scores)
         tp, fp, fn = binary_confusion(y_true, y_pred_binary)
 
         denominator = 2 * tp + fp + fn

--- a/src/pyclad/vision/metrics/pixel_f1_score.py
+++ b/src/pyclad/vision/metrics/pixel_f1_score.py
@@ -1,19 +1,18 @@
+from typing import Optional
+
 from sklearn.metrics import f1_score
 
 from pyclad.vision.metrics.pixel_metric import PixelMetric
-from pyclad.vision.metrics.pixel_threshold_utils import (
-    flatten_binary_masks,
-    threshold_pixel_scores,
-)
+from pyclad.vision.metrics.pixel_threshold_utils import flatten_binary_masks
 
 
 class PixelF1Score(PixelMetric):
-    def __init__(self, threshold: float = 0.5, zero_division: float = 0.0):
-        super().__init__(threshold)
+    def __init__(self, threshold: Optional[float] = None, *, quantile: float = 0.99, zero_division: float = 0.0):
+        super().__init__(threshold, quantile=quantile)
         self.zero_division = float(zero_division)
 
     def compute(self, anomaly_scores, y_pred, y_true) -> float:
-        y_pred_flat = flatten_binary_masks(threshold_pixel_scores(anomaly_scores, self._threshold))
+        y_pred_flat = flatten_binary_masks(self._binarize(anomaly_scores))
         y_true_flat = flatten_binary_masks(y_true)
         return float(f1_score(y_true=y_true_flat, y_pred=y_pred_flat, zero_division=self.zero_division))
 

--- a/src/pyclad/vision/metrics/pixel_iou.py
+++ b/src/pyclad/vision/metrics/pixel_iou.py
@@ -1,13 +1,10 @@
 from pyclad.vision.metrics.pixel_metric import PixelMetric
-from pyclad.vision.metrics.pixel_threshold_utils import (
-    binary_confusion,
-    threshold_pixel_scores,
-)
+from pyclad.vision.metrics.pixel_threshold_utils import binary_confusion
 
 
 class PixelIoU(PixelMetric):
     def compute(self, anomaly_scores, y_pred, y_true) -> float:
-        y_pred_binary = threshold_pixel_scores(anomaly_scores, self._threshold)
+        y_pred_binary = self._binarize(anomaly_scores)
         tp, fp, fn = binary_confusion(y_true, y_pred_binary)
 
         denominator = tp + fp + fn

--- a/src/pyclad/vision/metrics/pixel_metric.py
+++ b/src/pyclad/vision/metrics/pixel_metric.py
@@ -1,10 +1,43 @@
 import abc
+from typing import Optional
+
+import numpy as np
 
 from pyclad.metrics.base.base_metric import BaseMetric
+from pyclad.vision.metrics.pixel_threshold_utils import (
+    resolve_pixel_threshold,
+    threshold_pixel_scores,
+)
 
 
 class PixelMetric(BaseMetric, abc.ABC):
-    """Base class for pixel-level metrics that require a binarization threshold."""
+    """Base class for pixel-level metrics that binarize per-pixel anomaly scores.
 
-    def __init__(self, threshold: float = 0.5):
-        self._threshold = float(threshold)
+    The binarization threshold is either fixed or derived from the score
+    distribution. Anomaly-map scales differ wildly across models — e.g. PaSTe
+    distance maps are unbounded and positive, while FastFlow scores live in
+    ``[-1, 0)`` — so a single fixed threshold cannot serve all of them: a value
+    tuned for one model silently collapses the metric to 0 for another. By
+    default the threshold is therefore data-driven (a high quantile of the
+    evaluated score map), which is scale-invariant. Passing an explicit
+    ``threshold`` opts back into fixed binarization.
+
+    Caveat: the quantile default trades an arbitrary *value* for an arbitrary
+    *anomalous-pixel fraction* (``1 - quantile``, ~1% at the default). On
+    benchmarks with large defects this biases F1/Dice/IoU downward. For a
+    threshold-free assessment of localization quality prefer rank-based metrics
+    (Pixel-ROC-AUC, Pixel-AP, Pixel-AUPRO), which do not need binarization.
+    """
+
+    def __init__(self, threshold: Optional[float] = None, *, quantile: float = 0.99):
+        self._fixed_threshold: Optional[float] = None if threshold is None else float(threshold)
+        self._quantile = float(quantile)
+
+    def _binarize(self, anomaly_scores) -> np.ndarray:
+        threshold = resolve_pixel_threshold(
+            anomaly_scores,
+            mode="fixed" if self._fixed_threshold is not None else "train-quantile",
+            fixed_threshold=self._fixed_threshold if self._fixed_threshold is not None else 0.5,
+            quantile=self._quantile,
+        )
+        return threshold_pixel_scores(anomaly_scores, threshold)

--- a/src/pyclad/vision/models/fastflow/architecture.py
+++ b/src/pyclad/vision/models/fastflow/architecture.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from pyclad.vision.models.fastflow.backbones import (
+    TorchvisionFeatureExtractor,
+    default_fastflow_return_nodes,
+)
+from pyclad.vision.models.fastflow.flow import FastFlowSequence
+
+
+class AnomalyMapGenerator(nn.Module):
+    def __init__(self, input_size: tuple[int, int]):
+        super().__init__()
+        self.input_size = tuple(input_size)
+
+    def forward(self, hidden_variables: Sequence[torch.Tensor]) -> torch.Tensor:
+        flow_maps: list[torch.Tensor] = []
+        for hidden_variable in hidden_variables:
+            log_prob = -0.5 * torch.mean(hidden_variable**2, dim=1, keepdim=True)
+            probability = torch.exp(log_prob)
+            flow_map = F.interpolate(
+                -probability,
+                size=self.input_size,
+                mode="bilinear",
+                align_corners=False,
+            )
+            flow_maps.append(flow_map)
+
+        return torch.mean(torch.stack(flow_maps, dim=-1), dim=-1)
+
+
+class FastFlowArchitecture(nn.Module):
+    def __init__(
+        self,
+        input_size: tuple[int, int],
+        backbone_name: str,
+        backbone_return_nodes: Optional[tuple[str, ...]],
+        pretrained_backbone: bool,
+        freeze_backbone: bool,
+        normalize_features: bool,
+        flow_steps: int,
+        conv3x3_only: bool,
+        hidden_ratio: float,
+        affine_clamping: float,
+    ):
+        super().__init__()
+
+        if backbone_return_nodes is None:
+            backbone_return_nodes = default_fastflow_return_nodes(backbone_name)
+
+        self.input_size = tuple(input_size)
+        self.freeze_backbone = freeze_backbone
+        self.return_nodes = tuple(backbone_return_nodes)
+        self.feature_extractor = TorchvisionFeatureExtractor(
+            backbone_name=backbone_name,
+            return_nodes=self.return_nodes,
+            pretrained=pretrained_backbone,
+            freeze=freeze_backbone,
+        )
+
+        self.feature_shapes = tuple(self._infer_feature_shapes(self.input_size))
+
+        self.norms = nn.ModuleList(
+            [
+                nn.LayerNorm(list(shape), elementwise_affine=True) if normalize_features else nn.Identity()
+                for shape in self.feature_shapes
+            ]
+        )
+        self.fast_flow_blocks = nn.ModuleList(
+            [
+                FastFlowSequence(
+                    channels=shape[0],
+                    flow_steps=flow_steps,
+                    conv3x3_only=conv3x3_only,
+                    hidden_ratio=hidden_ratio,
+                    affine_clamping=affine_clamping,
+                )
+                for shape in self.feature_shapes
+            ]
+        )
+        self.anomaly_map_generator = AnomalyMapGenerator(input_size=self.input_size)
+
+    def _infer_feature_shapes(self, input_size: tuple[int, int]) -> list[tuple[int, int, int]]:
+        was_training = self.feature_extractor.training
+        self.feature_extractor.eval()
+        with torch.no_grad():
+            device = next(self.feature_extractor.parameters()).device
+            dummy = torch.zeros((1, 3, input_size[0], input_size[1]), dtype=torch.float32, device=device)
+            features = self.feature_extractor(dummy)
+        self.feature_extractor.train(was_training)
+
+        return [tuple(int(dimension) for dimension in feature.shape[1:]) for feature in features]
+
+    def train(self, mode: bool = True):
+        super().train(mode)
+        if self.freeze_backbone:
+            self.feature_extractor.eval()
+        return self
+
+    def _extract_features(self, batch: torch.Tensor) -> list[torch.Tensor]:
+        if self.freeze_backbone:
+            with torch.no_grad():
+                features = self.feature_extractor(batch)
+        else:
+            features = self.feature_extractor(batch)
+        return [norm(feature) for norm, feature in zip(self.norms, features)]
+
+    def forward(self, batch: torch.Tensor) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+        features = self._extract_features(batch)
+
+        hidden_variables: list[torch.Tensor] = []
+        log_jacobians: list[torch.Tensor] = []
+        for fast_flow_block, feature in zip(self.fast_flow_blocks, features):
+            hidden_variable, log_jacobian = fast_flow_block(feature)
+            hidden_variables.append(hidden_variable)
+            log_jacobians.append(log_jacobian)
+        return hidden_variables, log_jacobians
+
+    def inference(self, batch: torch.Tensor) -> torch.Tensor:
+        hidden_variables, _ = self.forward(batch)
+        return self.anomaly_map_generator(hidden_variables)[:, 0]
+
+    @staticmethod
+    def fastflow_loss(hidden_variables: Sequence[torch.Tensor], log_jacobians: Sequence[torch.Tensor]) -> torch.Tensor:
+        loss = hidden_variables[0].new_tensor(0.0)
+        for hidden_variable, log_jacobian in zip(hidden_variables, log_jacobians):
+            loss = loss + torch.mean(0.5 * torch.sum(hidden_variable**2, dim=(1, 2, 3)) - log_jacobian)
+        return loss

--- a/src/pyclad/vision/models/fastflow/backbones.py
+++ b/src/pyclad/vision/models/fastflow/backbones.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import Sequence
+
+import torch
+from torch import nn
+from torchvision.models.feature_extraction import create_feature_extractor
+
+from pyclad.vision.models.utilities.backbones import (
+    EFFICIENTNET_BACKBONES,
+    MOBILENET_BACKBONES,
+    RESNET_BACKBONES,
+    create_torchvision_model,
+)
+
+_RESNET_RETURN_NODES = ["relu", "layer1", "layer2", "layer3", "layer4"]
+_EFFICIENTNET_RETURN_NODES = ["features.1", "features.2", "features.3", "features.5", "features.7"]
+
+_DEFAULT_RETURN_NODES: dict[str, list[str]] = {
+    **{name: _RESNET_RETURN_NODES for name in RESNET_BACKBONES},
+    **{name: ["features.1", "features.3", "features.6", "features.13", "features.18"] for name in MOBILENET_BACKBONES},
+    **{name: _EFFICIENTNET_RETURN_NODES for name in EFFICIENTNET_BACKBONES},
+}
+
+
+def supported_backbone_names() -> tuple[str, ...]:
+    return tuple(_DEFAULT_RETURN_NODES.keys())
+
+
+def default_backbone_return_nodes(backbone_name: str) -> list[str]:
+    if backbone_name not in _DEFAULT_RETURN_NODES:
+        raise ValueError(f"No default return nodes for '{backbone_name}'. Set backbone_return_nodes explicitly.")
+    return _DEFAULT_RETURN_NODES[backbone_name]
+
+
+def default_fastflow_return_nodes(backbone_name: str) -> tuple[str, ...]:
+    try:
+        default_nodes = tuple(default_backbone_return_nodes(backbone_name))
+    except ValueError as exc:
+        raise ValueError(
+            f"Unsupported FastFlow backbone '{backbone_name}'. Supported default presets: "
+            f"{', '.join(supported_backbone_names())}. You can still use a custom torchvision backbone by "
+            "setting backbone_return_nodes explicitly."
+        ) from exc
+
+    # FastFlow is typically applied to a small set of intermediate 2D feature maps.
+    if len(default_nodes) >= 4:
+        return default_nodes[1:4]
+    if len(default_nodes) >= 3:
+        return default_nodes[:3]
+    if len(default_nodes) >= 1:
+        return default_nodes
+    raise ValueError(f"Backbone '{backbone_name}' did not expose any default feature nodes")
+
+
+class TorchvisionFeatureExtractor(nn.Module):
+    def __init__(
+        self,
+        backbone_name: str,
+        return_nodes: Sequence[str],
+        pretrained: bool,
+        freeze: bool,
+    ):
+        super().__init__()
+
+        self._nodes = tuple(return_nodes)
+        if len(self._nodes) == 0:
+            raise ValueError("return_nodes must contain at least one feature node")
+
+        backbone = create_torchvision_model(backbone_name, pretrained=pretrained)
+        self._extractor = create_feature_extractor(
+            model=backbone,
+            return_nodes=OrderedDict((node, node) for node in self._nodes),
+        )
+
+        if freeze:
+            for parameter in self._extractor.parameters():
+                parameter.requires_grad = False
+
+    @property
+    def return_nodes(self) -> tuple[str, ...]:
+        return self._nodes
+
+    def forward(self, x: torch.Tensor) -> list[torch.Tensor]:
+        features = self._extractor(x)
+        return [features[name] for name in self._nodes]

--- a/src/pyclad/vision/models/fastflow/config.py
+++ b/src/pyclad/vision/models/fastflow/config.py
@@ -2,11 +2,11 @@ from typing import Optional
 
 from pydantic import Field
 
-from pyclad.vision.models.utilities.config import LightningVisionConfig
+from pyclad.vision.models.utilities.config import ImageSize, LightningVisionConfig
 
 
 class FastFlowConfig(LightningVisionConfig):
-    input_size: tuple[int, int] = (256, 256)
+    input_size: ImageSize = (256, 256)
     batch_size: int = Field(default=8, gt=0)
     epochs: int = Field(default=200, ge=0)
 

--- a/src/pyclad/vision/models/fastflow/config.py
+++ b/src/pyclad/vision/models/fastflow/config.py
@@ -1,0 +1,25 @@
+from typing import Optional
+
+from pydantic import Field
+
+from pyclad.vision.models.utilities.config import LightningVisionConfig
+
+
+class FastFlowConfig(LightningVisionConfig):
+    input_size: tuple[int, int] = (256, 256)
+    batch_size: int = Field(default=8, gt=0)
+    epochs: int = Field(default=200, ge=0)
+
+    backbone_name: str = "wide_resnet50_2"
+    backbone_return_nodes: Optional[tuple[str, ...]] = None
+    pretrained_backbone: bool = True
+    freeze_backbone: bool = True
+    normalize_features: bool = True
+
+    adam_beta1: float = Field(default=0.9, ge=0.0, lt=1.0)
+    adam_beta2: float = Field(default=0.999, ge=0.0, lt=1.0)
+
+    flow_steps: int = Field(default=8, gt=0)
+    conv3x3_only: bool = False
+    hidden_ratio: float = Field(default=1.0, gt=0.0)
+    affine_clamping: float = Field(default=2.0, gt=0.0)

--- a/src/pyclad/vision/models/fastflow/fastflow.py
+++ b/src/pyclad/vision/models/fastflow/fastflow.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import pytorch_lightning as pl
+import torch
+from pytorch_lightning.utilities.types import OptimizerLRScheduler
+
+from pyclad.vision.models.fastflow.architecture import FastFlowArchitecture
+from pyclad.vision.models.fastflow.config import FastFlowConfig
+from pyclad.vision.models.utilities.base_model import LightningVisionModel
+
+
+class FastFlow(LightningVisionModel):
+    def __init__(self, config: Optional[FastFlowConfig] = None):
+        super().__init__(config or FastFlowConfig())
+
+    def _build_module(self) -> pl.LightningModule:
+        network = FastFlowArchitecture(
+            input_size=self.config.input_size,
+            backbone_name=self.config.backbone_name,
+            backbone_return_nodes=self.config.backbone_return_nodes,
+            pretrained_backbone=self.config.pretrained_backbone,
+            freeze_backbone=self.config.freeze_backbone,
+            normalize_features=self.config.normalize_features,
+            flow_steps=self.config.flow_steps,
+            conv3x3_only=self.config.conv3x3_only,
+            hidden_ratio=self.config.hidden_ratio,
+            affine_clamping=self.config.affine_clamping,
+        )
+        return FastFlowModule(
+            network=network,
+            learning_rate=self.config.learning_rate,
+            adam_betas=(self.config.adam_beta1, self.config.adam_beta2),
+            weight_decay=self.config.weight_decay,
+        )
+
+    def _inference_maps(self, batch: torch.Tensor) -> torch.Tensor:
+        self.module.eval()
+        with torch.no_grad():
+            return self.module.network.inference(batch)
+
+    def _extra_info(self) -> dict:
+        return {"backbone_return_nodes": self.module.network.return_nodes}
+
+    def name(self) -> str:
+        return "FastFlow"
+
+
+class FastFlowModule(pl.LightningModule):
+    def __init__(
+        self,
+        network: FastFlowArchitecture,
+        learning_rate: float,
+        adam_betas: tuple[float, float],
+        weight_decay: float,
+    ):
+        super().__init__()
+        self.network = network
+        self.learning_rate = learning_rate
+        self.adam_betas = adam_betas
+        self.weight_decay = weight_decay
+
+        self.save_hyperparameters(ignore=["network"])
+
+    def forward(self, x: torch.Tensor):
+        return self.network(x)
+
+    def training_step(self, batch, batch_idx):
+        x = batch[0]
+        hidden_variables, log_jacobians = self.network(x)
+        loss = FastFlowArchitecture.fastflow_loss(hidden_variables, log_jacobians)
+        self.log("train_loss", loss, on_step=False, on_epoch=True, prog_bar=True)
+        return loss
+
+    def configure_optimizers(self) -> OptimizerLRScheduler:
+        parameters = [parameter for parameter in self.network.parameters() if parameter.requires_grad]
+        return torch.optim.Adam(
+            parameters,
+            lr=self.learning_rate,
+            betas=self.adam_betas,
+            weight_decay=self.weight_decay,
+        )

--- a/src/pyclad/vision/models/fastflow/fastflow.py
+++ b/src/pyclad/vision/models/fastflow/fastflow.py
@@ -36,9 +36,7 @@ class FastFlow(LightningVisionModel):
         )
 
     def _inference_maps(self, batch: torch.Tensor) -> torch.Tensor:
-        self.module.eval()
-        with torch.no_grad():
-            return self.module.network.inference(batch)
+        return self.module.network.inference(batch)
 
     def _extra_info(self) -> dict:
         return {"backbone_return_nodes": self.module.network.return_nodes}

--- a/src/pyclad/vision/models/fastflow/flow.py
+++ b/src/pyclad/vision/models/fastflow/flow.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import math
+
+import torch
+from torch import nn
+
+
+def _global_affine_init_value(global_affine_init: float = 1.0) -> float:
+    return 2.0 * math.log(math.exp(5.0 * global_affine_init) - 1.0)
+
+
+class ConvSubnet(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int, hidden_ratio: float, kernel_size: int):
+        super().__init__()
+        hidden_channels = max(1, int(in_channels * hidden_ratio))
+        padding = kernel_size // 2
+        self.layers = nn.Sequential(
+            nn.Conv2d(in_channels, hidden_channels, kernel_size=kernel_size, padding=padding),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(hidden_channels, out_channels, kernel_size=kernel_size, padding=padding),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.layers(x)
+
+
+class FastFlowStep(nn.Module):
+    def __init__(
+        self,
+        channels: int,
+        hidden_ratio: float,
+        kernel_size: int,
+        affine_clamping: float,
+    ):
+        super().__init__()
+
+        self.split_len1 = channels - channels // 2
+        self.split_len2 = channels // 2
+        self.affine_clamping = affine_clamping
+        self.softplus = nn.Softplus(beta=0.5)
+
+        self.register_buffer("permutation", torch.randperm(channels))
+
+        global_scale_value = _global_affine_init_value()
+        self.global_scale = nn.Parameter(torch.full((1, channels, 1, 1), float(global_scale_value)))
+        self.global_offset = nn.Parameter(torch.zeros((1, channels, 1, 1)))
+        self.subnet = ConvSubnet(
+            in_channels=self.split_len1,
+            out_channels=2 * self.split_len2,
+            hidden_ratio=hidden_ratio,
+            kernel_size=kernel_size,
+        )
+
+    def _global_scale_activation(self) -> torch.Tensor:
+        return 0.1 * self.softplus(self.global_scale)
+
+    def _affine(self, x: torch.Tensor, affine_params: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        affine_params = affine_params * 0.1
+        log_scale = self.affine_clamping * torch.tanh(affine_params[:, : self.split_len2])
+        shift = affine_params[:, self.split_len2 :]
+        transformed = x * torch.exp(log_scale) + shift
+        log_det = torch.sum(log_scale, dim=(1, 2, 3))
+        return transformed, log_det
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        x1, x2 = torch.split(x, [self.split_len1, self.split_len2], dim=1)
+        affine_params = self.subnet(x1)
+        x2, log_det = self._affine(x2, affine_params)
+        output = torch.cat((x1, x2), dim=1)
+
+        global_scale = self._global_scale_activation()
+        output = output * global_scale + self.global_offset
+        output = output[:, self.permutation, :, :]
+
+        pixels_per_channel = output.shape[-2] * output.shape[-1]
+        global_log_det = pixels_per_channel * torch.sum(torch.log(global_scale))
+        log_det = log_det + global_log_det
+        return output, log_det
+
+
+class FastFlowSequence(nn.Module):
+    def __init__(
+        self,
+        channels: int,
+        flow_steps: int,
+        conv3x3_only: bool,
+        hidden_ratio: float,
+        affine_clamping: float,
+    ):
+        super().__init__()
+        steps: list[nn.Module] = []
+        for index in range(flow_steps):
+            kernel_size = 3 if conv3x3_only or index % 2 == 0 else 1
+            steps.append(
+                FastFlowStep(
+                    channels=channels,
+                    hidden_ratio=hidden_ratio,
+                    kernel_size=kernel_size,
+                    affine_clamping=affine_clamping,
+                )
+            )
+        self.steps = nn.ModuleList(steps)
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        total_log_det = x.new_zeros((x.shape[0],))
+        hidden = x
+        for step in self.steps:
+            hidden, log_det = step(hidden)
+            total_log_det = total_log_det + log_det
+        return hidden, total_log_det

--- a/src/pyclad/vision/models/paste/backbones.py
+++ b/src/pyclad/vision/models/paste/backbones.py
@@ -6,7 +6,12 @@ from typing import Callable, List, Optional, Tuple
 import torch
 from torch import nn
 
-from pyclad.vision.models.utilities.backbones import create_torchvision_model
+from pyclad.vision.models.utilities.backbones import (
+    EFFICIENTNET_BACKBONES,
+    MOBILENET_BACKBONES,
+    RESNET_BACKBONES,
+    create_torchvision_model,
+)
 
 
 @dataclass(frozen=True)
@@ -34,21 +39,9 @@ _MOBILENET_V2_SPEC = PaSTeBackboneSpec(default_ad_layers=(3, 6, 13), stage_build
 _EFFICIENTNET_SPEC = PaSTeBackboneSpec(default_ad_layers=(2, 3, 5), stage_builder=_features_stages)
 
 _BACKBONE_SPECS: dict[str, PaSTeBackboneSpec] = {
-    **{name: _RESNET_SPEC for name in ("resnet18", "resnet34", "resnet50", "wide_resnet50_2")},
-    "mobilenet_v2": _MOBILENET_V2_SPEC,
-    **{
-        name: _EFFICIENTNET_SPEC
-        for name in (
-            "efficientnet_b0",
-            "efficientnet_b1",
-            "efficientnet_b2",
-            "efficientnet_b3",
-            "efficientnet_b4",
-            "efficientnet_v2_s",
-            "efficientnet_v2_m",
-            "efficientnet_v2_l",
-        )
-    },
+    **{name: _RESNET_SPEC for name in RESNET_BACKBONES},
+    **{name: _MOBILENET_V2_SPEC for name in MOBILENET_BACKBONES},
+    **{name: _EFFICIENTNET_SPEC for name in EFFICIENTNET_BACKBONES},
 }
 
 

--- a/src/pyclad/vision/models/paste/config.py
+++ b/src/pyclad/vision/models/paste/config.py
@@ -1,9 +1,11 @@
-from typing import Literal, Optional
+from typing import Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import Field, model_validator
+
+from pyclad.vision.models.utilities.config import LightningVisionConfig
 
 
-class PaSTeConfig(BaseModel):
+class PaSTeConfig(LightningVisionConfig):
     backbone_name: str = "mobilenet_v2"
     ad_layers: Optional[tuple[int, ...]] = None
     student_bootstrap_layer: Optional[int] = 0
@@ -12,27 +14,9 @@ class PaSTeConfig(BaseModel):
     pretrained_student: bool = False
     freeze_teacher: bool = True
 
-    input_size: tuple[int, int] = (224, 224)
-    batch_size: int = Field(default=32, gt=0)
-    epochs: int = Field(default=100, ge=0)
     learning_rate: float = Field(default=0.4, gt=0.0)
     momentum: float = Field(default=0.9, ge=0.0, lt=1.0)
     weight_decay: float = Field(default=1e-4, ge=0.0)
-    show_training_progress: bool = True
-    early_stopping_patience: Optional[int] = Field(default=None, ge=0)
-    early_stopping_min_delta: float = Field(default=0.0, ge=0.0)
-    early_stopping_restore_best: bool = True
-
-    score_mode: Literal["max", "mean"] = "max"
-    threshold: Optional[float] = None
-    threshold_quantile: float = Field(default=0.99, gt=0.0, lt=1.0)
-
-    normalize_mean: Optional[tuple[float, ...]] = (0.485, 0.456, 0.406)
-    normalize_std: Optional[tuple[float, ...]] = (0.229, 0.224, 0.225)
-    input_range: Literal["uint8", "float01"] = "uint8"
-    input_layout: Literal["NHWC", "NCHW"] = "NHWC"
-
-    device: Optional[str] = None
 
     @model_validator(mode="after")
     def _validate_bootstrap(self):

--- a/src/pyclad/vision/models/paste/paste.py
+++ b/src/pyclad/vision/models/paste/paste.py
@@ -2,41 +2,20 @@ from __future__ import annotations
 
 from typing import Optional
 
-import numpy as np
 import pytorch_lightning as pl
 import torch
-import torch.nn.functional as F
-from pytorch_lightning.callbacks import EarlyStopping
 from pytorch_lightning.utilities.types import OptimizerLRScheduler
-from torch.utils.data import DataLoader, TensorDataset
 
 from pyclad.vision.models.paste.architecture import PaSTeArchitecture
 from pyclad.vision.models.paste.config import PaSTeConfig
-from pyclad.vision.models.utilities.preprocessing import ImagePreprocessor
-from pyclad.vision.models.utilities.utils import (
-    BestWeightsCallback,
-    resolve_device,
-    to_float,
-    trainer_device_config,
-)
-from pyclad.vision.models.vision_model import VisionModel
-from pyclad.vision.prediction_results import VisionPredictionResults
+from pyclad.vision.models.utilities.base_model import LightningVisionModel
 
 
-class PaSTe(VisionModel):
+class PaSTe(LightningVisionModel):
     def __init__(self, config: Optional[PaSTeConfig] = None):
-        self.config = config or PaSTeConfig()
+        super().__init__(config or PaSTeConfig())
 
-        self._device = resolve_device(self.config.device)
-        self._preprocessor = ImagePreprocessor(
-            input_size=self.config.input_size,
-            in_channels=3,
-            input_range=self.config.input_range,
-            input_layout=self.config.input_layout,
-            normalize_mean=self.config.normalize_mean,
-            normalize_std=self.config.normalize_std,
-        )
-
+    def _build_module(self) -> pl.LightningModule:
         network = PaSTeArchitecture(
             backbone_name=self.config.backbone_name,
             ad_layers=self.config.ad_layers,
@@ -46,162 +25,24 @@ class PaSTe(VisionModel):
             freeze_teacher=self.config.freeze_teacher,
             input_size=self.config.input_size,
         )
-        self.module = PaSTeModule(
+        return PaSTeModule(
             network=network,
             learning_rate=self.config.learning_rate,
             momentum=self.config.momentum,
             weight_decay=self.config.weight_decay,
-        ).to(self._device)
-
-        self._threshold = self.config.threshold
-        self._last_loss: Optional[float] = None
-
-    def _prepare_batches(self, data: np.ndarray, shuffle: bool) -> DataLoader:
-        x_t = self._preprocessor.transform(data)
-        dataset = TensorDataset(x_t)
-        return DataLoader(
-            dataset,
-            batch_size=self.config.batch_size,
-            shuffle=shuffle,
-            num_workers=0,
         )
 
-    def fit(self, data: np.ndarray):
-        if len(data) == 0 or self.config.epochs == 0:
-            return
-
-        callbacks: list[pl.Callback] = []
-        best_weights_callback: Optional[BestWeightsCallback] = None
-
-        if self.config.early_stopping_patience is not None:
-            callbacks.append(
-                EarlyStopping(
-                    monitor="train_loss",
-                    mode="min",
-                    patience=self.config.early_stopping_patience,
-                    min_delta=float(self.config.early_stopping_min_delta),
-                    check_on_train_epoch_end=True,
-                )
-            )
-
-            if self.config.early_stopping_restore_best:
-                best_weights_callback = BestWeightsCallback(
-                    monitor="train_loss",
-                    min_delta=float(self.config.early_stopping_min_delta),
-                )
-                callbacks.append(best_weights_callback)
-
-        accelerator, devices = trainer_device_config(self._device)
-        trainer = pl.Trainer(
-            max_epochs=self.config.epochs,
-            accelerator=accelerator,
-            devices=devices,
-            callbacks=callbacks,
-            logger=False,
-            enable_checkpointing=False,
-            enable_model_summary=False,
-            enable_progress_bar=self.config.show_training_progress,
-            num_sanity_val_steps=0,
-            log_every_n_steps=1,
-        )
-
-        trainer.fit(self.module, train_dataloaders=self._prepare_batches(data, shuffle=True))
-        self.module = self.module.to(self._device)
-        self._last_loss = to_float(trainer.callback_metrics.get("train_loss"))
-
-        if (
-            self.config.early_stopping_patience is not None
-            and self.config.early_stopping_restore_best
-            and best_weights_callback is not None
-            and best_weights_callback.best_state_dict is not None
-        ):
-            self.module.network.load_state_dict(best_weights_callback.best_state_dict)
-
-        if self.config.threshold is not None:
-            self._threshold = float(self.config.threshold)
-        else:
-            scores = self._score_data(data)
-            self._threshold = float(np.quantile(scores, self.config.threshold_quantile)) if len(scores) > 0 else 0.0
-
-    @staticmethod
-    def _resize_maps(score_maps: torch.Tensor, output_size: tuple[int, int]) -> torch.Tensor:
-        """Resize continuous per-pixel anomaly scores to ``output_size`` via bilinear."""
-        if tuple(score_maps.shape[-2:]) == tuple(output_size):
-            return score_maps
-        resized = F.interpolate(score_maps[:, None, :, :], size=output_size, mode="bilinear", align_corners=False)
-        return resized[:, 0]
-
-    def _forward_inference(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    def _inference_maps(self, batch: torch.Tensor) -> torch.Tensor:
         self.module.eval()
         with torch.no_grad():
-            score_maps, anomaly_scores = self.module.network.inference(x)
-        return score_maps, anomaly_scores
+            score_maps, _ = self.module.network.inference(batch)
+        return score_maps
 
-    def _score_data(self, data: np.ndarray) -> np.ndarray:
-        """Compute image-level anomaly scores. Used internally during fit() for threshold calibration."""
-        if len(data) == 0:
-            return np.asarray([], dtype=np.float32)
-
-        all_scores: list[np.ndarray] = []
-        for (batch_x,) in self._prepare_batches(data, shuffle=False):
-            batch_maps, _ = self._forward_inference(batch_x.to(self._device, dtype=torch.float32))
-            if self.config.score_mode == "mean":
-                batch_scores = batch_maps.mean(dim=(1, 2))
-            else:
-                batch_scores = batch_maps.view(batch_maps.size(0), -1).max(dim=1).values
-            all_scores.append(batch_scores.detach().cpu().numpy().astype(np.float32, copy=False))
-
-        return np.concatenate(all_scores, axis=0) if all_scores else np.asarray([], dtype=np.float32)
-
-    def predict(self, data: np.ndarray) -> VisionPredictionResults:
-        if len(data) == 0:
-            empty = np.asarray([], dtype=np.float32)
-            return VisionPredictionResults(
-                y_pred=np.asarray([], dtype=np.int64), anomaly_scores=empty, score_maps=empty
-            )
-
-        target_size = self._preprocessor.spatial_size(data)
-        all_maps: list[np.ndarray] = []
-        all_scores: list[np.ndarray] = []
-
-        for (batch_x,) in self._prepare_batches(data, shuffle=False):
-            raw_maps, _ = self._forward_inference(batch_x.to(self._device, dtype=torch.float32))
-
-            if self.config.score_mode == "mean":
-                batch_scores = raw_maps.mean(dim=(1, 2))
-            else:
-                batch_scores = raw_maps.view(raw_maps.size(0), -1).max(dim=1).values
-            all_scores.append(batch_scores.detach().cpu().numpy().astype(np.float32, copy=False))
-
-            resized = self._resize_maps(raw_maps, output_size=target_size)
-            all_maps.append(resized.detach().cpu().numpy().astype(np.float32, copy=False))
-
-        score_maps = np.concatenate(all_maps, axis=0)
-        anomaly_scores = np.concatenate(all_scores, axis=0)
-
-        if self.config.threshold is not None:
-            threshold = float(self.config.threshold)
-        elif self._threshold is not None:
-            threshold = float(self._threshold)
-        else:
-            threshold = 0.0
-
-        return VisionPredictionResults(
-            y_pred=(anomaly_scores > threshold).astype(int),
-            anomaly_scores=anomaly_scores,
-            score_maps=score_maps,
-        )
+    def _extra_info(self) -> dict:
+        return {"ad_layers": self.module.network.ad_layers}
 
     def name(self) -> str:
         return "PaSTe"
-
-    def additional_info(self) -> dict:
-        return {
-            **self.config.model_dump(),
-            "ad_layers": self.module.network.ad_layers,
-            "threshold": self._threshold,
-            "last_loss": self._last_loss,
-        }
 
 
 class PaSTeModule(pl.LightningModule):

--- a/src/pyclad/vision/models/paste/paste.py
+++ b/src/pyclad/vision/models/paste/paste.py
@@ -33,9 +33,7 @@ class PaSTe(LightningVisionModel):
         )
 
     def _inference_maps(self, batch: torch.Tensor) -> torch.Tensor:
-        self.module.eval()
-        with torch.no_grad():
-            score_maps, _ = self.module.network.inference(batch)
+        score_maps, _ = self.module.network.inference(batch)
         return score_maps
 
     def _extra_info(self) -> dict:

--- a/src/pyclad/vision/models/utilities/backbones.py
+++ b/src/pyclad/vision/models/utilities/backbones.py
@@ -3,6 +3,20 @@ import inspect
 import torchvision.models as tv_models
 from torch import nn
 
+RESNET_BACKBONES: tuple[str, ...] = ("resnet18", "resnet34", "resnet50", "wide_resnet50_2")
+MOBILENET_BACKBONES: tuple[str, ...] = ("mobilenet_v2",)
+EFFICIENTNET_BACKBONES: tuple[str, ...] = (
+    "efficientnet_b0",
+    "efficientnet_b1",
+    "efficientnet_b2",
+    "efficientnet_b3",
+    "efficientnet_b4",
+    "efficientnet_v2_s",
+    "efficientnet_v2_m",
+    "efficientnet_v2_l",
+)
+SUPPORTED_BACKBONES: tuple[str, ...] = RESNET_BACKBONES + MOBILENET_BACKBONES + EFFICIENTNET_BACKBONES
+
 
 def _resolve_torchvision_weights(model_fn, backbone_name: str):
     get_model_weights = getattr(tv_models, "get_model_weights", None)

--- a/src/pyclad/vision/models/utilities/base_model.py
+++ b/src/pyclad/vision/models/utilities/base_model.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Optional
+
+import numpy as np
+import pytorch_lightning as pl
+import torch
+import torch.nn.functional as F
+from pytorch_lightning.callbacks import EarlyStopping
+from torch.utils.data import DataLoader, TensorDataset
+
+from pyclad.vision.models.utilities.config import LightningVisionConfig, VisionConfig
+from pyclad.vision.models.utilities.preprocessing import ImagePreprocessor
+from pyclad.vision.models.utilities.utils import (
+    BestWeightsCallback,
+    resolve_device,
+    to_float,
+    trainer_device_config,
+)
+from pyclad.vision.models.vision_model import VisionModel
+from pyclad.vision.prediction_results import VisionPredictionResults
+
+
+class VisionScoringBase(VisionModel):
+    """Shared preprocessing, scoring, prediction and threshold logic for vision AD models.
+
+    Subclasses must implement :meth:`fit`, :meth:`name` and :meth:`_inference_maps`. The
+    inference hook is the single seam every model plugs into: it must return per-pixel
+    anomaly maps of shape ``(B, H, W)`` following the convention *higher = more anomalous*.
+    Everything else (batching, image-level aggregation, map resizing, threshold calibration
+    and resolution) is provided here and is independent of the training strategy.
+    """
+
+    def __init__(self, config: VisionConfig):
+        self.config = config
+        self._device = resolve_device(config.device)
+        self._preprocessor = ImagePreprocessor(
+            input_size=config.input_size,
+            in_channels=3,
+            input_range=config.input_range,
+            input_layout=config.input_layout,
+            normalize_mean=config.normalize_mean,
+            normalize_std=config.normalize_std,
+        )
+        self._threshold: Optional[float] = config.threshold
+        self._last_loss: Optional[float] = None
+
+    # --- subclass contract ---------------------------------------------------
+    @abstractmethod
+    def _inference_maps(self, batch: torch.Tensor) -> torch.Tensor:
+        """Return per-pixel anomaly maps ``(B, H, W)``; higher values are more anomalous.
+
+        ``batch`` is a preprocessed float tensor on this model's device.
+        """
+
+    def _extra_info(self) -> dict:
+        """Model-specific entries merged into :meth:`additional_info`."""
+        return {}
+
+    def _apply_seed(self) -> None:
+        """Seed the torch global RNG so weight init and channel permutations are reproducible.
+
+        A no-op when ``config.seed is None``. Concrete models must call this immediately
+        before their stochastic initialization: :class:`LightningVisionModel` does so before
+        building its module; single-pass models (e.g. memory-bank) should call it before
+        their random setup in ``fit``. Data-shuffling reproducibility is handled separately
+        (and universally) by the seeded generator in :meth:`_prepare_batches`.
+
+        Only the torch RNG is touched — intentionally not ``random``/``numpy``/env vars
+        (as ``pl.seed_everything`` would), since torch covers init and permutations here.
+        """
+        if self.config.seed is not None:
+            torch.manual_seed(self.config.seed)
+
+    def _prepare_batches(self, data: np.ndarray, shuffle: bool) -> DataLoader:
+        x_t = self._preprocessor.transform(data)
+        dataset = TensorDataset(x_t)
+        generator = torch.Generator().manual_seed(self.config.seed) if self.config.seed is not None else None
+        return DataLoader(
+            dataset, batch_size=self.config.batch_size, shuffle=shuffle, num_workers=0, generator=generator
+        )
+
+    def _aggregate_scores(self, score_maps: torch.Tensor) -> torch.Tensor:
+        if self.config.score_mode == "mean":
+            return score_maps.mean(dim=(1, 2))
+        return score_maps.reshape(score_maps.size(0), -1).max(dim=1).values
+
+    @staticmethod
+    def _resize_maps(score_maps: torch.Tensor, output_size: tuple[int, int]) -> torch.Tensor:
+        """Resize continuous per-pixel anomaly scores to ``output_size`` via bilinear."""
+        if tuple(score_maps.shape[-2:]) == tuple(output_size):
+            return score_maps
+        resized = F.interpolate(score_maps[:, None, :, :], size=output_size, mode="bilinear", align_corners=False)
+        return resized[:, 0]
+
+    def _run_inference(self, batch_x: torch.Tensor) -> torch.Tensor:
+        return self._inference_maps(batch_x.to(self._device, dtype=torch.float32))
+
+    def _score_data(self, data: np.ndarray) -> np.ndarray:
+        """Compute image-level anomaly scores. Used internally for threshold calibration."""
+        if len(data) == 0:
+            return np.asarray([], dtype=np.float32)
+
+        all_scores: list[np.ndarray] = []
+        for (batch_x,) in self._prepare_batches(data, shuffle=False):
+            batch_scores = self._aggregate_scores(self._run_inference(batch_x))
+            all_scores.append(batch_scores.detach().cpu().numpy().astype(np.float32, copy=False))
+
+        return np.concatenate(all_scores, axis=0) if all_scores else np.asarray([], dtype=np.float32)
+
+    def _calibrate_threshold(self, data: np.ndarray) -> None:
+        """Set the decision threshold from a fixed config value or a quantile of training scores."""
+        if self.config.threshold is not None:
+            self._threshold = float(self.config.threshold)
+            return
+        scores = self._score_data(data)
+        self._threshold = float(np.quantile(scores, self.config.threshold_quantile)) if len(scores) > 0 else None
+
+    def _resolve_threshold(self) -> float:
+        if self.config.threshold is not None:
+            return float(self.config.threshold)
+        if self._threshold is not None:
+            return float(self._threshold)
+        raise RuntimeError(
+            f"{self.name()}: anomaly threshold is not calibrated. Call fit() on nominal data "
+            "or set config.threshold explicitly before predict()."
+        )
+
+    def predict(self, data: np.ndarray) -> VisionPredictionResults:
+        if len(data) == 0:
+            empty = np.asarray([], dtype=np.float32)
+            return VisionPredictionResults(
+                y_pred=np.asarray([], dtype=np.int64), anomaly_scores=empty, score_maps=empty
+            )
+
+        target_size = self._preprocessor.spatial_size(data)
+        all_maps: list[np.ndarray] = []
+        all_scores: list[np.ndarray] = []
+
+        for (batch_x,) in self._prepare_batches(data, shuffle=False):
+            raw_maps = self._run_inference(batch_x)
+
+            batch_scores = self._aggregate_scores(raw_maps)
+            all_scores.append(batch_scores.detach().cpu().numpy().astype(np.float32, copy=False))
+
+            resized = self._resize_maps(raw_maps, output_size=target_size)
+            all_maps.append(resized.detach().cpu().numpy().astype(np.float32, copy=False))
+
+        score_maps = np.concatenate(all_maps, axis=0)
+        anomaly_scores = np.concatenate(all_scores, axis=0)
+        threshold = self._resolve_threshold()
+
+        return VisionPredictionResults(
+            y_pred=(anomaly_scores > threshold).astype(int),
+            anomaly_scores=anomaly_scores,
+            score_maps=score_maps,
+        )
+
+    def additional_info(self) -> dict:
+        return {
+            **self.config.model_dump(),
+            **self._extra_info(),
+            "threshold": self._threshold,
+            "last_loss": self._last_loss,
+        }
+
+
+class LightningVisionModel(VisionScoringBase):
+    """Base for vision AD models trained end-to-end with a PyTorch Lightning trainer.
+
+    Adds the gradient-training :meth:`fit` (optimizer loop, optional early stopping with
+    best-weight restoration, threshold calibration). Subclasses provide the network via
+    :meth:`_build_module` and the inference hook via :meth:`_inference_maps`.
+    """
+
+    config: LightningVisionConfig
+
+    def __init__(self, config: LightningVisionConfig):
+        super().__init__(config)
+        self._apply_seed()  # before _build_module(): seeds weight init and channel permutations
+        self.module = self._build_module().to(self._device)
+
+    @abstractmethod
+    def _build_module(self) -> pl.LightningModule:
+        """Build the LightningModule. It must expose the trainable network as ``.network``."""
+
+    def fit(self, data: np.ndarray):
+        if len(data) == 0 or self.config.epochs == 0:
+            return
+
+        callbacks: list[pl.Callback] = []
+        best_weights_callback: Optional[BestWeightsCallback] = None
+
+        if self.config.early_stopping_patience is not None:
+            callbacks.append(
+                EarlyStopping(
+                    monitor="train_loss",
+                    mode="min",
+                    patience=self.config.early_stopping_patience,
+                    min_delta=float(self.config.early_stopping_min_delta),
+                    check_on_train_epoch_end=True,
+                )
+            )
+
+            if self.config.early_stopping_restore_best:
+                best_weights_callback = BestWeightsCallback(
+                    monitor="train_loss",
+                    min_delta=float(self.config.early_stopping_min_delta),
+                )
+                callbacks.append(best_weights_callback)
+
+        accelerator, devices = trainer_device_config(self._device)
+        trainer = pl.Trainer(
+            max_epochs=self.config.epochs,
+            accelerator=accelerator,
+            devices=devices,
+            callbacks=callbacks,
+            logger=False,
+            enable_checkpointing=False,
+            enable_model_summary=False,
+            enable_progress_bar=self.config.show_training_progress,
+            num_sanity_val_steps=0,
+            log_every_n_steps=1,
+        )
+
+        trainer.fit(self.module, train_dataloaders=self._prepare_batches(data, shuffle=True))
+        self.module = self.module.to(self._device)
+        self._last_loss = to_float(trainer.callback_metrics.get("train_loss"))
+
+        if (
+            self.config.early_stopping_patience is not None
+            and self.config.early_stopping_restore_best
+            and best_weights_callback is not None
+            and best_weights_callback.best_state_dict is not None
+        ):
+            self.module.network.load_state_dict(best_weights_callback.best_state_dict)
+
+        self._calibrate_threshold(data)

--- a/src/pyclad/vision/models/utilities/base_model.py
+++ b/src/pyclad/vision/models/utilities/base_model.py
@@ -52,6 +52,11 @@ class VisionScoringBase(VisionModel):
         """Return per-pixel anomaly maps ``(B, H, W)``; higher values are more anomalous.
 
         ``batch`` is a preprocessed float tensor on this model's device.
+
+        For :class:`LightningVisionModel` subclasses this is invoked inside an eval-mode,
+        ``no_grad`` context managed by :meth:`LightningVisionModel._run_inference` (which also
+        restores the prior training mode), so the implementation should be a plain forward
+        pass. Single-pass (non-Lightning) models manage any grad/eval context themselves.
         """
 
     def _extra_info(self) -> dict:
@@ -184,6 +189,25 @@ class LightningVisionModel(VisionScoringBase):
     @abstractmethod
     def _build_module(self) -> pl.LightningModule:
         """Build the LightningModule. It must expose the trainable network as ``.network``."""
+
+    def _run_inference(self, batch_x: torch.Tensor) -> torch.Tensor:
+        """Run inference in eval mode under ``no_grad`` and restore the prior training mode.
+
+        Switching to ``eval()`` is required for correct inference (frozen BatchNorm stats,
+        disabled Dropout), but the previous mode must be restored afterwards: pyCLAD reuses
+        the same model instance across the concept stream, and PyTorch Lightning (>=2.2) no
+        longer resets train mode at the start of ``fit()``. A leaked ``eval()`` would silently
+        train BatchNorm/Dropout submodules in eval mode on every fit after the first.
+        ``train(was_training)`` re-dispatches into the architecture's overridden ``train()``,
+        so frozen backbones remain pinned to eval.
+        """
+        was_training = self.module.training
+        self.module.eval()
+        try:
+            with torch.no_grad():
+                return super()._run_inference(batch_x)
+        finally:
+            self.module.train(was_training)
 
     def fit(self, data: np.ndarray):
         if len(data) == 0 or self.config.epochs == 0:

--- a/src/pyclad/vision/models/utilities/config.py
+++ b/src/pyclad/vision/models/utilities/config.py
@@ -1,6 +1,9 @@
 from typing import Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PositiveFloat, PositiveInt, model_validator
+
+# Both spatial dimensions must be positive; reused by subclasses that override the default.
+ImageSize = tuple[PositiveInt, PositiveInt]
 
 
 class VisionConfig(BaseModel):
@@ -10,7 +13,7 @@ class VisionConfig(BaseModel):
     i.e. everything that is independent of how the model is trained.
     """
 
-    input_size: tuple[int, int] = (224, 224)
+    input_size: ImageSize = (224, 224)
     batch_size: int = Field(default=32, gt=0)
 
     score_mode: Literal["max", "mean"] = "max"
@@ -18,7 +21,7 @@ class VisionConfig(BaseModel):
     threshold_quantile: float = Field(default=0.99, gt=0.0, lt=1.0)
 
     normalize_mean: Optional[tuple[float, ...]] = (0.485, 0.456, 0.406)
-    normalize_std: Optional[tuple[float, ...]] = (0.229, 0.224, 0.225)
+    normalize_std: Optional[tuple[PositiveFloat, ...]] = (0.229, 0.224, 0.225)
     input_range: Literal["uint8", "float01"] = "uint8"
     input_layout: Literal["NHWC", "NCHW"] = "NHWC"
 
@@ -31,6 +34,14 @@ class VisionConfig(BaseModel):
     # here — it is a process-wide, non-reversible setting that belongs at the experiment
     # entry point, not in a model constructor.
     seed: Optional[int] = None
+
+    @model_validator(mode="after")
+    def _validate_normalization_pair(self):
+        # The preprocessor also enforces this (it additionally needs in_channels for the length
+        # check), but failing here keeps the both-or-neither invariant at the config layer.
+        if (self.normalize_mean is None) != (self.normalize_std is None):
+            raise ValueError("normalize_mean and normalize_std must be both set or both None")
+        return self
 
 
 class LightningVisionConfig(VisionConfig):

--- a/src/pyclad/vision/models/utilities/config.py
+++ b/src/pyclad/vision/models/utilities/config.py
@@ -1,0 +1,45 @@
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class VisionConfig(BaseModel):
+    """Configuration shared by all vision anomaly-detection models.
+
+    Holds only fields used for preprocessing, scoring and threshold calibration,
+    i.e. everything that is independent of how the model is trained.
+    """
+
+    input_size: tuple[int, int] = (224, 224)
+    batch_size: int = Field(default=32, gt=0)
+
+    score_mode: Literal["max", "mean"] = "max"
+    threshold: Optional[float] = None
+    threshold_quantile: float = Field(default=0.99, gt=0.0, lt=1.0)
+
+    normalize_mean: Optional[tuple[float, ...]] = (0.485, 0.456, 0.406)
+    normalize_std: Optional[tuple[float, ...]] = (0.229, 0.224, 0.225)
+    input_range: Literal["uint8", "float01"] = "uint8"
+    input_layout: Literal["NHWC", "NCHW"] = "NHWC"
+
+    device: Optional[str] = None
+
+    # Reproducibility. ``seed=None`` (default) leaves global RNG state untouched. When set,
+    # data shuffling is made reproducible via a local DataLoader generator, and models seed
+    # weight init / channel permutations through ``_apply_seed()``. Note: strict bitwise
+    # determinism (e.g. ``torch.use_deterministic_algorithms``) is intentionally NOT handled
+    # here — it is a process-wide, non-reversible setting that belongs at the experiment
+    # entry point, not in a model constructor.
+    seed: Optional[int] = None
+
+
+class LightningVisionConfig(VisionConfig):
+    """Adds gradient-training fields for models trained via a PyTorch Lightning trainer."""
+
+    epochs: int = Field(default=100, ge=0)
+    learning_rate: float = Field(default=1e-3, gt=0.0)
+    weight_decay: float = Field(default=0.0, ge=0.0)
+    show_training_progress: bool = True
+    early_stopping_patience: Optional[int] = Field(default=None, ge=0)
+    early_stopping_min_delta: float = Field(default=0.0, ge=0.0)
+    early_stopping_restore_best: bool = True

--- a/tests/vision/metrics/test_pixel_threshold_metrics.py
+++ b/tests/vision/metrics/test_pixel_threshold_metrics.py
@@ -40,3 +40,26 @@ def test_resolve_pixel_threshold_supports_train_quantile_mode():
     )
 
     assert np.isclose(threshold, 0.0875)
+
+
+def test_default_pixel_threshold_is_scale_invariant_and_non_degenerate():
+    # Same relative anomaly pattern, two absolute scales: positive (PaSTe-like)
+    # and shifted into the negative range (FastFlow maps live in [-1, 0)).
+    rng = np.random.default_rng(0)
+    score_maps = rng.uniform(0.0, 0.2, size=(1, 10, 10)).astype(np.float32)
+    score_maps[0, 0, :5] = rng.uniform(0.8, 1.0, size=5)  # 5 distinct anomalous pixels (highest)
+    masks = np.zeros((1, 10, 10), dtype=np.uint8)
+    masks[0, 0, :5] = 1
+
+    metric = PixelF1Score()  # data-driven (quantile) threshold by default
+    f1_positive = metric.compute(anomaly_scores=score_maps, y_pred=np.asarray([]), y_true=masks)
+    f1_negative = metric.compute(anomaly_scores=score_maps - 1.0, y_pred=np.asarray([]), y_true=masks)
+
+    # The quantile threshold shifts with the data, so the binarization — and the
+    # score — is identical regardless of the absolute scale of the maps.
+    assert f1_positive == f1_negative
+    assert f1_positive > 0.0
+
+    # The old fixed-0.5 default silently collapses to 0 on FastFlow-scale maps.
+    f1_fixed = PixelF1Score(threshold=0.5).compute(anomaly_scores=score_maps - 1.0, y_pred=np.asarray([]), y_true=masks)
+    assert f1_fixed == 0.0

--- a/tests/vision/models/test_fastflow.py
+++ b/tests/vision/models/test_fastflow.py
@@ -1,0 +1,75 @@
+import numpy as np
+import pytest
+
+from pyclad.vision.models.fastflow.config import FastFlowConfig
+from pyclad.vision.models.fastflow.fastflow import FastFlow
+from pyclad.vision.prediction_results import VisionPredictionResults
+
+
+def _config(**overrides) -> FastFlowConfig:
+    defaults = dict(
+        input_size=(64, 64),
+        backbone_name="resnet18",
+        pretrained_backbone=False,
+        flow_steps=2,
+        input_range="float01",
+        batch_size=1,
+        epochs=0,
+        show_training_progress=False,
+    )
+    defaults.update(overrides)
+    return FastFlowConfig(**defaults)
+
+
+@pytest.mark.parametrize("backbone_name", ["resnet18", "mobilenet_v2", "efficientnet_b0"])
+def test_fastflow_predict_shapes(backbone_name: str):
+    data = np.random.default_rng(0).random((1, 64, 64, 3), dtype=np.float32)
+    model = FastFlow(_config(backbone_name=backbone_name, threshold=0.0))
+
+    result = model.predict(data)
+
+    assert isinstance(result, VisionPredictionResults)
+    assert result.y_pred.shape == (1,)
+    assert result.anomaly_scores.shape == (1,)
+    assert result.score_maps.shape == (1, 64, 64)
+
+
+def test_fastflow_rejects_empty_return_nodes():
+    with pytest.raises(ValueError, match="at least one feature node"):
+        FastFlow(_config(backbone_return_nodes=()))
+
+
+def test_fastflow_predict_handles_empty_input():
+    model = FastFlow(_config(threshold=0.0))
+
+    result = model.predict(np.empty((0, 64, 64, 3), dtype=np.float32))
+
+    assert result.y_pred.shape == (0,)
+    assert result.anomaly_scores.shape == (0,)
+    assert result.score_maps.shape == (0,)
+
+
+def test_fastflow_seed_makes_results_reproducible():
+    data = np.random.default_rng(7).random((2, 64, 64, 3), dtype=np.float32)
+
+    def score_maps(seed: int) -> np.ndarray:
+        # pretrained_backbone=False -> backbone init is random; combined with the random
+        # flow weights and channel permutations, the whole model is seed-dependent.
+        model = FastFlow(_config(seed=seed, threshold=0.0))
+        return model.predict(data).score_maps
+
+    assert np.array_equal(score_maps(123), score_maps(123))  # same seed -> identical
+    assert not np.array_equal(score_maps(123), score_maps(456))  # different seed -> different
+
+
+def test_fastflow_fit_smoke_run():
+    data = np.random.default_rng(1).random((2, 64, 64, 3), dtype=np.float32)
+    model = FastFlow(_config(batch_size=2, epochs=1))
+
+    model.fit(data)
+    result = model.predict(data)
+
+    assert result.y_pred.shape == (2,)
+    assert result.anomaly_scores.shape == (2,)
+    assert result.score_maps.shape == (2, 64, 64)
+    assert model.additional_info()["last_loss"] is not None

--- a/tests/vision/models/test_fastflow.py
+++ b/tests/vision/models/test_fastflow.py
@@ -1,5 +1,9 @@
+from unittest.mock import patch
+
 import numpy as np
 import pytest
+import torch
+from pydantic import ValidationError
 
 from pyclad.vision.models.fastflow.config import FastFlowConfig
 from pyclad.vision.models.fastflow.fastflow import FastFlow
@@ -62,6 +66,23 @@ def test_fastflow_seed_makes_results_reproducible():
     assert not np.array_equal(score_maps(123), score_maps(456))  # different seed -> different
 
 
+def test_fastflow_inference_restores_training_mode():
+    # _inference_maps must not leave the module stuck in eval(): pyCLAD reuses the same
+    # instance across the concept stream and Lightning (>=2.2) no longer resets train mode at
+    # fit start, so a leaked eval() would silently train BatchNorm/Dropout in eval mode on
+    # later fits. predict() must round-trip the module's training flag.
+    data = np.random.default_rng(0).random((1, 64, 64, 3), dtype=np.float32)
+    model = FastFlow(_config(threshold=0.0))
+
+    model.module.train()
+    model.predict(data)
+    assert model.module.training is True
+
+    model.module.eval()
+    model.predict(data)
+    assert model.module.training is False
+
+
 def test_fastflow_fit_smoke_run():
     data = np.random.default_rng(1).random((2, 64, 64, 3), dtype=np.float32)
     model = FastFlow(_config(batch_size=2, epochs=1))
@@ -73,3 +94,83 @@ def test_fastflow_fit_smoke_run():
     assert result.anomaly_scores.shape == (2,)
     assert result.score_maps.shape == (2, 64, 64)
     assert model.additional_info()["last_loss"] is not None
+
+
+def test_fastflow_second_fit_still_trains_in_train_mode():
+    # The eval-mode restore in _run_inference must let a 2nd fit on a reused instance keep
+    # training in TRAIN mode after a predict() forced eval(). A trainable BatchNorm's
+    # num_batches_tracked only advances in train mode, so a leaked eval() (training BN in eval
+    # mode) would freeze it -- this is the regression to guard, not mere weight movement (the
+    # optimizer steps in eval mode too). freeze_backbone=False puts the backbone BN in the
+    # trainable path (and also covers that otherwise-untested branch).
+    rng = np.random.default_rng(2)
+    data_a = rng.random((2, 64, 64, 3), dtype=np.float32)
+    data_b = rng.random((2, 64, 64, 3), dtype=np.float32)
+    model = FastFlow(_config(batch_size=2, epochs=1, freeze_backbone=False))
+
+    model.fit(data_a)
+    model.predict(data_a)  # forces eval(); must be restored before the next fit
+
+    bn = next(m for m in model.module.network.modules() if isinstance(m, torch.nn.BatchNorm2d))
+    tracked_before = bn.num_batches_tracked.clone()
+    model.fit(data_b)
+
+    assert bn.num_batches_tracked.item() > tracked_before.item()  # 2nd fit ran in train mode
+    assert model.module.training is True  # left in train mode, not stuck in eval
+
+
+def test_fastflow_fit_calibrates_threshold_from_quantile():
+    # With threshold=None, fit() must calibrate a finite threshold from the configured quantile
+    # of the training scores. Assert against an independent recomputation of that quantile (not
+    # predict()'s own decision rule, which would be tautological).
+    data = np.random.default_rng(3).random((4, 64, 64, 3), dtype=np.float32)
+    model = FastFlow(_config(batch_size=2, epochs=1))  # threshold defaults to None
+
+    model.fit(data)
+
+    threshold = model.additional_info()["threshold"]
+    assert threshold is not None and np.isfinite(threshold)
+
+    expected = float(np.quantile(model._score_data(data), model.config.threshold_quantile))
+    assert threshold == pytest.approx(expected)
+
+
+def test_fastflow_early_stopping_restores_best_weights():
+    # Exercises the early-stopping + best-weights-restore branch in LightningVisionModel.fit,
+    # which is on by default (early_stopping_restore_best=True) but otherwise untested.
+    data = np.random.default_rng(4).random((2, 64, 64, 3), dtype=np.float32)
+    model = FastFlow(_config(batch_size=2, epochs=2, early_stopping_patience=0))
+
+    with patch.object(
+        model.module.network,
+        "load_state_dict",
+        wraps=model.module.network.load_state_dict,
+    ) as restore_spy:
+        model.fit(data)
+
+    assert restore_spy.called  # best weights were restored after training
+    assert model.module.training is True
+
+
+@pytest.mark.parametrize("input_size", [(0, 64), (64, 0), (-1, 64)])
+def test_fastflow_config_rejects_nonpositive_input_size(input_size):
+    with pytest.raises(ValidationError):
+        FastFlowConfig(input_size=input_size)
+
+
+@pytest.mark.parametrize("normalize_std", [(0.0, 0.5, 0.5), (-0.1, 0.5, 0.5)])
+def test_fastflow_config_rejects_nonpositive_normalize_std(normalize_std):
+    with pytest.raises(ValidationError):
+        FastFlowConfig(normalize_std=normalize_std)
+
+
+def test_fastflow_config_rejects_half_specified_normalization():
+    with pytest.raises(ValidationError):
+        FastFlowConfig(normalize_std=None)  # mean keeps its default 3-tuple -> mismatch
+    with pytest.raises(ValidationError):
+        FastFlowConfig(normalize_mean=None)  # std keeps its default 3-tuple -> mismatch
+
+
+def test_fastflow_config_accepts_valid_normalization():
+    FastFlowConfig(normalize_mean=None, normalize_std=None)  # both off
+    FastFlowConfig(normalize_std=(0.2, 0.2, 0.2))  # both set (mean defaults)

--- a/tests/vision/models/test_paste.py
+++ b/tests/vision/models/test_paste.py
@@ -47,6 +47,31 @@ def test_paste_rejects_invalid_bootstrap_layer():
         PaSTeConfig(backbone_name="resnet18", ad_layers=(1, 2, 3), student_bootstrap_layer=1)
 
 
+def test_paste_seed_makes_results_reproducible():
+    data = np.random.default_rng(7).random((2, 64, 64, 3), dtype=np.float32)
+
+    def score_maps(seed: int) -> np.ndarray:
+        model = PaSTe(
+            PaSTeConfig(
+                input_size=(64, 64),
+                backbone_name="resnet18",
+                student_bootstrap_layer=0,
+                pretrained_teacher=False,
+                pretrained_student=False,  # random student init -> seed-dependent
+                input_range="float01",
+                batch_size=1,
+                epochs=0,
+                threshold=0.5,
+                show_training_progress=False,
+                seed=seed,
+            )
+        )
+        return model.predict(data).score_maps
+
+    assert np.array_equal(score_maps(123), score_maps(123))  # same seed -> identical
+    assert not np.array_equal(score_maps(123), score_maps(456))  # different seed -> different
+
+
 def test_paste_fit_smoke_run():
     data = np.random.default_rng(1).random((2, 64, 64, 3), dtype=np.float32)
     model = PaSTe(

--- a/tests/vision/models/test_paste.py
+++ b/tests/vision/models/test_paste.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import numpy as np
 import pytest
+import torch
 
 from pyclad.vision.models.paste.config import PaSTeConfig
 from pyclad.vision.models.paste.paste import PaSTe
@@ -72,6 +73,36 @@ def test_paste_seed_makes_results_reproducible():
     assert not np.array_equal(score_maps(123), score_maps(456))  # different seed -> different
 
 
+def test_paste_inference_restores_training_mode():
+    # _inference_maps must not leave the module stuck in eval(): the same instance is fitted
+    # repeatedly across the concept stream and Lightning (>=2.2) no longer resets train mode at
+    # fit start, so a leaked eval() would silently train the (always-trainable) student
+    # BatchNorm in eval mode on later fits. predict() must round-trip the module's training flag.
+    data = np.random.default_rng(0).random((1, 64, 64, 3), dtype=np.float32)
+    model = PaSTe(
+        PaSTeConfig(
+            input_size=(64, 64),
+            backbone_name="resnet18",
+            student_bootstrap_layer=0,
+            pretrained_teacher=False,
+            pretrained_student=False,
+            input_range="float01",
+            batch_size=1,
+            epochs=0,
+            threshold=0.5,
+            show_training_progress=False,
+        )
+    )
+
+    model.module.train()
+    model.predict(data)
+    assert model.module.training is True
+
+    model.module.eval()
+    model.predict(data)
+    assert model.module.training is False
+
+
 def test_paste_fit_smoke_run():
     data = np.random.default_rng(1).random((2, 64, 64, 3), dtype=np.float32)
     model = PaSTe(
@@ -94,3 +125,36 @@ def test_paste_fit_smoke_run():
     assert result.y_pred.shape == (2,)
     assert result.anomaly_scores.shape == (2,)
     assert result.score_maps.shape == (2, 64, 64)
+
+
+def test_paste_second_fit_still_trains_student_in_train_mode():
+    # The eval-mode restore must let a 2nd fit on the reused instance keep training the
+    # (always-trainable) student in TRAIN mode after a predict() forced eval(). A student
+    # BatchNorm's num_batches_tracked only advances in train mode, so a leaked eval() would
+    # freeze it -- that is the regression to guard (the optimizer steps in eval mode too).
+    rng = np.random.default_rng(2)
+    data_a = rng.random((2, 64, 64, 3), dtype=np.float32)
+    data_b = rng.random((2, 64, 64, 3), dtype=np.float32)
+    model = PaSTe(
+        PaSTeConfig(
+            input_size=(64, 64),
+            backbone_name="resnet18",
+            student_bootstrap_layer=0,
+            pretrained_teacher=False,
+            pretrained_student=False,
+            input_range="float01",
+            batch_size=2,
+            epochs=1,
+            show_training_progress=False,
+        )
+    )
+
+    model.fit(data_a)
+    model.predict(data_a)  # forces eval(); must be restored before the next fit
+
+    bn = next(m for m in model.module.network.student.modules() if isinstance(m, torch.nn.BatchNorm2d))
+    tracked_before = bn.num_batches_tracked.clone()
+    model.fit(data_b)
+
+    assert bn.num_batches_tracked.item() > tracked_before.item()  # 2nd fit trained student in train mode
+    assert model.module.training is True

--- a/tests/vision/models/test_utils.py
+++ b/tests/vision/models/test_utils.py
@@ -1,0 +1,46 @@
+import copy
+import types
+
+import pytest
+import torch
+from torch import nn
+
+from pyclad.vision.models.utilities.utils import BestWeightsCallback
+
+
+def _trainer(loss: float) -> types.SimpleNamespace:
+    return types.SimpleNamespace(callback_metrics={"train_loss": torch.tensor(loss)})
+
+
+def test_best_weights_callback_tracks_min_delta_improvements():
+    module = types.SimpleNamespace(network=nn.Linear(2, 2))
+    callback = BestWeightsCallback(monitor="train_loss", min_delta=0.1)
+
+    # First epoch: baseline recorded and current weights captured.
+    callback.on_train_epoch_end(_trainer(1.0), module)
+    assert callback.best_loss == pytest.approx(1.0)
+    assert callback.best_state_dict is not None
+    epoch0_weight = copy.deepcopy(module.network.state_dict()["weight"])
+    assert torch.equal(callback.best_state_dict["weight"], epoch0_weight)
+
+    # Mutate weights, then report a sub-min_delta improvement: best must NOT update.
+    with torch.no_grad():
+        module.network.weight.add_(1.0)
+    callback.on_train_epoch_end(_trainer(0.95), module)  # delta 0.05 < 0.1
+    assert callback.best_loss == pytest.approx(1.0)
+    assert torch.equal(callback.best_state_dict["weight"], epoch0_weight)
+
+    # A larger-than-min_delta improvement: best updates to the current (mutated) weights.
+    callback.on_train_epoch_end(_trainer(0.8), module)  # delta 0.2 > 0.1
+    assert callback.best_loss == pytest.approx(0.8)
+    assert torch.equal(callback.best_state_dict["weight"], module.network.state_dict()["weight"])
+
+
+def test_best_weights_callback_ignores_missing_monitor_key():
+    module = types.SimpleNamespace(network=nn.Linear(2, 2))
+    callback = BestWeightsCallback(monitor="train_loss", min_delta=0.0)
+
+    callback.on_train_epoch_end(types.SimpleNamespace(callback_metrics={}), module)
+
+    assert callback.best_loss is None
+    assert callback.best_state_dict is None


### PR DESCRIPTION
## Summary

Adds the **FastFlow** model. As part of this change, the PaSTe and FastFlow models are refactored onto a shared base, so both reuse the same training, prediction, and thresholding scaffolding.

A new vision model only needs to implement its training logic and a single inference hook (`_inference_maps`) returning per-pixel anomaly maps. A model opts into pixel-level evaluation by returning `score_maps` in its results, with no config flags needed.

## What's included

- **FastFlow model**: architecture, flow blocks, backbone feature extraction, and config.
- **Shared base classes**: PaSTe is rewired onto them, removing the duplicated `fit` / `predict` / thresholding code that FastFlow would otherwise have copied.
- **Shared config layer**: per-model configs only contain model-specific fields.
- **Shared backbone registry**: backbone name lists are deduplicated between models.
- **Scale-invariant pixel thresholding** for F1, Dice, and IoU.
- **Optional reproducibility seed** in the shared config: seeds weight initialization, channel permutations, and data shuffling; `seed=None` keeps the current behavior.