### PR TITLE
Fix heatmap concept label ordering

### DIFF
--- a/examples/plot_heatmap_example.py
+++ b/examples/plot_heatmap_example.py
@@ -5,7 +5,7 @@ from pyclad.analysis.scenario_heatmap import plot_metric_heatmap
 
 if __name__ == "__main__":
     """This example showcase how to generate ROC-AUC heatmap for the results of concept aware scenario"""
-    results_path = pathlib.Path("output.json")  # you need to generate this file using concept_aware_examply.py
+    results_path = pathlib.Path("output.json")  # you need to generate this file using concept_aware_example.py
     with open(results_path) as fp:
         loaded_data = json.load(fp)
         concepts_order = loaded_data["concept_metric_callback_ROC-AUC"]["concepts_order"]

--- a/src/pyclad/analysis/scenario_heatmap.py
+++ b/src/pyclad/analysis/scenario_heatmap.py
@@ -30,25 +30,21 @@ def plot_metric_heatmap(
     figsize: tuple = (6, 5),
     ignore_upper_diagonal: bool = False,
 ):
-    sns.set_theme(style="darkgrid")
-    sns.set(rc={"figure.figsize": figsize})
+    matrix_keys = set(matrix.keys())
+    assert all(
+        set(concept_results.keys()) == matrix_keys for concept_results in matrix.values()
+    ), "The outer dict and every inner dict must have the same keys."  # TODO: Allow for different keys in the inner dicts
 
-    data = []  # learned_concept, evaluated_concept, metric_value
+    sns.set_theme(style="darkgrid", rc={"figure.figsize": figsize})
 
-    for learned_concept in concepts_order:
-        for evaluated_concept in concepts_order:
-            metric_value = matrix[learned_concept][evaluated_concept]
-            data.append(
-                [
-                    learned_concept if names_mapping is None else names_mapping[learned_concept],
-                    evaluated_concept if names_mapping is None else names_mapping[evaluated_concept],
-                    metric_value,
-                ]
-            )
+    df = pd.DataFrame(
+        [[matrix[learned][evaluated] for evaluated in concepts_order] for learned in concepts_order],
+        index=concepts_order,
+        columns=concepts_order,
+    )
+    if names_mapping is not None:
+        df = df.rename(index=names_mapping, columns=names_mapping)
 
-    df = pd.DataFrame(data, columns=["learned_concept", "evaluated_concept", "metric_value"])
-    df = df.pivot(index="learned_concept", columns="evaluated_concept", values="metric_value")
-    df = df.reindex(index=concepts_order, columns=concepts_order)
     p: Axes = sns.heatmap(
         df,
         vmin=0,

--- a/tests/analysis/test_scenario_heatmap.py
+++ b/tests/analysis/test_scenario_heatmap.py
@@ -1,0 +1,24 @@
+from matplotlib import pyplot as plt
+from matplotlib.axes import Axes
+
+from pyclad.analysis import scenario_heatmap
+
+
+def test_plot_metric_heatmap_uses_mapped_concept_names_for_display():
+    matrix = {
+        "concept1": {"concept1": 1.0, "concept2": 0.2},
+        "concept2": {"concept1": 0.8, "concept2": 0.9},
+    }
+    names_mapping = {"concept1": "C1", "concept2": "C2"}
+
+    axes = scenario_heatmap.plot_metric_heatmap(matrix, ["concept1", "concept2"], names_mapping=names_mapping)
+
+    expected_values = [[1.0, 0.2], [0.8, 0.9]]
+    expected_labels = ["C1", "C2"]
+    try:
+        assert isinstance(axes, Axes)
+        assert [label.get_text() for label in axes.get_xticklabels()] == expected_labels
+        assert [label.get_text() for label in axes.get_yticklabels()] == expected_labels
+        assert axes.collections[0].get_array().reshape(2, 2).tolist() == expected_values
+    finally:
+        plt.close(axes.figure)


### PR DESCRIPTION
Before we did `df.reindex` after remapping the concept names, which resulted in a matrix of NaNs