### PR TITLE
Add step-schedule grouping of concepts into training steps

### DIFF
--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -47,6 +47,46 @@ cad_dataset = CadCicids2017Dataset(ordering='curriculum_asc')
 ```
 
 
+### Step Schedule (Grouping)
+
+By default every concept is its own training step. CDAD-style continual anomaly detection
+benchmarks instead merge consecutive concepts into larger training steps, while keeping
+evaluation per concept. `pyclad.data.grouping` implements this with a compact notation, where
+tokens are separated by `-` and `NxM` repeats `N` `M` times:
+
+| Spec | Parsed | Meaning (15 concepts) |
+|---|---|---|
+| `"14-1"` | `[14, 1]` | one large base step, then one new concept |
+| `"10-5"` | `[10, 5]` | two steps |
+| `"3x5"` | `[3, 3, 3, 3, 3]` | five steps of three concepts each |
+| `"10-1x5"` | `[10, 1, 1, 1, 1, 1]` | a base of 10, then five single-concept steps |
+
+```python
+from pyclad.data.grouping import apply_step_schedule
+
+scheduled = apply_step_schedule(dataset, schedule="14-1")
+
+scheduled.train_concepts()   # 2 grouped concepts: step_0, step_1
+scheduled.test_concepts()    # still 15 concepts, one per category
+scheduled.first_seen_step()  # {'bottle': 0, ..., 'wood': 0, 'zipper': 1}
+```
+
+The schedule must sum to the number of train concepts. Train concepts are always merged;
+merging preserves the concrete concept class, so a `VisionConcept` keeps its `masks` aligned
+with `data`. Test concepts stay per category unless `group_test=True`, which requires them to
+align 1:1 with the train concepts and describes a different experiment -- do not mix results
+from the two in one table.
+
+Because training now takes $T$ steps while evaluation still covers $N$ concepts, the resulting
+metric matrix is rectangular ($T \times N$, $T < N$). See [Metrics](metrics.md) for the metrics
+that can read such a matrix.
+
+
+Grouping merges *consecutive* concepts, so the dataset must already be in its final order:
+**ordering, then grouping, then first_seen_step**. The mapping from concept to the training
+step that first includes it is derived from the order *before* the merge, which is why the
+grouped dataset computes and carries it for you instead of leaving it to the caller.
+
 ### Continual Scenario Extraction
 
 We devised a simple algorithm to extract continual learning datasets in the format supported by pyCLAD, based on any

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -63,9 +63,11 @@ only at the final step cannot have been forgotten yet:
 $f_k = \max_{j \in [s_k,\, T-2]} R_{j, k} - R_{T-1, k}$
 
 - **Schedule-Aware Forward Transfer**: the model's performance on concepts it has not been trained
-on yet, averaged over the pre-training rows. Concepts with $s_k = 0$ are skipped:
+on yet, averaged over the pre-training rows. Concepts with $s_k = 0$ are skipped, and so are
+individual cells where the base metric was undefined, so the mean is taken over the non-NaN
+pre-training rows rather than over all $s_k$ of them:
 
-$\text{fwt}_k = \frac{1}{s_k}\sum_{j=0}^{s_k - 1} R_{j, k}$
+$\text{fwt}_k = \underset{j \,\in\, [0,\, s_k - 1]}{\text{mean}} R_{j, k}$
 
 - **Schedule-Aware New Task Acquisition**: performance on a concept right after it first entered
 training, before any later step could interfere. Together with the forgetting measure it separates

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -34,6 +34,61 @@ $\text{FWT} = \frac{\sum_{i<j}^{N} R_{i, j}}{\frac{N(N-1)}{2}}$
 
 
 
+### Rectangular matrices and step schedules
+
+When training steps group several concepts (see [Step Schedule](datasets.md)), the rows of $R$ are
+training steps and the columns are evaluated concepts, so $R$ becomes rectangular ($T \times N$
+with $T < N$) and the two axes no longer share names.
+
+The three metrics above walk the diagonal or the triangles of $R$, which is only meaningful when
+each training step corresponds to exactly one evaluated concept. Handed a rectangular matrix they
+raise `ValueError` instead of returning a number computed over cells that do not mean what the
+formula assumes.
+
+For rectangular matrices pyCLAD provides metrics that take one extra argument: $s_k$, the index of
+the training step at which evaluated concept $k$ first entered training. Rows above $s_k$ describe
+the model *before* it ever saw that concept, which is a different quantity from forgetting. Indices
+below are 0-based, so the final training step is $T-1$.
+
+- **Final Step Average** (FSA): the average across all evaluated concepts after the last training
+step. This is the `A-AUROC` figure reported by CDAD-style papers. It reads only the last row, so it
+works on square and rectangular matrices alike:
+
+$\text{FSA} = \frac{1}{N}\sum_{k=0}^{N-1} R_{T-1, k}$
+
+- **Schedule-Aware Forgetting Measure**: forgetting restricted to the rows in which a concept had
+already been trained. Concepts with $s_k \ge T-1$ are skipped, since a concept that enters training
+only at the final step cannot have been forgotten yet:
+
+$f_k = \max_{j \in [s_k,\, T-2]} R_{j, k} - R_{T-1, k}$
+
+- **Schedule-Aware Forward Transfer**: the model's performance on concepts it has not been trained
+on yet, averaged over the pre-training rows. Concepts with $s_k = 0$ are skipped:
+
+$\text{fwt}_k = \frac{1}{s_k}\sum_{j=0}^{s_k - 1} R_{j, k}$
+
+- **Schedule-Aware New Task Acquisition**: performance on a concept right after it first entered
+training, before any later step could interfere. Together with the forgetting measure it separates
+a plasticity problem (the concept was never learned) from a stability one (it was learned, then
+lost). On a square matrix with one concept per step this reads the diagonal:
+
+$\text{nta}_k = R_{s_k, k}$
+
+Wiring them up is one argument, because the grouped dataset carries the mapping:
+
+```python
+callback = ConceptMetricCallback(
+    base_metric=RocAuc(),
+    summarized_metrics=[FinalStepAverage()],
+    schedule_aware_metrics=[
+        ScheduleAwareForgettingMeasure(),
+        ScheduleAwareForwardTransfer(),
+        ScheduleAwareNewTaskAcquisition(),
+    ],
+    first_seen_step=scheduled_dataset.first_seen_step(),
+)
+```
+
 The evaluation protocol slightly differs based on the scenario. Specifically:
 
 - **Concept-aware** and **concept-incremental**: batches $T_i$ (training) and $E_i$ (evaluation) correspond to the single $i-$th concept.

--- a/examples/step_schedule_example.py
+++ b/examples/step_schedule_example.py
@@ -1,14 +1,22 @@
 import logging
 import pathlib
 
-from pyclad.callbacks.evaluation.concept_metric_evaluation import ConceptMetricCallback
+from pyclad.callbacks.evaluation.concept_metric_evaluation import (
+    ScheduleAwareConceptMetricCallback,
+)
 from pyclad.data.grouping import apply_step_schedule
 from pyclad.data.readers.concepts_readers import read_dataset_from_npy
 from pyclad.metrics.base.roc_auc import RocAuc
 from pyclad.metrics.continual.final_step_average import FinalStepAverage
-from pyclad.metrics.continual.schedule_aware_forgetting_measure import ScheduleAwareForgettingMeasure
-from pyclad.metrics.continual.schedule_aware_forward_transfer import ScheduleAwareForwardTransfer
-from pyclad.metrics.continual.schedule_aware_new_task_acquisition import ScheduleAwareNewTaskAcquisition
+from pyclad.metrics.continual.schedule_aware_forgetting_measure import (
+    ScheduleAwareForgettingMeasure,
+)
+from pyclad.metrics.continual.schedule_aware_forward_transfer import (
+    ScheduleAwareForwardTransfer,
+)
+from pyclad.metrics.continual.schedule_aware_new_task_acquisition import (
+    ScheduleAwareNewTaskAcquisition,
+)
 from pyclad.models.adapters.pyod_adapters import IsolationForestAdapter
 from pyclad.output.json_writer import JsonOutputWriter
 from pyclad.scenarios.concept_aware import ConceptAwareScenario
@@ -41,7 +49,7 @@ if __name__ == "__main__":
     # Metrics that walk the diagonal (ContinualAverage, BackwardTransfer, ForwardTransfer,
     # ForgettingMeasure) reject a rectangular matrix -- pass the schedule-aware ones instead.
     callbacks = [
-        ConceptMetricCallback(
+        ScheduleAwareConceptMetricCallback(
             base_metric=RocAuc(),
             summarized_metrics=[FinalStepAverage()],
             schedule_aware_metrics=[

--- a/examples/step_schedule_example.py
+++ b/examples/step_schedule_example.py
@@ -1,0 +1,60 @@
+import logging
+import pathlib
+
+from pyclad.callbacks.evaluation.concept_metric_evaluation import ConceptMetricCallback
+from pyclad.data.grouping import apply_step_schedule
+from pyclad.data.readers.concepts_readers import read_dataset_from_npy
+from pyclad.metrics.base.roc_auc import RocAuc
+from pyclad.metrics.continual.final_step_average import FinalStepAverage
+from pyclad.metrics.continual.schedule_aware_forgetting_measure import ScheduleAwareForgettingMeasure
+from pyclad.metrics.continual.schedule_aware_forward_transfer import ScheduleAwareForwardTransfer
+from pyclad.metrics.continual.schedule_aware_new_task_acquisition import ScheduleAwareNewTaskAcquisition
+from pyclad.models.adapters.pyod_adapters import IsolationForestAdapter
+from pyclad.output.json_writer import JsonOutputWriter
+from pyclad.scenarios.concept_aware import ConceptAwareScenario
+from pyclad.strategies.baselines.naive import NaiveStrategy
+
+logging.basicConfig(level=logging.INFO, handlers=[logging.StreamHandler()])
+
+if __name__ == "__main__":
+    """
+    This example showcases step-schedule grouping: instead of one training step per concept,
+    consecutive concepts are merged into multi-concept training steps, while evaluation stays
+    per concept. The NSL-KDD scenario below has 5 concepts and the schedule "3-2" turns them
+    into 2 training steps (3 concepts, then 2), so the metric matrix becomes 2 x 5.
+
+    Ordering matters: concepts must already be in their final order before grouping, because
+    grouping merges *consecutive* concepts.
+    """
+    dataset = read_dataset_from_npy(
+        pathlib.Path("resources/nsl-kdd_random_anomalies_5_concepts_1000_per_cluster.npy"), dataset_name="NSL-KDD-R"
+    )
+
+    scheduled_dataset = apply_step_schedule(dataset, schedule="3-2")
+    print("Training steps:", [concept.name for concept in scheduled_dataset.train_concepts()])
+    print("Evaluated concepts:", [concept.name for concept in scheduled_dataset.test_concepts()])
+    print("First seen step:", scheduled_dataset.first_seen_step())
+
+    model = IsolationForestAdapter()
+    strategy = NaiveStrategy(model)
+
+    # Metrics that walk the diagonal (ContinualAverage, BackwardTransfer, ForwardTransfer,
+    # ForgettingMeasure) reject a rectangular matrix -- pass the schedule-aware ones instead.
+    callbacks = [
+        ConceptMetricCallback(
+            base_metric=RocAuc(),
+            summarized_metrics=[FinalStepAverage()],
+            schedule_aware_metrics=[
+                ScheduleAwareForgettingMeasure(),
+                ScheduleAwareForwardTransfer(),
+                ScheduleAwareNewTaskAcquisition(),
+            ],
+            first_seen_step=scheduled_dataset.first_seen_step(),
+        )
+    ]
+
+    scenario = ConceptAwareScenario(scheduled_dataset, strategy=strategy, callbacks=callbacks)
+    scenario.run()
+
+    output_writer = JsonOutputWriter(pathlib.Path("output_step_schedule.json"))
+    output_writer.write([model, scheduled_dataset, strategy, *callbacks])

--- a/examples/step_schedule_vision_example.py
+++ b/examples/step_schedule_vision_example.py
@@ -1,7 +1,9 @@
 import logging
 import pathlib
 
-from pyclad.callbacks.evaluation.concept_metric_evaluation import ConceptMetricCallback
+from pyclad.callbacks.evaluation.concept_metric_evaluation import (
+    ScheduleAwareConceptMetricCallback,
+)
 from pyclad.callbacks.evaluation.time_evaluation import TimeEvaluationCallback
 from pyclad.data.grouping import apply_step_schedule
 from pyclad.metrics.base.average_precision import AveragePrecision
@@ -20,7 +22,7 @@ from pyclad.output.json_writer import JsonOutputWriter
 from pyclad.scenarios.concept_incremental import ConceptIncrementalScenario
 from pyclad.strategies.baselines.naive import NaiveStrategy
 from pyclad.vision.callbacks.vision_pixel_concept_metric_callback import (
-    VisionPixelConceptMetricCallback,
+    ScheduleAwareVisionPixelConceptMetricCallback,
 )
 from pyclad.vision.data.readers.vision_reader import read_vision_dataset
 from pyclad.vision.metrics.pixel_aupro import PixelAUPRO
@@ -96,26 +98,26 @@ if __name__ == "__main__":
 
     callbacks = [
         # Image-level
-        ConceptMetricCallback(
+        ScheduleAwareConceptMetricCallback(
             base_metric=RocAuc(),
             summarized_metrics=summarized_metrics,
             schedule_aware_metrics=schedule_aware_metrics,
             first_seen_step=first_seen_step,
         ),
-        ConceptMetricCallback(
+        ScheduleAwareConceptMetricCallback(
             base_metric=AveragePrecision(),
             summarized_metrics=summarized_metrics,
             schedule_aware_metrics=schedule_aware_metrics,
             first_seen_step=first_seen_step,
         ),
         # Pixel-level
-        VisionPixelConceptMetricCallback(
+        ScheduleAwareVisionPixelConceptMetricCallback(
             base_metric=PixelRocAuc(),
             summarized_metrics=summarized_metrics,
             schedule_aware_metrics=schedule_aware_metrics,
             first_seen_step=first_seen_step,
         ),
-        VisionPixelConceptMetricCallback(
+        ScheduleAwareVisionPixelConceptMetricCallback(
             base_metric=PixelAUPRO(),
             summarized_metrics=summarized_metrics,
             schedule_aware_metrics=schedule_aware_metrics,

--- a/examples/step_schedule_vision_example.py
+++ b/examples/step_schedule_vision_example.py
@@ -1,0 +1,133 @@
+import logging
+import pathlib
+
+from pyclad.callbacks.evaluation.concept_metric_evaluation import ConceptMetricCallback
+from pyclad.callbacks.evaluation.time_evaluation import TimeEvaluationCallback
+from pyclad.data.grouping import apply_step_schedule
+from pyclad.metrics.base.average_precision import AveragePrecision
+from pyclad.metrics.base.roc_auc import RocAuc
+from pyclad.metrics.continual.final_step_average import FinalStepAverage
+from pyclad.metrics.continual.schedule_aware_forgetting_measure import (
+    ScheduleAwareForgettingMeasure,
+)
+from pyclad.metrics.continual.schedule_aware_forward_transfer import (
+    ScheduleAwareForwardTransfer,
+)
+from pyclad.metrics.continual.schedule_aware_new_task_acquisition import (
+    ScheduleAwareNewTaskAcquisition,
+)
+from pyclad.output.json_writer import JsonOutputWriter
+from pyclad.scenarios.concept_incremental import ConceptIncrementalScenario
+from pyclad.strategies.baselines.naive import NaiveStrategy
+from pyclad.vision.callbacks.vision_pixel_concept_metric_callback import (
+    VisionPixelConceptMetricCallback,
+)
+from pyclad.vision.data.readers.vision_reader import read_vision_dataset
+from pyclad.vision.metrics.pixel_aupro import PixelAUPRO
+from pyclad.vision.metrics.pixel_roc_auc import PixelRocAuc
+from pyclad.vision.models.rd4ad.config import RD4ADConfig
+from pyclad.vision.models.rd4ad.rd4ad import RD4AD
+
+logging.basicConfig(level=logging.INFO)
+
+STEP_SCHEDULE = "3x5"
+
+if __name__ == "__main__":
+    """
+    This example showcases CDAD-style step-schedule grouping on MVTec AD.
+
+    Instead of 15 training steps (one per category), the schedule "3x5" trains on five
+    consecutive steps holding three categories each. Evaluation stays per category, so the
+    metric matrix is 5 x 15 rather than 15 x 15.
+
+    Other schedules on MVTec's 15 categories: "14-1", "10-5", "10-1x5". On VisA's 12
+    categories, "8-1x4". The schedule must sum to the number of train concepts.
+    """
+    # 1. Read the benchmark. Concepts must already be in their final order before grouping,
+    #    since grouping merges *consecutive* concepts: ordering -> grouping -> first_seen_step.
+    dataset = read_vision_dataset(
+        root=pathlib.Path("resources/vision/mvtec_ad"),
+        benchmark="mvtec",
+        resize_to=(256, 256),
+        data_mode="numpy",
+        color_mode="rgb",
+        max_train_samples_per_category=50,
+        max_test_samples_per_category=50,
+    )
+
+    # 2. Group the training stream. Test concepts stay per category (group_test=False).
+    scheduled_dataset = apply_step_schedule(dataset, schedule=STEP_SCHEDULE)
+
+    print("Training steps:", [(c.name, c.data.shape[0]) for c in scheduled_dataset.train_concepts()])
+    print("Evaluated categories:", [c.name for c in scheduled_dataset.test_concepts()])
+    print("First seen step:", scheduled_dataset.first_seen_step())
+
+    model = RD4AD(
+        RD4ADConfig(
+            input_size=(256, 256),
+            backbone_name="resnet18",
+            pretrained_encoder=True,
+            freeze_encoder=True,
+            batch_size=16,
+            epochs=2,
+            learning_rate=5e-3,
+            score_smoothing_sigma=4.0,
+            score_mode="max",
+            threshold_quantile=0.99,
+            show_training_progress=True,
+        )
+    )
+    # Any strategy works -- grouping only changes what a training step contains. Naive makes
+    # the forgetting story easiest to read; swap in ReplayEnhancedStrategy to soften it.
+    strategy = NaiveStrategy(model)
+
+    # 3. Metrics. ContinualAverage, BackwardTransfer, ForwardTransfer and ForgettingMeasure
+    #    walk the diagonal or the triangles of the matrix and reject a rectangular one --
+    #    on a 5 x 15 matrix their formulas do not mean what they say. Use FinalStepAverage
+    #    (the A-AUROC of CDAD papers) plus the schedule-aware metrics, which take the step
+    #    at which each category first entered training.
+    summarized_metrics = [FinalStepAverage()]
+    schedule_aware_metrics = [
+        ScheduleAwareForgettingMeasure(),
+        ScheduleAwareForwardTransfer(),
+        ScheduleAwareNewTaskAcquisition(),
+    ]
+    first_seen_step = scheduled_dataset.first_seen_step()
+
+    callbacks = [
+        # Image-level
+        ConceptMetricCallback(
+            base_metric=RocAuc(),
+            summarized_metrics=summarized_metrics,
+            schedule_aware_metrics=schedule_aware_metrics,
+            first_seen_step=first_seen_step,
+        ),
+        ConceptMetricCallback(
+            base_metric=AveragePrecision(),
+            summarized_metrics=summarized_metrics,
+            schedule_aware_metrics=schedule_aware_metrics,
+            first_seen_step=first_seen_step,
+        ),
+        # Pixel-level
+        VisionPixelConceptMetricCallback(
+            base_metric=PixelRocAuc(),
+            summarized_metrics=summarized_metrics,
+            schedule_aware_metrics=schedule_aware_metrics,
+            first_seen_step=first_seen_step,
+        ),
+        VisionPixelConceptMetricCallback(
+            base_metric=PixelAUPRO(),
+            summarized_metrics=summarized_metrics,
+            schedule_aware_metrics=schedule_aware_metrics,
+            first_seen_step=first_seen_step,
+        ),
+        TimeEvaluationCallback(),
+    ]
+
+    scenario = ConceptIncrementalScenario(dataset=scheduled_dataset, strategy=strategy, callbacks=callbacks)
+    scenario.run()
+
+    # The grouped dataset reports the schedule, the train steps and first_seen_step in its
+    # own info(), so the output JSON is self-describing without assembling metadata by hand.
+    output_writer = JsonOutputWriter(pathlib.Path(f"output_step_schedule_mvtec_{STEP_SCHEDULE}.json"))
+    output_writer.write([model, scheduled_dataset, strategy, *callbacks])

--- a/src/pyclad/callbacks/evaluation/concept_metric_evaluation.py
+++ b/src/pyclad/callbacks/evaluation/concept_metric_evaluation.py
@@ -1,10 +1,11 @@
 from collections import defaultdict
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Union
 
 import numpy as np
 
 from pyclad.callbacks.callback import Callback
 from pyclad.data.concept import Concept
+from pyclad.data.grouping import StepScheduledConceptsDataset
 from pyclad.metrics.base.base_metric import BaseMetric
 from pyclad.metrics.continual.concepts_metric import (
     ConceptLevelMatrix,
@@ -14,24 +15,20 @@ from pyclad.metrics.continual.concepts_metric import (
 )
 from pyclad.output.output_writer import InfoProvider
 
+FirstSeenStepSource = Union[Mapping[str, int], StepScheduledConceptsDataset]
+
 
 class ConceptMetricCallback(Callback, InfoProvider):
     """Collects a base metric for every (training step, evaluated concept) pair.
 
-    Rows are training steps in the order they were learned, columns are evaluated concepts
-    in the order they were first evaluated. In the default setting both axes hold the same
-    concept names and the matrix is square (``N x N``).
+    Rows follow the order in which concepts were learned, columns the order in which they were
+    evaluated. With one concept per training step both axes hold the same names, columns are
+    aligned to the training order, and the matrix is square.
 
-    When training steps group several categories (see :mod:`pyclad.data.grouping`) the rows
-    are the grouped steps while the columns remain the original categories, so the matrix
-    becomes rectangular (``T x N``) and the axes no longer share names. Metrics that need to
-    know when each category entered training are passed via ``schedule_aware_metrics``
-    together with ``first_seen_step``.
-
-    :param schedule_aware_metrics: metrics computed as ``compute(matrix, first_seen_steps)``.
-    :param first_seen_step: category name -> index of the training step that first includes
-        it, typically ``StepScheduledConceptsDataset.first_seen_step()``. Required whenever
-        ``schedule_aware_metrics`` is non-empty.
+    When training steps group several concepts (see :mod:`pyclad.data.grouping`) the axes stop
+    sharing names: rows are the grouped steps while columns stay per concept, so the matrix is
+    rectangular. Metrics that need to know when each concept entered training live in
+    :class:`ScheduleAwareConceptMetricCallback`.
     """
 
     def __init__(
@@ -39,8 +36,6 @@ class ConceptMetricCallback(Callback, InfoProvider):
         base_metric: BaseMetric,
         summarized_metrics: Iterable[SummarizedMetric],
         stepwise_metrics: Iterable[StepwiseConceptMetric] = None,
-        schedule_aware_metrics: Iterable[ScheduleAwareMetric] = (),
-        first_seen_step: Optional[Mapping[str, int]] = None,
     ):
         self._base_metric: BaseMetric = base_metric
         self._metric_matrix: Dict[str, Dict[str, float]] = defaultdict(dict)
@@ -48,10 +43,6 @@ class ConceptMetricCallback(Callback, InfoProvider):
         self._evaluated_concepts: List[str] = []
         self._summarized_metrics = summarized_metrics
         self._stepwise_metrics = stepwise_metrics if stepwise_metrics is not None else []
-        self._schedule_aware_metrics: List[ScheduleAwareMetric] = list(schedule_aware_metrics)
-        self._first_seen_step = dict(first_seen_step) if first_seen_step is not None else None
-
-        validate_schedule_aware_configuration(self._schedule_aware_metrics, self._first_seen_step)
 
     def after_training(self, learned_concept: Concept):
         self._learned_concepts.append(learned_concept.name)
@@ -75,28 +66,115 @@ class ConceptMetricCallback(Callback, InfoProvider):
         if evaluated_concept.name not in self._evaluated_concepts:
             self._evaluated_concepts.append(evaluated_concept.name)
 
-    def info(self) -> Dict[str, Any]:
-        concept_level_matrix = build_dense_matrix(self._metric_matrix, self._learned_concepts, self._evaluated_concepts)
-        summarized_metrics = {m.name(): m.compute(concept_level_matrix) for m in self._summarized_metrics}
-        stepwise_metrics = {m.name(): m.compute(concept_level_matrix) for m in self._stepwise_metrics}
+    def column_order(self) -> List[str]:
+        """Concept order of the matrix columns, as actually used to build it."""
+        return resolve_column_order(self._learned_concepts, self._evaluated_concepts)
 
-        payload = {
-            "base_metric_name": self._base_metric.name(),
-            "metrics": summarized_metrics,
-            "stepwise_metrics": stepwise_metrics,
-            "concepts_order": self._learned_concepts,
-            "test_order": self._evaluated_concepts,
-            "metric_matrix": self._metric_matrix,
+    def dense_matrix(self) -> ConceptLevelMatrix:
+        return build_dense_matrix(self._metric_matrix, self._learned_concepts, self._evaluated_concepts)
+
+    def info(self) -> Dict[str, Any]:
+        concept_level_matrix = self.dense_matrix()
+        return {
+            f"concept_metric_callback_{self._base_metric.name()}": {
+                "base_metric_name": self._base_metric.name(),
+                "metrics": {m.name(): m.compute(concept_level_matrix) for m in self._summarized_metrics},
+                "stepwise_metrics": {m.name(): m.compute(concept_level_matrix) for m in self._stepwise_metrics},
+                "concepts_order": self._learned_concepts,
+                "test_order": self.column_order(),
+                "metric_matrix": self._metric_matrix,
+            }
         }
 
-        if self._first_seen_step is not None:
-            first_seen_steps = align_first_seen_steps(self._first_seen_step, self._evaluated_concepts)
-            payload["first_seen_step"] = dict(zip(self._evaluated_concepts, first_seen_steps))
-            payload["schedule_aware_metrics"] = {
-                m.name(): m.compute(concept_level_matrix, first_seen_steps) for m in self._schedule_aware_metrics
-            }
 
-        return {f"concept_metric_callback_{self._base_metric.name()}": payload}
+class ScheduleAwareConceptMetricCallback(ConceptMetricCallback):
+    """:class:`ConceptMetricCallback` that also reports metrics over a step-scheduled matrix.
+
+    Changes nothing about how the matrix is collected, only what is reported from it. Use it when
+    training steps group several concepts, so the matrix is rectangular and the square-only
+    metrics no longer apply.
+
+    :param schedule_aware_metrics: metrics computed as ``compute(matrix, first_seen_steps)``.
+    :param first_seen_step: either a :class:`~pyclad.data.grouping.StepScheduledConceptsDataset`,
+        whose mapping is then read at reporting time rather than copied at construction, or a
+        plain ``{concept: step}`` mapping for a stream not built by
+        :func:`~pyclad.data.grouping.apply_step_schedule`.
+    """
+
+    def __init__(
+        self,
+        base_metric: BaseMetric,
+        summarized_metrics: Iterable[SummarizedMetric],
+        stepwise_metrics: Iterable[StepwiseConceptMetric] = None,
+        schedule_aware_metrics: Iterable[ScheduleAwareMetric] = (),
+        first_seen_step: Optional[FirstSeenStepSource] = None,
+    ):
+        super().__init__(base_metric, summarized_metrics, stepwise_metrics)
+        self._schedule_aware = ScheduleAwareSupport(schedule_aware_metrics, first_seen_step)
+
+    def info(self) -> Dict[str, Any]:
+        payload = super().info()
+        if not payload:
+            return payload
+        next(iter(payload.values())).update(
+            self._schedule_aware.payload_additions(self.dense_matrix(), self.column_order())
+        )
+        return payload
+
+
+class ScheduleAwareSupport:
+    """The extra reporting that schedule-aware callbacks layer onto a base callback.
+
+    Kept out of the callbacks themselves so the image-level and pixel-level variants -- and any
+    base callback added later -- share one implementation instead of a copy each.
+    """
+
+    def __init__(
+        self,
+        metrics: Iterable[ScheduleAwareMetric],
+        first_seen_step: Optional[FirstSeenStepSource],
+    ):
+        self._metrics: List[ScheduleAwareMetric] = list(metrics)
+        if not self._metrics:
+            raise ValueError("schedule_aware_metrics must not be empty; use the plain callback when there are none.")
+        if first_seen_step is None:
+            raise ValueError(
+                "schedule_aware_metrics require first_seen_step, mapping every evaluated concept to "
+                "the training step that first includes it. Pass the StepScheduledConceptsDataset "
+                "returned by pyclad.data.grouping.apply_step_schedule, or an explicit mapping."
+            )
+        self._first_seen_step = first_seen_step
+
+    def first_seen_step(self) -> Dict[str, int]:
+        """Resolve the mapping, reading it off the dataset when one was given."""
+        if isinstance(self._first_seen_step, StepScheduledConceptsDataset):
+            return self._first_seen_step.first_seen_step()
+        return dict(self._first_seen_step)
+
+    def payload_additions(self, metric_matrix: ConceptLevelMatrix, evaluated_concepts: Sequence[str]) -> Dict[str, Any]:
+        first_seen_steps = align_first_seen_steps(self.first_seen_step(), evaluated_concepts)
+        return {
+            "first_seen_step": dict(zip(evaluated_concepts, first_seen_steps)),
+            "schedule_aware_metrics": {
+                metric.name(): metric.compute(metric_matrix, first_seen_steps) for metric in self._metrics
+            },
+        }
+
+
+def resolve_column_order(train_order: Sequence[str], test_order: Sequence[str]) -> List[str]:
+    """Return the concept order the matrix columns should follow.
+
+    When both axes hold the same concepts the matrix is square and its cells are read by position:
+    ``[i][i]`` must mean "concept *i* evaluated after training on concept *i*". The two orders are
+    tracked independently, so columns are aligned to the training order to keep that true even
+    when a dataset evaluates its concepts in a different order than it trains them.
+
+    When the axes differ -- grouped training steps against per-concept evaluation -- there is no
+    positional correspondence to preserve, and the evaluation order is kept.
+    """
+    if set(train_order) == set(test_order):
+        return list(train_order)
+    return list(test_order)
 
 
 def build_dense_matrix(
@@ -106,19 +184,20 @@ def build_dense_matrix(
 ) -> ConceptLevelMatrix:
     """Turn the sparse ``{learned: {evaluated: value}}`` mapping into a dense matrix.
 
-    Rows follow ``train_order``, columns follow ``test_order``. The scenario evaluates every
-    test concept after every training step, so a missing cell means a broken run rather than
-    a legitimately unknown value.
+    Rows follow ``train_order``; columns follow :func:`resolve_column_order`. The scenario
+    evaluates every test concept after every training step, so a missing cell means a broken run
+    rather than a legitimately unknown value.
 
     :raises ValueError: when any (training step, evaluated concept) pair is missing.
     """
     if len(train_order) == 0 or len(test_order) == 0:
         return [[]]
 
+    column_order = resolve_column_order(train_order, test_order)
     values: ConceptLevelMatrix = []
     for learned_concept in train_order:
         row = []
-        for evaluated_concept in test_order:
+        for evaluated_concept in column_order:
             if evaluated_concept not in metric_matrix.get(learned_concept, {}):
                 raise ValueError(
                     f"Concept {evaluated_concept!r} was not evaluated after training step "
@@ -130,27 +209,16 @@ def build_dense_matrix(
 
 
 def align_first_seen_steps(first_seen_step: Mapping[str, int], test_order: Sequence[str]) -> List[int]:
-    """Order a ``{category: first seen step}`` mapping to match the matrix columns.
+    """Order a ``{concept: first seen step}`` mapping to match the matrix columns.
 
     :raises ValueError: when an evaluated concept is absent from the mapping.
     """
     missing = [name for name in test_order if name not in first_seen_step]
     if missing:
         raise ValueError(
-            f"first_seen_step is missing an entry for evaluated concepts {missing}. "
-            "It must cover every evaluated concept; build it with "
-            "pyclad.data.grouping.compute_first_seen_step."
+            f"first_seen_step is missing an entry for evaluated concepts {missing}. It must cover "
+            "every evaluated concept. Note that schedule-aware metrics describe the rectangular "
+            "matrix produced with group_test=False; with group_test=True both axes hold grouped "
+            "step names and these metrics do not apply."
         )
     return [int(first_seen_step[name]) for name in test_order]
-
-
-def validate_schedule_aware_configuration(
-    schedule_aware_metrics: Sequence[ScheduleAwareMetric], first_seen_step: Optional[Mapping[str, int]]
-) -> None:
-    """:raises ValueError: when schedule-aware metrics are requested without a mapping to feed them."""
-    if schedule_aware_metrics and first_seen_step is None:
-        raise ValueError(
-            "schedule_aware_metrics require first_seen_step, mapping every evaluated concept "
-            "to the training step that first includes it. Use "
-            "StepScheduledConceptsDataset.first_seen_step()."
-        )

--- a/src/pyclad/callbacks/evaluation/concept_metric_evaluation.py
+++ b/src/pyclad/callbacks/evaluation/concept_metric_evaluation.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
 
 import numpy as np
 
@@ -8,6 +8,7 @@ from pyclad.data.concept import Concept
 from pyclad.metrics.base.base_metric import BaseMetric
 from pyclad.metrics.continual.concepts_metric import (
     ConceptLevelMatrix,
+    ScheduleAwareMetric,
     StepwiseConceptMetric,
     SummarizedMetric,
 )
@@ -15,17 +16,42 @@ from pyclad.output.output_writer import InfoProvider
 
 
 class ConceptMetricCallback(Callback, InfoProvider):
+    """Collects a base metric for every (training step, evaluated concept) pair.
+
+    Rows are training steps in the order they were learned, columns are evaluated concepts
+    in the order they were first evaluated. In the default setting both axes hold the same
+    concept names and the matrix is square (``N x N``).
+
+    When training steps group several categories (see :mod:`pyclad.data.grouping`) the rows
+    are the grouped steps while the columns remain the original categories, so the matrix
+    becomes rectangular (``T x N``) and the axes no longer share names. Metrics that need to
+    know when each category entered training are passed via ``schedule_aware_metrics``
+    together with ``first_seen_step``.
+
+    :param schedule_aware_metrics: metrics computed as ``compute(matrix, first_seen_steps)``.
+    :param first_seen_step: category name -> index of the training step that first includes
+        it, typically ``StepScheduledConceptsDataset.first_seen_step()``. Required whenever
+        ``schedule_aware_metrics`` is non-empty.
+    """
+
     def __init__(
         self,
         base_metric: BaseMetric,
         summarized_metrics: Iterable[SummarizedMetric],
         stepwise_metrics: Iterable[StepwiseConceptMetric] = None,
+        schedule_aware_metrics: Iterable[ScheduleAwareMetric] = (),
+        first_seen_step: Optional[Mapping[str, int]] = None,
     ):
         self._base_metric: BaseMetric = base_metric
         self._metric_matrix: Dict[str, Dict[str, float]] = defaultdict(dict)
         self._learned_concepts: List[str] = []
+        self._evaluated_concepts: List[str] = []
         self._summarized_metrics = summarized_metrics
         self._stepwise_metrics = stepwise_metrics if stepwise_metrics is not None else []
+        self._schedule_aware_metrics: List[ScheduleAwareMetric] = list(schedule_aware_metrics)
+        self._first_seen_step = dict(first_seen_step) if first_seen_step is not None else None
+
+        validate_schedule_aware_configuration(self._schedule_aware_metrics, self._first_seen_step)
 
     def after_training(self, learned_concept: Concept):
         self._learned_concepts.append(learned_concept.name)
@@ -46,32 +72,85 @@ class ConceptMetricCallback(Callback, InfoProvider):
         metric_value = self._base_metric.compute(anomaly_scores=anomaly_scores, y_true=y_true, y_pred=y_pred)
         self._metric_matrix[self._learned_concepts[-1]][evaluated_concept.name] = metric_value
 
+        if evaluated_concept.name not in self._evaluated_concepts:
+            self._evaluated_concepts.append(evaluated_concept.name)
+
     def info(self) -> Dict[str, Any]:
-        concept_level_matrix = self._transform_to_ordered_matrix(self._metric_matrix, self._learned_concepts)
+        concept_level_matrix = build_dense_matrix(self._metric_matrix, self._learned_concepts, self._evaluated_concepts)
         summarized_metrics = {m.name(): m.compute(concept_level_matrix) for m in self._summarized_metrics}
         stepwise_metrics = {m.name(): m.compute(concept_level_matrix) for m in self._stepwise_metrics}
 
-        return {
-            f"concept_metric_callback_{self._base_metric.name()}": {
-                "base_metric_name": self._base_metric.name(),
-                "metrics": summarized_metrics,
-                "stepwise_metrics": stepwise_metrics,
-                "concepts_order": self._learned_concepts,
-                "metric_matrix": self._metric_matrix,
-            }
+        payload = {
+            "base_metric_name": self._base_metric.name(),
+            "metrics": summarized_metrics,
+            "stepwise_metrics": stepwise_metrics,
+            "concepts_order": self._learned_concepts,
+            "test_order": self._evaluated_concepts,
+            "metric_matrix": self._metric_matrix,
         }
 
-    @staticmethod
-    def _transform_to_ordered_matrix(
-        metric_matrix: Dict[str, Dict[str, float]], concepts_order: List[str]
-    ) -> ConceptLevelMatrix:
-        if len(concepts_order) == 0:
-            return [[]]
-        values = []
+        if self._first_seen_step is not None:
+            first_seen_steps = align_first_seen_steps(self._first_seen_step, self._evaluated_concepts)
+            payload["first_seen_step"] = dict(zip(self._evaluated_concepts, first_seen_steps))
+            payload["schedule_aware_metrics"] = {
+                m.name(): m.compute(concept_level_matrix, first_seen_steps) for m in self._schedule_aware_metrics
+            }
 
-        for learned_concept in concepts_order:
-            values.append([])
-            for evaluated_concept in concepts_order:
-                values[-1].append(metric_matrix[learned_concept][evaluated_concept])
+        return {f"concept_metric_callback_{self._base_metric.name()}": payload}
 
-        return values
+
+def build_dense_matrix(
+    metric_matrix: Mapping[str, Mapping[str, float]],
+    train_order: Sequence[str],
+    test_order: Sequence[str],
+) -> ConceptLevelMatrix:
+    """Turn the sparse ``{learned: {evaluated: value}}`` mapping into a dense matrix.
+
+    Rows follow ``train_order``, columns follow ``test_order``. The scenario evaluates every
+    test concept after every training step, so a missing cell means a broken run rather than
+    a legitimately unknown value.
+
+    :raises ValueError: when any (training step, evaluated concept) pair is missing.
+    """
+    if len(train_order) == 0 or len(test_order) == 0:
+        return [[]]
+
+    values: ConceptLevelMatrix = []
+    for learned_concept in train_order:
+        row = []
+        for evaluated_concept in test_order:
+            if evaluated_concept not in metric_matrix.get(learned_concept, {}):
+                raise ValueError(
+                    f"Concept {evaluated_concept!r} was not evaluated after training step "
+                    f"{learned_concept!r}; the concept-level matrix is incomplete."
+                )
+            row.append(metric_matrix[learned_concept][evaluated_concept])
+        values.append(row)
+    return values
+
+
+def align_first_seen_steps(first_seen_step: Mapping[str, int], test_order: Sequence[str]) -> List[int]:
+    """Order a ``{category: first seen step}`` mapping to match the matrix columns.
+
+    :raises ValueError: when an evaluated concept is absent from the mapping.
+    """
+    missing = [name for name in test_order if name not in first_seen_step]
+    if missing:
+        raise ValueError(
+            f"first_seen_step is missing an entry for evaluated concepts {missing}. "
+            "It must cover every evaluated concept; build it with "
+            "pyclad.data.grouping.compute_first_seen_step."
+        )
+    return [int(first_seen_step[name]) for name in test_order]
+
+
+def validate_schedule_aware_configuration(
+    schedule_aware_metrics: Sequence[ScheduleAwareMetric], first_seen_step: Optional[Mapping[str, int]]
+) -> None:
+    """:raises ValueError: when schedule-aware metrics are requested without a mapping to feed them."""
+    if schedule_aware_metrics and first_seen_step is None:
+        raise ValueError(
+            "schedule_aware_metrics require first_seen_step, mapping every evaluated concept "
+            "to the training step that first includes it. Use "
+            "StepScheduledConceptsDataset.first_seen_step()."
+        )

--- a/src/pyclad/data/grouping.py
+++ b/src/pyclad/data/grouping.py
@@ -1,0 +1,326 @@
+"""Step-schedule grouping of concepts into multi-category training steps.
+
+Instead of the default "one category = one training step", consecutive concepts are
+merged into a single training step according to a schedule such as ``"14-1"``,
+``"10-5"``, ``"3x5"`` or ``"10-1x5"``. Training then walks over ``T`` steps while
+evaluation stays per category (``N``), which is how CDAD-style continual anomaly
+detection papers report results.
+
+The side effect is that the concept-level metric matrix stops being square: it becomes
+``T x N`` with ``T < N``. Metrics that assume a square matrix (``ContinualAverage``,
+``BackwardTransfer``, ``ForwardTransfer``, ``ForgettingMeasure``) reject such a matrix;
+use the schedule-aware metrics in :mod:`pyclad.metrics.continual` instead.
+
+Order of operations matters: **ordering -> grouping -> first_seen_step**. Concepts must
+already be in their final order before grouping, and ``first_seen_step`` is derived from
+the category order *before* the merge.
+"""
+
+import re
+from dataclasses import fields, replace
+from typing import Dict, List, Optional, Sequence, Union
+
+import numpy as np
+
+from pyclad.data.concept import Concept
+from pyclad.data.datasets.concepts_dataset import ConceptsDataset
+
+StepSchedule = List[int]
+StepScheduleLike = Union[str, Sequence[int]]
+
+_SCHEDULE_TOKEN_PATTERN = re.compile(r"^\s*(\d+)\s*(?:[x×*]\s*(\d+))?\s*$")
+
+
+class StepScheduledConceptsDataset(ConceptsDataset):
+    """A :class:`ConceptsDataset` whose train concepts are grouped into scheduled steps.
+
+    Carries the schedule metadata needed to interpret the resulting ``T x N`` metric
+    matrix, so that callbacks and metrics do not have to be wired up by hand:
+
+    * :meth:`schedule` -- class counts per training step, e.g. ``[14, 1]``.
+    * :meth:`category_order` -- category order *before* grouping (length ``N``).
+    * :meth:`first_seen_step` -- category name -> index of the training step that first
+      includes it. This is what the schedule-aware metrics consume.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        train_concepts: List[Concept],
+        test_concepts: List[Concept],
+        schedule: StepSchedule,
+        category_order: Sequence[str],
+        group_test: bool = False,
+    ):
+        super().__init__(name=name, train_concepts=train_concepts, test_concepts=test_concepts)
+        self._schedule = list(schedule)
+        self._category_order = list(category_order)
+        self._group_test = bool(group_test)
+        self._first_seen_step = dict(
+            zip(self._category_order, compute_first_seen_step(self._category_order, self._schedule))
+        )
+
+    def schedule(self) -> StepSchedule:
+        return list(self._schedule)
+
+    def category_order(self) -> List[str]:
+        """Category order before grouping, i.e. the training order of the original concepts."""
+        return list(self._category_order)
+
+    def first_seen_step(self) -> Dict[str, int]:
+        """Map category name -> index of the training step that first includes it."""
+        return dict(self._first_seen_step)
+
+    def group_test(self) -> bool:
+        return self._group_test
+
+    def additional_info(self) -> Dict[str, object]:
+        return {
+            **super().additional_info(),
+            "step_schedule": format_step_schedule(self._schedule),
+            "step_schedule_parsed": self.schedule(),
+            "group_test": self._group_test,
+            "category_order": self.category_order(),
+            "train_steps": [concept.name for concept in self.train_concepts()],
+            "first_seen_step": self.first_seen_step(),
+        }
+
+
+def parse_step_schedule(spec: StepScheduleLike, total_categories: Optional[int] = None) -> StepSchedule:
+    """Parse a step-schedule spec into an explicit list of class counts per step.
+
+    Accepted string forms, tokens separated by ``-``, where ``NxM`` repeats ``N`` ``M``
+    times (``×`` and ``*`` are accepted in place of ``x``):
+
+    * ``"14-1"`` -> ``[14, 1]``
+    * ``"10-5"`` -> ``[10, 5]``
+    * ``"3x5"`` -> ``[3, 3, 3, 3, 3]``
+    * ``"10-1x5"`` -> ``[10, 1, 1, 1, 1, 1]``
+
+    A sequence of ints is returned as an equivalent list after validation.
+
+    :param spec: schedule string or explicit sequence of class counts.
+    :param total_categories: when given, the schedule must sum to exactly this value.
+    :raises ValueError: on an empty, malformed, or non-positive schedule, or when the
+        schedule does not sum to ``total_categories``.
+    """
+    schedule = _parse_schedule_string(spec) if isinstance(spec, str) else [int(value) for value in spec]
+
+    if not schedule:
+        raise ValueError(f"Step schedule must contain at least one step, got {spec!r}.")
+    if any(step <= 0 for step in schedule):
+        raise ValueError(f"Step schedule entries must be positive, got {schedule}.")
+    if total_categories is not None and sum(schedule) != total_categories:
+        raise ValueError(f"Step schedule {schedule} sums to {sum(schedule)}, expected {total_categories}.")
+
+    return schedule
+
+
+def format_step_schedule(schedule: Sequence[int]) -> str:
+    """Render a parsed schedule back into its compact string form, e.g. ``[10, 1, 1, 1]`` -> ``"10-1x3"``."""
+    parts: List[str] = []
+    index = 0
+    while index < len(schedule):
+        run_end = index
+        while run_end < len(schedule) and schedule[run_end] == schedule[index]:
+            run_end += 1
+        run_length = run_end - index
+        parts.append(f"{schedule[index]}x{run_length}" if run_length > 1 else str(schedule[index]))
+        index = run_end
+    return "-".join(parts)
+
+
+def group_concepts_by_schedule(
+    concepts: Sequence[Concept],
+    schedule: StepScheduleLike,
+    name_prefix: str = "step",
+    name_mode: str = "indexed",
+    name_separator: str = "+",
+) -> List[Concept]:
+    """Merge consecutive concepts into one concept per scheduled step.
+
+    Merging concatenates every array-valued field along the batch axis and preserves the
+    concrete concept class, so a :class:`~pyclad.vision.data.vision_concept.VisionConcept`
+    keeps its ``masks`` aligned with ``data``.
+
+    :param concepts: ordered concepts, one per original category.
+    :param schedule: class counts per step; must sum to ``len(concepts)``.
+    :param name_mode: ``"indexed"`` names steps ``{name_prefix}_{i}``, ``"joined"`` joins
+        the original category names with ``name_separator``.
+    :raises ValueError: when the schedule does not match the concept count, on an unknown
+        ``name_mode``, or when concepts within a step cannot be merged.
+    """
+    if name_mode not in {"indexed", "joined"}:
+        raise ValueError(f"name_mode must be 'indexed' or 'joined', got {name_mode!r}.")
+
+    parsed = parse_step_schedule(schedule)
+    if sum(parsed) != len(concepts):
+        raise ValueError(f"Schedule sum ({sum(parsed)}) does not match number of concepts ({len(concepts)}).")
+
+    grouped: List[Concept] = []
+    cursor = 0
+    for step_index, step_size in enumerate(parsed):
+        chunk = list(concepts[cursor : cursor + step_size])
+        cursor += step_size
+
+        if name_mode == "joined":
+            group_name = name_separator.join(concept.name for concept in chunk)
+        else:
+            group_name = f"{name_prefix}_{step_index}"
+
+        grouped.append(_merge_concepts(chunk, group_name))
+
+    return grouped
+
+
+def apply_step_schedule(
+    dataset: ConceptsDataset,
+    schedule: StepScheduleLike,
+    group_test: bool = False,
+    dataset_name: Optional[str] = None,
+    name_mode: str = "indexed",
+    name_separator: str = "+",
+) -> StepScheduledConceptsDataset:
+    """Group a dataset's concepts according to ``schedule``.
+
+    Train concepts are always grouped. Test concepts are kept per category unless
+    ``group_test=True``, so that evaluation still reports per-class metrics (the CDAD
+    convention) and the metric matrix is ``T x N``.
+
+    The dataset must already be in its final concept order -- grouping merges *consecutive*
+    concepts, so any reordering has to happen first.
+
+    :param group_test: when True, test concepts are grouped with the same schedule, which
+        requires them to align 1:1 with the train concepts and yields a ``T x T`` matrix.
+        That is a different experiment from the ``T x N`` one; do not mix the two.
+    :raises ValueError: when the schedule does not sum to the number of train concepts, or
+        when ``group_test=True`` and the train/test concepts do not align.
+    """
+    train_concepts = dataset.train_concepts()
+    parsed = parse_step_schedule(schedule, total_categories=len(train_concepts))
+    category_order = [concept.name for concept in train_concepts]
+
+    grouped_train = group_concepts_by_schedule(
+        concepts=train_concepts,
+        schedule=parsed,
+        name_mode=name_mode,
+        name_separator=name_separator,
+    )
+
+    test_concepts = dataset.test_concepts()
+    if group_test:
+        if len(test_concepts) != len(train_concepts):
+            raise ValueError(
+                "group_test=True requires test concepts to align 1:1 with train concepts "
+                f"(got {len(test_concepts)} test vs {len(train_concepts)} train)."
+            )
+        resolved_test = group_concepts_by_schedule(
+            concepts=test_concepts,
+            schedule=parsed,
+            name_mode=name_mode,
+            name_separator=name_separator,
+        )
+    else:
+        resolved_test = list(test_concepts)
+
+    return StepScheduledConceptsDataset(
+        name=dataset_name or f"{dataset.name()}__{format_step_schedule(parsed)}",
+        train_concepts=grouped_train,
+        test_concepts=resolved_test,
+        schedule=parsed,
+        category_order=category_order,
+        group_test=group_test,
+    )
+
+
+def compute_first_seen_step(ordered_concept_names: Sequence[str], schedule: StepScheduleLike) -> List[int]:
+    """Return, for each category, the index of the training step that first includes it.
+
+    ``ordered_concept_names`` is the per-category training order (length ``N``) *before*
+    grouping. The returned list has the same length and order.
+
+    For MVTec with ``"14-1"`` and alphabetical ordering the result is
+    ``[0] * 14 + [1]`` -- everything but ``zipper`` enters training at step 0.
+
+    :raises ValueError: when the schedule does not sum to ``len(ordered_concept_names)``.
+    """
+    parsed = parse_step_schedule(schedule, total_categories=len(ordered_concept_names))
+
+    first_seen: List[int] = []
+    for step_index, step_size in enumerate(parsed):
+        first_seen.extend([step_index] * step_size)
+    return first_seen
+
+
+def first_seen_step_for_test_order(
+    ordered_concept_names: Sequence[str],
+    schedule: StepScheduleLike,
+    test_order: Sequence[str],
+) -> List[int]:
+    """Re-align first-seen step indices to an arbitrary evaluation (column) order.
+
+    :param ordered_concept_names: training order before grouping.
+    :param test_order: column order used by the evaluation callback.
+    :raises KeyError: when a name in ``test_order`` is absent from ``ordered_concept_names``.
+    """
+    name_to_step = dict(zip(ordered_concept_names, compute_first_seen_step(ordered_concept_names, schedule)))
+
+    aligned: List[int] = []
+    for name in test_order:
+        if name not in name_to_step:
+            raise KeyError(
+                f"Test concept {name!r} is not present in the training order; its first-seen step is unknown."
+            )
+        aligned.append(name_to_step[name])
+    return aligned
+
+
+def _parse_schedule_string(spec: str) -> StepSchedule:
+    if not spec.strip():
+        raise ValueError("Step schedule string is empty.")
+
+    schedule: StepSchedule = []
+    for raw_token in spec.split("-"):
+        match = _SCHEDULE_TOKEN_PATTERN.match(raw_token)
+        if match is None:
+            raise ValueError(
+                f"Invalid step-schedule token {raw_token!r} in {spec!r}. Expected 'N' or 'NxM', e.g. '14' or '3x5'."
+            )
+        size = int(match.group(1))
+        repeat = int(match.group(2)) if match.group(2) is not None else 1
+        if size <= 0 or repeat <= 0:
+            raise ValueError(f"Step-schedule token {raw_token!r} in {spec!r} must use positive numbers.")
+        schedule.extend([size] * repeat)
+    return schedule
+
+
+def _merge_concepts(chunk: Sequence[Concept], group_name: str) -> Concept:
+    """Merge concepts of one step, preserving their concrete class and array fields."""
+    first = chunk[0]
+    if len(chunk) == 1:
+        return replace(first, name=group_name)
+
+    concept_type = type(first)
+    for concept in chunk[1:]:
+        if type(concept) is not concept_type:
+            raise ValueError(
+                f"Cannot group concepts of different type within one step: "
+                f"{concept_type.__name__} and {type(concept).__name__}."
+            )
+
+    merged_fields = {}
+    for field in fields(concept_type):
+        if field.name == "name":
+            continue
+        values = [getattr(concept, field.name) for concept in chunk]
+        if all(value is None for value in values):
+            merged_fields[field.name] = None
+        elif any(value is None for value in values):
+            raise ValueError(
+                f"Cannot group concepts where some define {field.name!r} and others do not: "
+                f"{[concept.name for concept in chunk]}."
+            )
+        else:
+            merged_fields[field.name] = np.concatenate([np.asarray(value) for value in values], axis=0)
+
+    return concept_type(name=group_name, **merged_fields)

--- a/src/pyclad/data/grouping.py
+++ b/src/pyclad/data/grouping.py
@@ -68,7 +68,20 @@ class StepScheduledConceptsDataset(ConceptsDataset):
         return list(self._category_order)
 
     def first_seen_step(self) -> Dict[str, int]:
-        """Map category name -> index of the training step that first includes it."""
+        """Map category name -> index of the training step that first includes it.
+
+        :raises ValueError: when ``group_test=True``. The mapping is keyed by the original
+            category names, but grouped test concepts are named after their step, so the two
+            share no names. Schedule-aware metrics describe the rectangular matrix that only
+            ``group_test=False`` produces; with ``group_test=True`` both axes collapse to the
+            same T steps and the asymmetry they measure no longer exists.
+        """
+        if self._group_test:
+            raise ValueError(
+                f"Dataset {self.name()!r} was grouped with group_test=True, so its test concepts are "
+                "grouped steps rather than categories and first_seen_step does not apply. "
+                "Schedule-aware metrics need group_test=False."
+            )
         return dict(self._first_seen_step)
 
     def group_test(self) -> bool:
@@ -157,12 +170,13 @@ def group_concepts_by_schedule(
     if sum(parsed) != len(concepts):
         raise ValueError(f"Schedule sum ({sum(parsed)}) does not match number of concepts ({len(concepts)}).")
 
-    grouped: List[Concept] = []
-    cursor = 0
-    for step_index, step_size in enumerate(parsed):
-        chunk = list(concepts[cursor : cursor + step_size])
-        cursor += step_size
+    positions = _first_seen_index_per_position(parsed)
+    chunks: List[List[Concept]] = [[] for _ in parsed]
+    for position, concept in enumerate(concepts):
+        chunks[positions[position]].append(concept)
 
+    grouped: List[Concept] = []
+    for step_index, chunk in enumerate(chunks):
         if name_mode == "joined":
             group_name = name_separator.join(concept.name for concept in chunk)
         else:
@@ -209,10 +223,11 @@ def apply_step_schedule(
 
     test_concepts = dataset.test_concepts()
     if group_test:
-        if len(test_concepts) != len(train_concepts):
+        test_names = [concept.name for concept in test_concepts]
+        if test_names != category_order:
             raise ValueError(
-                "group_test=True requires test concepts to align 1:1 with train concepts "
-                f"(got {len(test_concepts)} test vs {len(train_concepts)} train)."
+                "group_test=True requires test concepts to align 1:1 with train concepts, in the "
+                f"same order. Train concepts: {category_order}. Test concepts: {test_names}."
             )
         resolved_test = group_concepts_by_schedule(
             concepts=test_concepts,
@@ -245,11 +260,7 @@ def compute_first_seen_step(ordered_concept_names: Sequence[str], schedule: Step
     :raises ValueError: when the schedule does not sum to ``len(ordered_concept_names)``.
     """
     parsed = parse_step_schedule(schedule, total_categories=len(ordered_concept_names))
-
-    first_seen: List[int] = []
-    for step_index, step_size in enumerate(parsed):
-        first_seen.extend([step_index] * step_size)
-    return first_seen
+    return _first_seen_index_per_position(parsed)
 
 
 def first_seen_step_for_test_order(
@@ -258,6 +269,9 @@ def first_seen_step_for_test_order(
     test_order: Sequence[str],
 ) -> List[int]:
     """Re-align first-seen step indices to an arbitrary evaluation (column) order.
+
+    The callbacks in this library align the mapping themselves, so this helper exists for
+    callers that build a concept-level matrix outside pyCLAD and need the same alignment.
 
     :param ordered_concept_names: training order before grouping.
     :param test_order: column order used by the evaluation callback.
@@ -273,6 +287,18 @@ def first_seen_step_for_test_order(
             )
         aligned.append(name_to_step[name])
     return aligned
+
+
+def _first_seen_index_per_position(schedule: StepSchedule) -> List[int]:
+    """Map each position in a merged sequence to the step it lands in.
+
+    Shared by :func:`compute_first_seen_step` and :func:`group_concepts_by_schedule` so the two
+    cannot disagree about where a schedule's chunk boundaries fall.
+    """
+    positions: List[int] = []
+    for step_index, step_size in enumerate(schedule):
+        positions.extend([step_index] * step_size)
+    return positions
 
 
 def _parse_schedule_string(spec: str) -> StepSchedule:
@@ -295,7 +321,13 @@ def _parse_schedule_string(spec: str) -> StepSchedule:
 
 
 def _merge_concepts(chunk: Sequence[Concept], group_name: str) -> Concept:
-    """Merge concepts of one step, preserving their concrete class and array fields."""
+    """Merge concepts of one step, preserving their concrete class and array fields.
+
+    Contract: every field of a :class:`Concept` other than ``name`` is either ``None`` or an
+    array whose first axis is the batch, so merging concatenates it along that axis. This holds
+    for ``Concept`` and :class:`~pyclad.vision.data.vision_concept.VisionConcept`; a subclass
+    adding a scalar or per-concept field would need its own merge rule here.
+    """
     first = chunk[0]
     if len(chunk) == 1:
         return replace(first, name=group_name)

--- a/src/pyclad/metrics/continual/average_continual.py
+++ b/src/pyclad/metrics/continual/average_continual.py
@@ -3,12 +3,14 @@ import numpy as np
 from pyclad.metrics.continual.concepts_metric import (
     ConceptLevelMatrix,
     SummarizedMetric,
+    validate_square_matrix,
 )
 
 
 class ContinualAverage(SummarizedMetric):
 
     def compute(self, metric_matrix: ConceptLevelMatrix) -> float:
+        validate_square_matrix(metric_matrix, self.name())
         concepts_no = len(metric_matrix)
         if concepts_no == 0:
             return 0

--- a/src/pyclad/metrics/continual/backward_transfer.py
+++ b/src/pyclad/metrics/continual/backward_transfer.py
@@ -3,11 +3,13 @@ import numpy as np
 from pyclad.metrics.continual.concepts_metric import (
     ConceptLevelMatrix,
     SummarizedMetric,
+    validate_square_matrix,
 )
 
 
 class BackwardTransfer(SummarizedMetric):
     def compute(self, metric_matrix: ConceptLevelMatrix) -> float:
+        validate_square_matrix(metric_matrix, self.name())
         concepts_no = len(metric_matrix)
 
         values = []

--- a/src/pyclad/metrics/continual/concepts_metric.py
+++ b/src/pyclad/metrics/continual/concepts_metric.py
@@ -1,6 +1,8 @@
 import abc
 from typing import List, Sequence, Tuple
 
+import numpy as np
+
 ConceptLevelMatrix = List[List[float]]  # ConceptLevelMatrix[learned_concept][evaluated_concept]
 
 
@@ -59,8 +61,9 @@ def validate_square_matrix(metric_matrix: ConceptLevelMatrix, metric_name: str) 
     produced by a step schedule they would silently return a number computed over cells
     that do not mean what the formula assumes.
 
-    :raises ValueError: when the matrix has rows of unequal length, or has both rows and
-        columns but is not square.
+    :raises ValueError: when the matrix has rows of unequal length, or is non-empty and not
+        square. An empty matrix (``[]``) is accepted; ``[[]]`` is not, since one row with no
+        columns is not square.
     """
     row_lengths = {len(row) for row in metric_matrix}
     if len(row_lengths) > 1:
@@ -70,7 +73,7 @@ def validate_square_matrix(metric_matrix: ConceptLevelMatrix, metric_name: str) 
         )
 
     rows, columns = matrix_shape(metric_matrix)
-    if rows > 0 and columns > 0 and rows != columns:
+    if rows > 0 and rows != columns:
         raise ValueError(
             f"{metric_name} requires a square concept-level matrix, got {rows}x{columns}. "
             "A rectangular matrix comes from step-scheduled training, where rows are training "
@@ -97,3 +100,8 @@ def validate_first_seen_steps(
                 f"{metric_name}: first_seen_steps[{column}] = {first_seen} is out of range "
                 f"for a matrix with {rows} training steps."
             )
+
+
+def is_nan(value: float) -> bool:
+    """True when ``value`` is NaN. Metric matrices carry NaN where a base metric was undefined."""
+    return bool(np.isnan(value))

--- a/src/pyclad/metrics/continual/concepts_metric.py
+++ b/src/pyclad/metrics/continual/concepts_metric.py
@@ -1,5 +1,5 @@
 import abc
-from typing import List
+from typing import List, Sequence, Tuple
 
 ConceptLevelMatrix = List[List[float]]  # ConceptLevelMatrix[learned_concept][evaluated_concept]
 
@@ -22,3 +22,78 @@ class StepwiseConceptMetric(abc.ABC):
 
     @abc.abstractmethod
     def name(self) -> str: ...
+
+
+class ScheduleAwareMetric(abc.ABC):
+    """Base class for metrics computed over a rectangular (``T x N``) concept-level matrix.
+
+    Such a matrix appears when training steps group several categories (see
+    :mod:`pyclad.data.grouping`) while evaluation stays per category. Rows are training
+    steps, columns are evaluated categories, and the two axes no longer share names.
+
+    Interpreting such a matrix requires knowing, for each column, the training step at
+    which that category was first trained on -- rows above it describe the model *before*
+    it ever saw the category, which is a different quantity from forgetting. That mapping
+    is supplied as ``first_seen_steps``, aligned with the matrix columns; build it with
+    :func:`pyclad.data.grouping.compute_first_seen_step`.
+    """
+
+    @abc.abstractmethod
+    def compute(self, metric_matrix: ConceptLevelMatrix, first_seen_steps: Sequence[int]) -> float: ...
+
+    @abc.abstractmethod
+    def name(self) -> str: ...
+
+
+def matrix_shape(metric_matrix: ConceptLevelMatrix) -> Tuple[int, int]:
+    """Return ``(rows, columns)`` of a concept-level matrix."""
+    rows = len(metric_matrix)
+    return rows, len(metric_matrix[0]) if rows > 0 else 0
+
+
+def validate_square_matrix(metric_matrix: ConceptLevelMatrix, metric_name: str) -> None:
+    """Reject a rectangular concept-level matrix.
+
+    Metrics that walk the diagonal or the triangles of the matrix are only meaningful when
+    every training step corresponds to exactly one evaluated concept. On a ``T x N`` matrix
+    produced by a step schedule they would silently return a number computed over cells
+    that do not mean what the formula assumes.
+
+    :raises ValueError: when the matrix has rows of unequal length, or has both rows and
+        columns but is not square.
+    """
+    row_lengths = {len(row) for row in metric_matrix}
+    if len(row_lengths) > 1:
+        raise ValueError(
+            f"{metric_name} requires a square concept-level matrix, but its rows have "
+            f"unequal lengths: {sorted(row_lengths)}."
+        )
+
+    rows, columns = matrix_shape(metric_matrix)
+    if rows > 0 and columns > 0 and rows != columns:
+        raise ValueError(
+            f"{metric_name} requires a square concept-level matrix, got {rows}x{columns}. "
+            "A rectangular matrix comes from step-scheduled training, where rows are training "
+            "steps and columns are categories; use the schedule-aware metrics instead."
+        )
+
+
+def validate_first_seen_steps(
+    metric_matrix: ConceptLevelMatrix, first_seen_steps: Sequence[int], metric_name: str
+) -> None:
+    """Check that ``first_seen_steps`` aligns with the columns of ``metric_matrix``.
+
+    :raises ValueError: when the lengths differ, or an index falls outside the matrix rows.
+    """
+    rows, columns = matrix_shape(metric_matrix)
+    if len(first_seen_steps) != columns:
+        raise ValueError(
+            f"{metric_name}: first_seen_steps has length {len(first_seen_steps)} "
+            f"but the matrix has {columns} columns."
+        )
+    for column, first_seen in enumerate(first_seen_steps):
+        if not 0 <= int(first_seen) < rows:
+            raise ValueError(
+                f"{metric_name}: first_seen_steps[{column}] = {first_seen} is out of range "
+                f"for a matrix with {rows} training steps."
+            )

--- a/src/pyclad/metrics/continual/final_step_average.py
+++ b/src/pyclad/metrics/continual/final_step_average.py
@@ -3,6 +3,7 @@ import numpy as np
 from pyclad.metrics.continual.concepts_metric import (
     ConceptLevelMatrix,
     SummarizedMetric,
+    is_nan,
 )
 
 
@@ -20,12 +21,8 @@ class FinalStepAverage(SummarizedMetric):
         if len(metric_matrix) == 0:
             return 0.0
 
-        final_row = [value for value in metric_matrix[-1] if not _is_nan(value)]
+        final_row = [value for value in metric_matrix[-1] if not is_nan(value)]
         return float(np.mean(final_row)) if final_row else 0.0
 
     def name(self) -> str:
         return "FinalStepAverage"
-
-
-def _is_nan(value: float) -> bool:
-    return bool(np.isnan(value))

--- a/src/pyclad/metrics/continual/final_step_average.py
+++ b/src/pyclad/metrics/continual/final_step_average.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+from pyclad.metrics.continual.concepts_metric import (
+    ConceptLevelMatrix,
+    SummarizedMetric,
+)
+
+
+class FinalStepAverage(SummarizedMetric):
+    """Average of the base metric over all evaluated concepts after the last training step.
+
+    This is the ``A-AUROC`` figure reported by CDAD-style continual anomaly detection
+    papers: train through the whole sequence, then average across every test concept.
+
+    Works on both square (``N x N``) and rectangular (``T x N``) matrices, since it only
+    reads the last row. ``NaN`` entries are ignored. Higher is better.
+    """
+
+    def compute(self, metric_matrix: ConceptLevelMatrix) -> float:
+        if len(metric_matrix) == 0:
+            return 0.0
+
+        final_row = [value for value in metric_matrix[-1] if not _is_nan(value)]
+        return float(np.mean(final_row)) if final_row else 0.0
+
+    def name(self) -> str:
+        return "FinalStepAverage"
+
+
+def _is_nan(value: float) -> bool:
+    return bool(np.isnan(value))

--- a/src/pyclad/metrics/continual/forgetting_measure.py
+++ b/src/pyclad/metrics/continual/forgetting_measure.py
@@ -3,6 +3,7 @@ import numpy as np
 from pyclad.metrics.continual.concepts_metric import (
     ConceptLevelMatrix,
     StepwiseConceptMetric,
+    validate_square_matrix,
 )
 
 
@@ -22,6 +23,8 @@ class ForgettingMeasure(StepwiseConceptMetric):
         Returns:
             Mean FM after learning each concepts.
         """
+        validate_square_matrix(metric_matrix, self.name())
+
         concepts_no = len(metric_matrix)
 
         if concepts_no == 0:

--- a/src/pyclad/metrics/continual/forward_transfer.py
+++ b/src/pyclad/metrics/continual/forward_transfer.py
@@ -3,11 +3,13 @@ import numpy as np
 from pyclad.metrics.continual.concepts_metric import (
     ConceptLevelMatrix,
     SummarizedMetric,
+    validate_square_matrix,
 )
 
 
 class ForwardTransfer(SummarizedMetric):
     def compute(self, metric_matrix: ConceptLevelMatrix) -> float:
+        validate_square_matrix(metric_matrix, self.name())
         concepts_no = len(metric_matrix)
 
         if concepts_no == 0:

--- a/src/pyclad/metrics/continual/schedule_aware_forgetting_measure.py
+++ b/src/pyclad/metrics/continual/schedule_aware_forgetting_measure.py
@@ -5,6 +5,7 @@ import numpy as np
 from pyclad.metrics.continual.concepts_metric import (
     ConceptLevelMatrix,
     ScheduleAwareMetric,
+    is_nan,
     validate_first_seen_steps,
 )
 
@@ -40,10 +41,10 @@ class ScheduleAwareForgettingMeasure(ScheduleAwareMetric):
             history = [
                 metric_matrix[row][column]
                 for row in range(int(first_seen), last_train_row)
-                if not _is_nan(metric_matrix[row][column])
+                if not is_nan(metric_matrix[row][column])
             ]
             final = metric_matrix[last_train_row][column]
-            if not history or _is_nan(final):
+            if not history or is_nan(final):
                 continue
 
             values.append(max(history) - final)
@@ -52,7 +53,3 @@ class ScheduleAwareForgettingMeasure(ScheduleAwareMetric):
 
     def name(self) -> str:
         return "ScheduleAwareForgettingMeasure"
-
-
-def _is_nan(value: float) -> bool:
-    return bool(np.isnan(value))

--- a/src/pyclad/metrics/continual/schedule_aware_forgetting_measure.py
+++ b/src/pyclad/metrics/continual/schedule_aware_forgetting_measure.py
@@ -1,0 +1,58 @@
+from typing import Sequence
+
+import numpy as np
+
+from pyclad.metrics.continual.concepts_metric import (
+    ConceptLevelMatrix,
+    ScheduleAwareMetric,
+    validate_first_seen_steps,
+)
+
+
+class ScheduleAwareForgettingMeasure(ScheduleAwareMetric):
+    """Forgetting Measure restricted to the rows in which a category had already been trained.
+
+    For each evaluated category ``k`` first trained at step ``s_k <= T - 2``:
+
+    ``f_k = max_{j in [s_k, T - 2]} M[j][k] - M[T - 1][k]``
+
+    Columns with ``s_k >= T - 1`` are skipped: a category that only enters training at the
+    final step cannot have been forgotten yet.
+
+    This restriction is what separates the metric from :class:`ForgettingMeasure`. On a
+    ``T x N`` matrix the rows above ``s_k`` describe the model *before* it ever saw the
+    category, so ``peak - final`` there measures improvement, not forgetting, and averaging
+    it in drags the result toward zero or below. Lower is better.
+    """
+
+    def compute(self, metric_matrix: ConceptLevelMatrix, first_seen_steps: Sequence[int]) -> float:
+        rows = len(metric_matrix)
+        if rows < 2:
+            return 0.0
+        validate_first_seen_steps(metric_matrix, first_seen_steps, self.name())
+
+        last_train_row = rows - 1
+        values = []
+        for column, first_seen in enumerate(first_seen_steps):
+            if int(first_seen) >= last_train_row:
+                continue
+
+            history = [
+                metric_matrix[row][column]
+                for row in range(int(first_seen), last_train_row)
+                if not _is_nan(metric_matrix[row][column])
+            ]
+            final = metric_matrix[last_train_row][column]
+            if not history or _is_nan(final):
+                continue
+
+            values.append(max(history) - final)
+
+        return float(np.mean(values)) if values else 0.0
+
+    def name(self) -> str:
+        return "ScheduleAwareForgettingMeasure"
+
+
+def _is_nan(value: float) -> bool:
+    return bool(np.isnan(value))

--- a/src/pyclad/metrics/continual/schedule_aware_forward_transfer.py
+++ b/src/pyclad/metrics/continual/schedule_aware_forward_transfer.py
@@ -1,0 +1,44 @@
+from typing import Sequence
+
+import numpy as np
+
+from pyclad.metrics.continual.concepts_metric import (
+    ConceptLevelMatrix,
+    ScheduleAwareMetric,
+    validate_first_seen_steps,
+)
+
+
+class ScheduleAwareForwardTransfer(ScheduleAwareMetric):
+    """Average performance on categories the model has not been trained on yet.
+
+    For each evaluated category ``k`` first trained at step ``s_k > 0``:
+
+    ``fwt_k = mean_{j in [0, s_k - 1]} M[j][k]``
+
+    Columns with ``s_k = 0`` are skipped -- they have no pre-training rows. ``NaN`` entries
+    are ignored. Higher is better: it measures how well knowledge from earlier steps
+    transfers to categories that are still unseen.
+    """
+
+    def compute(self, metric_matrix: ConceptLevelMatrix, first_seen_steps: Sequence[int]) -> float:
+        if len(metric_matrix) == 0:
+            return 0.0
+        validate_first_seen_steps(metric_matrix, first_seen_steps, self.name())
+
+        per_column_means = []
+        for column, first_seen in enumerate(first_seen_steps):
+            pre_training_values = [
+                metric_matrix[row][column] for row in range(int(first_seen)) if not _is_nan(metric_matrix[row][column])
+            ]
+            if pre_training_values:
+                per_column_means.append(float(np.mean(pre_training_values)))
+
+        return float(np.mean(per_column_means)) if per_column_means else 0.0
+
+    def name(self) -> str:
+        return "ScheduleAwareForwardTransfer"
+
+
+def _is_nan(value: float) -> bool:
+    return bool(np.isnan(value))

--- a/src/pyclad/metrics/continual/schedule_aware_forward_transfer.py
+++ b/src/pyclad/metrics/continual/schedule_aware_forward_transfer.py
@@ -5,6 +5,7 @@ import numpy as np
 from pyclad.metrics.continual.concepts_metric import (
     ConceptLevelMatrix,
     ScheduleAwareMetric,
+    is_nan,
     validate_first_seen_steps,
 )
 
@@ -29,7 +30,7 @@ class ScheduleAwareForwardTransfer(ScheduleAwareMetric):
         per_column_means = []
         for column, first_seen in enumerate(first_seen_steps):
             pre_training_values = [
-                metric_matrix[row][column] for row in range(int(first_seen)) if not _is_nan(metric_matrix[row][column])
+                metric_matrix[row][column] for row in range(int(first_seen)) if not is_nan(metric_matrix[row][column])
             ]
             if pre_training_values:
                 per_column_means.append(float(np.mean(pre_training_values)))
@@ -38,7 +39,3 @@ class ScheduleAwareForwardTransfer(ScheduleAwareMetric):
 
     def name(self) -> str:
         return "ScheduleAwareForwardTransfer"
-
-
-def _is_nan(value: float) -> bool:
-    return bool(np.isnan(value))

--- a/src/pyclad/metrics/continual/schedule_aware_new_task_acquisition.py
+++ b/src/pyclad/metrics/continual/schedule_aware_new_task_acquisition.py
@@ -5,6 +5,7 @@ import numpy as np
 from pyclad.metrics.continual.concepts_metric import (
     ConceptLevelMatrix,
     ScheduleAwareMetric,
+    is_nan,
     validate_first_seen_steps,
 )
 
@@ -31,14 +32,10 @@ class ScheduleAwareNewTaskAcquisition(ScheduleAwareMetric):
         values = [
             float(metric_matrix[int(first_seen)][column])
             for column, first_seen in enumerate(first_seen_steps)
-            if not _is_nan(metric_matrix[int(first_seen)][column])
+            if not is_nan(metric_matrix[int(first_seen)][column])
         ]
 
         return float(np.mean(values)) if values else 0.0
 
     def name(self) -> str:
         return "ScheduleAwareNewTaskAcquisition"
-
-
-def _is_nan(value: float) -> bool:
-    return bool(np.isnan(value))

--- a/src/pyclad/metrics/continual/schedule_aware_new_task_acquisition.py
+++ b/src/pyclad/metrics/continual/schedule_aware_new_task_acquisition.py
@@ -1,0 +1,44 @@
+from typing import Sequence
+
+import numpy as np
+
+from pyclad.metrics.continual.concepts_metric import (
+    ConceptLevelMatrix,
+    ScheduleAwareMetric,
+    validate_first_seen_steps,
+)
+
+
+class ScheduleAwareNewTaskAcquisition(ScheduleAwareMetric):
+    """Average performance on each category right after it first entered training.
+
+    For each evaluated category ``k`` first trained at step ``s_k``: ``nta_k = M[s_k][k]``.
+
+    This is how well the model acquires a new category before any later step has had a
+    chance to interfere, which disentangles two failure modes that a single number hides:
+    low acquisition means the category was never learned (plasticity), while high
+    acquisition together with high forgetting means it was learned and then lost
+    (stability). On a square matrix with the identity schedule this reads the diagonal.
+
+    ``NaN`` entries are ignored. Higher is better.
+    """
+
+    def compute(self, metric_matrix: ConceptLevelMatrix, first_seen_steps: Sequence[int]) -> float:
+        if len(metric_matrix) == 0:
+            return 0.0
+        validate_first_seen_steps(metric_matrix, first_seen_steps, self.name())
+
+        values = [
+            float(metric_matrix[int(first_seen)][column])
+            for column, first_seen in enumerate(first_seen_steps)
+            if not _is_nan(metric_matrix[int(first_seen)][column])
+        ]
+
+        return float(np.mean(values)) if values else 0.0
+
+    def name(self) -> str:
+        return "ScheduleAwareNewTaskAcquisition"
+
+
+def _is_nan(value: float) -> bool:
+    return bool(np.isnan(value))

--- a/src/pyclad/vision/callbacks/vision_pixel_concept_metric_callback.py
+++ b/src/pyclad/vision/callbacks/vision_pixel_concept_metric_callback.py
@@ -1,19 +1,21 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, Dict, Iterable, List, Mapping, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 import numpy as np
 
 from pyclad.callbacks.callback import Callback
 from pyclad.callbacks.evaluation.concept_metric_evaluation import (
-    align_first_seen_steps,
+    FirstSeenStepSource,
+    ScheduleAwareSupport,
     build_dense_matrix,
-    validate_schedule_aware_configuration,
+    resolve_column_order,
 )
 from pyclad.data.concept import Concept
 from pyclad.metrics.base.base_metric import BaseMetric
 from pyclad.metrics.continual.concepts_metric import (
+    ConceptLevelMatrix,
     ScheduleAwareMetric,
     SummarizedMetric,
 )
@@ -37,28 +39,21 @@ class VisionPixelConceptMetricCallback(Callback, InfoProvider):
     carries no masks. Note that skipping *some* pairs leaves the matrix incomplete,
     which :meth:`info` reports as an error rather than papering over.
 
-    Like ``ConceptMetricCallback`` it supports step-scheduled training (see
-    :mod:`pyclad.data.grouping`): rows follow the grouped training steps, columns follow
-    the evaluated categories, and ``schedule_aware_metrics`` with ``first_seen_step``
-    compute metrics over the resulting ``T x N`` matrix.
+    For step-scheduled training (see :mod:`pyclad.data.grouping`), where rows are grouped
+    training steps and columns stay per category, use
+    :class:`ScheduleAwareVisionPixelConceptMetricCallback`.
     """
 
     def __init__(
         self,
         base_metric: BaseMetric,
         summarized_metrics: Iterable[SummarizedMetric] = (),
-        schedule_aware_metrics: Iterable[ScheduleAwareMetric] = (),
-        first_seen_step: Optional[Mapping[str, int]] = None,
     ):
         self._base_metric = base_metric
         self._summarized_metrics: List[SummarizedMetric] = list(summarized_metrics)
-        self._schedule_aware_metrics: List[ScheduleAwareMetric] = list(schedule_aware_metrics)
-        self._first_seen_step = dict(first_seen_step) if first_seen_step is not None else None
         self._metric_matrix: Dict[str, Dict[str, float]] = defaultdict(dict)
         self._learned_concepts: List[str] = []
         self._evaluated_concepts: List[str] = []
-
-        validate_schedule_aware_configuration(self._schedule_aware_metrics, self._first_seen_step)
 
     def after_training(self, learned_concept: Concept, *args, **kwargs) -> None:
         self._learned_concepts.append(learned_concept.name)
@@ -87,25 +82,54 @@ class VisionPixelConceptMetricCallback(Callback, InfoProvider):
         )
         self._metric_matrix[learned][evaluated_concept.name] = value
 
+    def column_order(self) -> List[str]:
+        """Concept order of the matrix columns, as actually used to build it."""
+        return resolve_column_order(self._learned_concepts, self._evaluated_concepts)
+
+    def dense_matrix(self) -> ConceptLevelMatrix:
+        return build_dense_matrix(self._metric_matrix, self._learned_concepts, self._evaluated_concepts)
+
     def info(self) -> Dict[str, Any]:
         if not self._evaluated_concepts:
             return {}
 
-        dense = build_dense_matrix(self._metric_matrix, self._learned_concepts, self._evaluated_concepts)
-        payload = {
-            "base_metric_name": self._base_metric.name(),
-            "metrics": {m.name(): m.compute(dense) for m in self._summarized_metrics},
-            "concepts_order": self._learned_concepts,
-            "test_order": self._evaluated_concepts,
-            "metric_matrix": self._metric_matrix,
-            "evaluation_level": "pixel",
+        dense = self.dense_matrix()
+        return {
+            f"pixel_concept_metric_callback_{self._base_metric.name()}": {
+                "base_metric_name": self._base_metric.name(),
+                "metrics": {m.name(): m.compute(dense) for m in self._summarized_metrics},
+                "concepts_order": self._learned_concepts,
+                "test_order": self.column_order(),
+                "metric_matrix": self._metric_matrix,
+                "evaluation_level": "pixel",
+            }
         }
 
-        if self._first_seen_step is not None:
-            first_seen_steps = align_first_seen_steps(self._first_seen_step, self._evaluated_concepts)
-            payload["first_seen_step"] = dict(zip(self._evaluated_concepts, first_seen_steps))
-            payload["schedule_aware_metrics"] = {
-                m.name(): m.compute(dense, first_seen_steps) for m in self._schedule_aware_metrics
-            }
 
-        return {f"pixel_concept_metric_callback_{self._base_metric.name()}": payload}
+class ScheduleAwareVisionPixelConceptMetricCallback(VisionPixelConceptMetricCallback):
+    """Pixel-level counterpart of
+    :class:`~pyclad.callbacks.evaluation.concept_metric_evaluation.ScheduleAwareConceptMetricCallback`.
+
+    Shares its schedule-aware reporting through
+    :class:`~pyclad.callbacks.evaluation.concept_metric_evaluation.ScheduleAwareSupport`, so the
+    two levels cannot drift apart.
+    """
+
+    def __init__(
+        self,
+        base_metric: BaseMetric,
+        summarized_metrics: Iterable[SummarizedMetric] = (),
+        schedule_aware_metrics: Iterable[ScheduleAwareMetric] = (),
+        first_seen_step: Optional[FirstSeenStepSource] = None,
+    ):
+        super().__init__(base_metric, summarized_metrics)
+        self._schedule_aware = ScheduleAwareSupport(schedule_aware_metrics, first_seen_step)
+
+    def info(self) -> Dict[str, Any]:
+        payload = super().info()
+        if not payload:
+            return payload
+        next(iter(payload.values())).update(
+            self._schedule_aware.payload_additions(self.dense_matrix(), self.column_order())
+        )
+        return payload

--- a/src/pyclad/vision/callbacks/vision_pixel_concept_metric_callback.py
+++ b/src/pyclad/vision/callbacks/vision_pixel_concept_metric_callback.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Mapping, Optional
 
 import numpy as np
 
 from pyclad.callbacks.callback import Callback
+from pyclad.callbacks.evaluation.concept_metric_evaluation import (
+    align_first_seen_steps,
+    build_dense_matrix,
+    validate_schedule_aware_configuration,
+)
 from pyclad.data.concept import Concept
 from pyclad.metrics.base.base_metric import BaseMetric
 from pyclad.metrics.continual.concepts_metric import (
-    ConceptLevelMatrix,
+    ScheduleAwareMetric,
     SummarizedMetric,
 )
 from pyclad.output.output_writer import InfoProvider
@@ -29,19 +34,31 @@ class VisionPixelConceptMetricCallback(Callback, InfoProvider):
     Skips silently when ``score_maps`` is absent (i.e. the strategy returned a
     plain :class:`pyclad.output.prediction_results.PredictionResults`), when the
     evaluated concept is not a :class:`VisionConcept`, or when the concept
-    carries no masks.
+    carries no masks. Note that skipping *some* pairs leaves the matrix incomplete,
+    which :meth:`info` reports as an error rather than papering over.
+
+    Like ``ConceptMetricCallback`` it supports step-scheduled training (see
+    :mod:`pyclad.data.grouping`): rows follow the grouped training steps, columns follow
+    the evaluated categories, and ``schedule_aware_metrics`` with ``first_seen_step``
+    compute metrics over the resulting ``T x N`` matrix.
     """
 
     def __init__(
         self,
         base_metric: BaseMetric,
         summarized_metrics: Iterable[SummarizedMetric] = (),
+        schedule_aware_metrics: Iterable[ScheduleAwareMetric] = (),
+        first_seen_step: Optional[Mapping[str, int]] = None,
     ):
         self._base_metric = base_metric
         self._summarized_metrics: List[SummarizedMetric] = list(summarized_metrics)
+        self._schedule_aware_metrics: List[ScheduleAwareMetric] = list(schedule_aware_metrics)
+        self._first_seen_step = dict(first_seen_step) if first_seen_step is not None else None
         self._metric_matrix: Dict[str, Dict[str, float]] = defaultdict(dict)
         self._learned_concepts: List[str] = []
         self._evaluated_concepts: List[str] = []
+
+        validate_schedule_aware_configuration(self._schedule_aware_metrics, self._first_seen_step)
 
     def after_training(self, learned_concept: Concept, *args, **kwargs) -> None:
         self._learned_concepts.append(learned_concept.name)
@@ -74,23 +91,21 @@ class VisionPixelConceptMetricCallback(Callback, InfoProvider):
         if not self._evaluated_concepts:
             return {}
 
-        ordered = list(self._evaluated_concepts)
-        dense = self._to_dense_matrix(self._metric_matrix, ordered)
-        return {
-            f"pixel_concept_metric_callback_{self._base_metric.name()}": {
-                "base_metric_name": self._base_metric.name(),
-                "metrics": {m.name(): m.compute(dense) for m in self._summarized_metrics},
-                "concepts_order": ordered,
-                "metric_matrix": self._metric_matrix,
-                "evaluation_level": "pixel",
-            }
+        dense = build_dense_matrix(self._metric_matrix, self._learned_concepts, self._evaluated_concepts)
+        payload = {
+            "base_metric_name": self._base_metric.name(),
+            "metrics": {m.name(): m.compute(dense) for m in self._summarized_metrics},
+            "concepts_order": self._learned_concepts,
+            "test_order": self._evaluated_concepts,
+            "metric_matrix": self._metric_matrix,
+            "evaluation_level": "pixel",
         }
 
-    @staticmethod
-    def _to_dense_matrix(
-        metric_matrix: Dict[str, Dict[str, float]],
-        concepts_order: List[str],
-    ) -> ConceptLevelMatrix:
-        if not concepts_order:
-            return [[]]
-        return [[metric_matrix[learned][evaluated] for evaluated in concepts_order] for learned in concepts_order]
+        if self._first_seen_step is not None:
+            first_seen_steps = align_first_seen_steps(self._first_seen_step, self._evaluated_concepts)
+            payload["first_seen_step"] = dict(zip(self._evaluated_concepts, first_seen_steps))
+            payload["schedule_aware_metrics"] = {
+                m.name(): m.compute(dense, first_seen_steps) for m in self._schedule_aware_metrics
+            }
+
+        return {f"pixel_concept_metric_callback_{self._base_metric.name()}": payload}

--- a/tests/callbacks/evaluation/test_rectangular_matrix_evaluation.py
+++ b/tests/callbacks/evaluation/test_rectangular_matrix_evaluation.py
@@ -8,8 +8,14 @@ share names and the matrix is rectangular.
 import numpy as np
 import pytest
 
-from pyclad.callbacks.evaluation.concept_metric_evaluation import ConceptMetricCallback
+from pyclad.callbacks.evaluation.concept_metric_evaluation import (
+    ConceptMetricCallback,
+    ScheduleAwareConceptMetricCallback,
+    build_dense_matrix,
+)
 from pyclad.data.concept import Concept
+from pyclad.data.datasets.concepts_dataset import ConceptsDataset
+from pyclad.data.grouping import apply_step_schedule
 from pyclad.metrics.base.base_metric import BaseMetric
 from pyclad.metrics.continual.concepts_metric import (
     ConceptLevelMatrix,
@@ -105,7 +111,7 @@ def test_rejecting_a_matrix_with_a_missing_cell():
 
 def test_passing_the_aligned_first_seen_steps_to_schedule_aware_metrics():
     metric = RecordingScheduleAwareMetric()
-    callback = ConceptMetricCallback(
+    callback = ScheduleAwareConceptMetricCallback(
         ScoreDrivenBaseMetric(),
         summarized_metrics=[],
         schedule_aware_metrics=[metric],
@@ -123,7 +129,7 @@ def test_passing_the_aligned_first_seen_steps_to_schedule_aware_metrics():
 
 def test_realigning_first_seen_steps_to_the_evaluation_order():
     metric = RecordingScheduleAwareMetric()
-    callback = ConceptMetricCallback(
+    callback = ScheduleAwareConceptMetricCallback(
         ScoreDrivenBaseMetric(),
         summarized_metrics=[],
         schedule_aware_metrics=[metric],
@@ -138,7 +144,7 @@ def test_realigning_first_seen_steps_to_the_evaluation_order():
 
 def test_rejecting_schedule_aware_metrics_without_a_first_seen_mapping():
     with pytest.raises(ValueError, match="first_seen_step"):
-        ConceptMetricCallback(
+        ScheduleAwareConceptMetricCallback(
             ScoreDrivenBaseMetric(),
             summarized_metrics=[],
             schedule_aware_metrics=[RecordingScheduleAwareMetric()],
@@ -146,7 +152,7 @@ def test_rejecting_schedule_aware_metrics_without_a_first_seen_mapping():
 
 
 def test_rejecting_a_first_seen_mapping_that_misses_an_evaluated_category():
-    callback = ConceptMetricCallback(
+    callback = ScheduleAwareConceptMetricCallback(
         ScoreDrivenBaseMetric(),
         summarized_metrics=[],
         schedule_aware_metrics=[RecordingScheduleAwareMetric()],
@@ -166,3 +172,68 @@ def test_square_scenario_keeps_reporting_identical_train_and_test_order():
 
     assert _info(callback)["concepts_order"] == ["a", "b"]
     assert _info(callback)["test_order"] == ["a", "b"]
+
+
+class TestAxisAlignment:
+    """A square matrix must stay name-consistent: cell [i][i] means "concept i after learning i".
+
+    Rows follow the training order and columns the evaluation order, and those are tracked
+    independently. When both axes hold the same concepts, pairing them by position rather than
+    by name silently transposes cells, and the square-only metrics then average the wrong ones
+    without raising.
+    """
+
+    def test_columns_follow_the_training_order_when_both_axes_hold_the_same_concepts(self):
+        metric_matrix = {"A": {"A": 0.9, "B": 0.1}, "B": {"A": 0.2, "B": 0.8}}
+
+        matrix = build_dense_matrix(metric_matrix, train_order=["A", "B"], test_order=["B", "A"])
+
+        assert matrix == [[0.9, 0.1], [0.2, 0.8]]
+
+    def test_columns_keep_the_evaluation_order_when_the_axes_differ(self):
+        metric_matrix = {"step_0": {"b": 0.1, "a": 0.2}, "step_1": {"b": 0.3, "a": 0.4}}
+
+        matrix = build_dense_matrix(metric_matrix, train_order=["step_0", "step_1"], test_order=["b", "a"])
+
+        assert matrix == [[0.1, 0.2], [0.3, 0.4]]
+
+    def test_callback_reports_the_column_order_it_actually_used(self):
+        callback = ConceptMetricCallback(ScoreDrivenBaseMetric(), summarized_metrics=[])
+        _run(callback, [[0.1, 0.2], [0.3, 0.4]], test_categories=["b", "a"], train_steps=["a", "b"])
+
+        info = _info(callback)
+
+        assert info["concepts_order"] == ["a", "b"]
+        assert info["test_order"] == ["a", "b"]
+
+
+class TestScheduleAwareWiring:
+    def test_reading_the_mapping_off_a_step_scheduled_dataset(self):
+        dataset = ConceptsDataset(
+            name="toy",
+            train_concepts=[Concept(name=c, data=np.zeros((2, 1))) for c in TEST_CATEGORIES],
+            test_concepts=[Concept(name=c, data=np.zeros((2, 1)), labels=np.zeros(2)) for c in TEST_CATEGORIES],
+        )
+        scheduled = apply_step_schedule(dataset, "2-1")
+        metric = RecordingScheduleAwareMetric()
+        callback = ScheduleAwareConceptMetricCallback(
+            ScoreDrivenBaseMetric(),
+            summarized_metrics=[],
+            schedule_aware_metrics=[metric],
+            first_seen_step=scheduled,
+        )
+
+        _run(callback, [[0.9, 0.8, 0.1], [0.6, 0.4, 0.7]])
+        _info(callback)
+
+        assert metric.received_first_seen == [0, 0, 1]
+
+    def test_rejecting_schedule_aware_callback_without_any_schedule_aware_metric(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            ScheduleAwareConceptMetricCallback(
+                ScoreDrivenBaseMetric(), summarized_metrics=[], first_seen_step=FIRST_SEEN
+            )
+
+    def test_plain_callback_no_longer_accepts_schedule_aware_arguments(self):
+        with pytest.raises(TypeError):
+            ConceptMetricCallback(ScoreDrivenBaseMetric(), summarized_metrics=[], first_seen_step=FIRST_SEEN)

--- a/tests/callbacks/evaluation/test_rectangular_matrix_evaluation.py
+++ b/tests/callbacks/evaluation/test_rectangular_matrix_evaluation.py
@@ -1,0 +1,168 @@
+"""Concept-metric callback behaviour when training steps group several categories.
+
+With a step schedule the train axis holds ``T`` grouped steps (``step_0``, ``step_1``, ...)
+while the test axis keeps the ``N`` original category names, so the two axes no longer
+share names and the matrix is rectangular.
+"""
+
+import numpy as np
+import pytest
+
+from pyclad.callbacks.evaluation.concept_metric_evaluation import ConceptMetricCallback
+from pyclad.data.concept import Concept
+from pyclad.metrics.base.base_metric import BaseMetric
+from pyclad.metrics.continual.concepts_metric import (
+    ConceptLevelMatrix,
+    ScheduleAwareMetric,
+)
+from pyclad.metrics.continual.final_step_average import FinalStepAverage
+
+TEST_CATEGORIES = ["bottle", "cable", "capsule"]
+TRAIN_STEPS = ["step_0", "step_1"]
+FIRST_SEEN = {"bottle": 0, "cable": 0, "capsule": 1}
+
+
+class ScoreDrivenBaseMetric(BaseMetric):
+    """Returns the single value passed in as ``anomaly_scores``, so tests can pin cells."""
+
+    def compute(self, anomaly_scores, y_pred, y_true) -> float:
+        return float(anomaly_scores[0])
+
+    def name(self) -> str:
+        return "ScoreDriven"
+
+
+class RecordingScheduleAwareMetric(ScheduleAwareMetric):
+    def __init__(self):
+        self.received_matrix = None
+        self.received_first_seen = None
+
+    def compute(self, metric_matrix: ConceptLevelMatrix, first_seen_steps) -> float:
+        self.received_matrix = metric_matrix
+        self.received_first_seen = list(first_seen_steps)
+        return 0.42
+
+    def name(self) -> str:
+        return "RecordingScheduleAware"
+
+
+def _info(callback):
+    return callback.info()["concept_metric_callback_ScoreDriven"]
+
+
+def _run(callback, cell_values, test_categories=TEST_CATEGORIES, train_steps=TRAIN_STEPS):
+    """Drive the callback the way ConceptAwareScenario would, pinning each matrix cell."""
+    for step_index, step_name in enumerate(train_steps):
+        callback.after_training(Concept(name=step_name, data=np.array([])))
+        for category_index, category in enumerate(test_categories):
+            callback.after_evaluation(
+                evaluated_concept=Concept(name=category, data=np.array([])),
+                y_true=np.array([0]),
+                y_pred=np.array([0]),
+                anomaly_scores=np.array([cell_values[step_index][category_index]]),
+            )
+
+
+def test_building_a_rectangular_matrix_from_grouped_training_steps():
+    callback = ConceptMetricCallback(ScoreDrivenBaseMetric(), summarized_metrics=[FinalStepAverage()])
+
+    _run(callback, [[0.9, 0.8, 0.1], [0.6, 0.4, 0.7]])
+
+    assert _info(callback)["metrics"]["FinalStepAverage"] == pytest.approx((0.6 + 0.4 + 0.7) / 3)
+
+
+def test_reporting_train_and_test_order_separately():
+    callback = ConceptMetricCallback(ScoreDrivenBaseMetric(), summarized_metrics=[])
+
+    _run(callback, [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+
+    assert _info(callback)["concepts_order"] == TRAIN_STEPS
+    assert _info(callback)["test_order"] == TEST_CATEGORIES
+
+
+def test_rejecting_a_matrix_with_a_missing_cell():
+    callback = ConceptMetricCallback(ScoreDrivenBaseMetric(), summarized_metrics=[])
+    callback.after_training(Concept(name="step_0", data=np.array([])))
+    for category in TEST_CATEGORIES:
+        callback.after_evaluation(
+            evaluated_concept=Concept(name=category, data=np.array([])),
+            y_true=np.array([0]),
+            y_pred=np.array([0]),
+            anomaly_scores=np.array([0.5]),
+        )
+    # Second step evaluates only one of the three categories.
+    callback.after_training(Concept(name="step_1", data=np.array([])))
+    callback.after_evaluation(
+        evaluated_concept=Concept(name="bottle", data=np.array([])),
+        y_true=np.array([0]),
+        y_pred=np.array([0]),
+        anomaly_scores=np.array([0.5]),
+    )
+
+    with pytest.raises(ValueError, match="was not evaluated"):
+        callback.info()
+
+
+def test_passing_the_aligned_first_seen_steps_to_schedule_aware_metrics():
+    metric = RecordingScheduleAwareMetric()
+    callback = ConceptMetricCallback(
+        ScoreDrivenBaseMetric(),
+        summarized_metrics=[],
+        schedule_aware_metrics=[metric],
+        first_seen_step=FIRST_SEEN,
+    )
+
+    _run(callback, [[0.9, 0.8, 0.1], [0.6, 0.4, 0.7]])
+    info = _info(callback)
+
+    assert metric.received_first_seen == [0, 0, 1]
+    assert metric.received_matrix == [[0.9, 0.8, 0.1], [0.6, 0.4, 0.7]]
+    assert info["schedule_aware_metrics"]["RecordingScheduleAware"] == 0.42
+    assert info["first_seen_step"] == FIRST_SEEN
+
+
+def test_realigning_first_seen_steps_to_the_evaluation_order():
+    metric = RecordingScheduleAwareMetric()
+    callback = ConceptMetricCallback(
+        ScoreDrivenBaseMetric(),
+        summarized_metrics=[],
+        schedule_aware_metrics=[metric],
+        first_seen_step=FIRST_SEEN,
+    )
+
+    _run(callback, [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], test_categories=["capsule", "bottle", "cable"])
+    _info(callback)
+
+    assert metric.received_first_seen == [1, 0, 0]
+
+
+def test_rejecting_schedule_aware_metrics_without_a_first_seen_mapping():
+    with pytest.raises(ValueError, match="first_seen_step"):
+        ConceptMetricCallback(
+            ScoreDrivenBaseMetric(),
+            summarized_metrics=[],
+            schedule_aware_metrics=[RecordingScheduleAwareMetric()],
+        )
+
+
+def test_rejecting_a_first_seen_mapping_that_misses_an_evaluated_category():
+    callback = ConceptMetricCallback(
+        ScoreDrivenBaseMetric(),
+        summarized_metrics=[],
+        schedule_aware_metrics=[RecordingScheduleAwareMetric()],
+        first_seen_step={"bottle": 0, "cable": 0},
+    )
+
+    _run(callback, [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+
+    with pytest.raises(ValueError, match="capsule"):
+        callback.info()
+
+
+def test_square_scenario_keeps_reporting_identical_train_and_test_order():
+    callback = ConceptMetricCallback(ScoreDrivenBaseMetric(), summarized_metrics=[])
+
+    _run(callback, [[0.1, 0.2], [0.3, 0.4]], test_categories=["a", "b"], train_steps=["a", "b"])
+
+    assert _info(callback)["concepts_order"] == ["a", "b"]
+    assert _info(callback)["test_order"] == ["a", "b"]

--- a/tests/callbacks/evaluation/test_schedule_aware_support.py
+++ b/tests/callbacks/evaluation/test_schedule_aware_support.py
@@ -1,0 +1,99 @@
+"""Direct tests for the helper both schedule-aware callbacks share.
+
+Testing it on its own is the point of factoring it out: the image-level and pixel-level
+callbacks then exercise one implementation rather than a copy each.
+"""
+
+import numpy as np
+import pytest
+
+from pyclad.callbacks.evaluation.concept_metric_evaluation import ScheduleAwareSupport
+from pyclad.data.concept import Concept
+from pyclad.data.datasets.concepts_dataset import ConceptsDataset
+from pyclad.data.grouping import apply_step_schedule
+from pyclad.metrics.continual.concepts_metric import (
+    ConceptLevelMatrix,
+    ScheduleAwareMetric,
+)
+
+CATEGORIES = ["a", "b", "c"]
+MATRIX = [[0.9, 0.8, 0.1], [0.6, 0.4, 0.7]]
+
+
+class RecordingMetric(ScheduleAwareMetric):
+    def __init__(self):
+        self.received_first_seen = None
+
+    def compute(self, metric_matrix: ConceptLevelMatrix, first_seen_steps) -> float:
+        self.received_first_seen = list(first_seen_steps)
+        return 0.5
+
+    def name(self) -> str:
+        return "Recording"
+
+
+def _scheduled_dataset(schedule="2-1"):
+    dataset = ConceptsDataset(
+        name="toy",
+        train_concepts=[Concept(name=c, data=np.zeros((2, 1))) for c in CATEGORIES],
+        test_concepts=[Concept(name=c, data=np.zeros((2, 1)), labels=np.zeros(2)) for c in CATEGORIES],
+    )
+    return apply_step_schedule(dataset, schedule)
+
+
+def test_resolving_the_mapping_from_a_plain_dict():
+    support = ScheduleAwareSupport([RecordingMetric()], {"a": 0, "b": 0, "c": 1})
+
+    assert support.first_seen_step() == {"a": 0, "b": 0, "c": 1}
+
+
+def test_resolving_the_mapping_from_a_step_scheduled_dataset():
+    support = ScheduleAwareSupport([RecordingMetric()], _scheduled_dataset())
+
+    assert support.first_seen_step() == {"a": 0, "b": 0, "c": 1}
+
+
+def test_reading_the_dataset_mapping_at_report_time_rather_than_at_construction():
+    """A dataset is read when the payload is built, so the two cannot drift apart."""
+    dataset = _scheduled_dataset()
+    support = ScheduleAwareSupport([RecordingMetric()], dataset)
+
+    first = support.first_seen_step()
+    second = support.first_seen_step()
+
+    assert first == second == dataset.first_seen_step()
+
+
+def test_aligning_the_steps_to_the_column_order():
+    metric = RecordingMetric()
+    support = ScheduleAwareSupport([metric], _scheduled_dataset())
+
+    support.payload_additions(MATRIX, ["c", "a", "b"])
+
+    assert metric.received_first_seen == [1, 0, 0]
+
+
+def test_payload_reports_the_metrics_and_the_resolved_mapping():
+    support = ScheduleAwareSupport([RecordingMetric()], {"a": 0, "b": 0, "c": 1})
+
+    payload = support.payload_additions(MATRIX, CATEGORIES)
+
+    assert payload["schedule_aware_metrics"] == {"Recording": 0.5}
+    assert payload["first_seen_step"] == {"a": 0, "b": 0, "c": 1}
+
+
+def test_rejecting_an_empty_metric_list():
+    with pytest.raises(ValueError, match="must not be empty"):
+        ScheduleAwareSupport([], {"a": 0})
+
+
+def test_rejecting_a_missing_mapping():
+    with pytest.raises(ValueError, match="first_seen_step"):
+        ScheduleAwareSupport([RecordingMetric()], None)
+
+
+def test_rejecting_a_concept_absent_from_the_mapping():
+    support = ScheduleAwareSupport([RecordingMetric()], {"a": 0, "b": 0})
+
+    with pytest.raises(ValueError, match="'c'"):
+        support.payload_additions(MATRIX, CATEGORIES)

--- a/tests/data/test_grouping.py
+++ b/tests/data/test_grouping.py
@@ -1,0 +1,295 @@
+import numpy as np
+import pytest
+
+from pyclad.data.concept import Concept
+from pyclad.data.datasets.concepts_dataset import ConceptsDataset
+from pyclad.data.grouping import (
+    StepScheduledConceptsDataset,
+    apply_step_schedule,
+    compute_first_seen_step,
+    first_seen_step_for_test_order,
+    format_step_schedule,
+    group_concepts_by_schedule,
+    parse_step_schedule,
+)
+from pyclad.vision.data.vision_concept import VisionConcept
+
+MVTEC_CATEGORIES = [
+    "bottle",
+    "cable",
+    "capsule",
+    "carpet",
+    "grid",
+    "hazelnut",
+    "leather",
+    "metal_nut",
+    "pill",
+    "screw",
+    "tile",
+    "toothbrush",
+    "transistor",
+    "wood",
+    "zipper",
+]
+
+
+def _concept(name: str, rows: int, *, with_labels: bool = False, value: float = 0.0) -> Concept:
+    return Concept(
+        name=name,
+        data=np.full((rows, 2), value, dtype=np.float64),
+        labels=np.zeros(rows, dtype=np.int64) if with_labels else None,
+    )
+
+
+def _vision_concept(name: str, rows: int) -> VisionConcept:
+    return VisionConcept(
+        name=name,
+        data=np.zeros((rows, 4, 4, 3), dtype=np.uint8),
+        labels=np.zeros(rows, dtype=np.int64),
+        masks=np.zeros((rows, 4, 4), dtype=np.uint8),
+    )
+
+
+class TestParseStepSchedule:
+    @pytest.mark.parametrize(
+        "spec, expected",
+        [
+            ("14-1", [14, 1]),
+            ("10-5", [10, 5]),
+            ("3x5", [3, 3, 3, 3, 3]),
+            ("3×5", [3, 3, 3, 3, 3]),
+            ("3*5", [3, 3, 3, 3, 3]),
+            ("10-1x5", [10, 1, 1, 1, 1, 1]),
+            ("8-1x4", [8, 1, 1, 1, 1]),
+            ("15", [15]),
+            (" 14 - 1 ", [14, 1]),
+        ],
+    )
+    def test_parsing_string_specs(self, spec, expected):
+        assert parse_step_schedule(spec) == expected
+
+    def test_parsing_sequence_of_ints(self):
+        assert parse_step_schedule([10, 5]) == [10, 5]
+
+    def test_accepting_matching_total_categories(self):
+        assert parse_step_schedule("14-1", total_categories=15) == [14, 1]
+
+    def test_rejecting_schedule_that_does_not_sum_to_total_categories(self):
+        with pytest.raises(ValueError, match="sums to 15"):
+            parse_step_schedule("14-1", total_categories=12)
+
+    @pytest.mark.parametrize("spec", ["", "   ", "0-5", "5-0", "a", "14-", "-14", "3x0", "1.5"])
+    def test_rejecting_invalid_specs(self, spec):
+        with pytest.raises(ValueError):
+            parse_step_schedule(spec)
+
+    def test_rejecting_empty_sequence(self):
+        with pytest.raises(ValueError):
+            parse_step_schedule([])
+
+    def test_rejecting_non_positive_entries_in_sequence(self):
+        with pytest.raises(ValueError):
+            parse_step_schedule([3, 0, 2])
+
+
+class TestFormatStepSchedule:
+    @pytest.mark.parametrize(
+        "schedule, expected",
+        [
+            ([14, 1], "14-1"),
+            ([10, 1, 1, 1], "10-1x3"),
+            ([3, 3, 3, 3, 3], "3x5"),
+            ([15], "15"),
+        ],
+    )
+    def test_formatting_is_inverse_of_parsing(self, schedule, expected):
+        assert format_step_schedule(schedule) == expected
+        assert parse_step_schedule(expected) == schedule
+
+
+class TestGroupConceptsBySchedule:
+    def test_grouping_produces_one_concept_per_step(self):
+        concepts = [_concept(f"c{i}", rows=2) for i in range(5)]
+
+        grouped = group_concepts_by_schedule(concepts, [3, 2])
+
+        assert len(grouped) == 2
+        assert [c.data.shape[0] for c in grouped] == [6, 4]
+
+    def test_indexed_naming_is_the_default(self):
+        concepts = [_concept(f"c{i}", rows=1) for i in range(3)]
+
+        grouped = group_concepts_by_schedule(concepts, [2, 1])
+
+        assert [c.name for c in grouped] == ["step_0", "step_1"]
+
+    def test_joined_naming_uses_original_category_names(self):
+        concepts = [_concept(name, rows=1) for name in ["bottle", "cable", "capsule"]]
+
+        grouped = group_concepts_by_schedule(concepts, [2, 1], name_mode="joined")
+
+        assert [c.name for c in grouped] == ["bottle+cable", "capsule"]
+
+    def test_concatenating_data_in_schedule_order(self):
+        concepts = [_concept("a", rows=1, value=1.0), _concept("b", rows=1, value=2.0)]
+
+        grouped = group_concepts_by_schedule(concepts, [2])
+
+        np.testing.assert_array_equal(grouped[0].data, np.array([[1.0, 1.0], [2.0, 2.0]]))
+
+    def test_concatenating_labels_when_all_concepts_have_them(self):
+        concepts = [_concept(f"c{i}", rows=2, with_labels=True) for i in range(2)]
+
+        grouped = group_concepts_by_schedule(concepts, [2])
+
+        assert grouped[0].labels.shape == (4,)
+
+    def test_keeping_labels_none_when_no_concept_has_them(self):
+        concepts = [_concept(f"c{i}", rows=2) for i in range(2)]
+
+        grouped = group_concepts_by_schedule(concepts, [2])
+
+        assert grouped[0].labels is None
+
+    def test_rejecting_mix_of_labelled_and_unlabelled_concepts(self):
+        concepts = [_concept("a", rows=2, with_labels=True), _concept("b", rows=2)]
+
+        with pytest.raises(ValueError, match="labels"):
+            group_concepts_by_schedule(concepts, [2])
+
+    def test_rejecting_schedule_that_does_not_match_concept_count(self):
+        concepts = [_concept(f"c{i}", rows=1) for i in range(5)]
+
+        with pytest.raises(ValueError, match="does not match"):
+            group_concepts_by_schedule(concepts, [3, 3])
+
+    def test_rejecting_unknown_name_mode(self):
+        concepts = [_concept("a", rows=1)]
+
+        with pytest.raises(ValueError, match="name_mode"):
+            group_concepts_by_schedule(concepts, [1], name_mode="fancy")
+
+    def test_preserving_vision_concept_type_and_masks(self):
+        concepts = [_vision_concept("a", rows=2), _vision_concept("b", rows=3)]
+
+        grouped = group_concepts_by_schedule(concepts, [2])
+
+        assert isinstance(grouped[0], VisionConcept)
+        assert grouped[0].masks.shape == (5, 4, 4)
+        assert grouped[0].data.shape[0] == grouped[0].masks.shape[0]
+
+    def test_preserving_masks_for_single_concept_step(self):
+        concepts = [_vision_concept("a", rows=2)]
+
+        grouped = group_concepts_by_schedule(concepts, [1])
+
+        assert isinstance(grouped[0], VisionConcept)
+        assert grouped[0].masks.shape == (2, 4, 4)
+        assert grouped[0].name == "step_0"
+
+    def test_rejecting_mixed_concept_types_within_a_step(self):
+        concepts = [_vision_concept("a", rows=2), _concept("b", rows=2, with_labels=True)]
+
+        with pytest.raises(ValueError, match="type"):
+            group_concepts_by_schedule(concepts, [2])
+
+
+class TestComputeFirstSeenStep:
+    def test_mvtec_14_1(self):
+        assert compute_first_seen_step(MVTEC_CATEGORIES, "14-1") == [0] * 14 + [1]
+
+    def test_mvtec_3x5(self):
+        expected = [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4]
+
+        assert compute_first_seen_step(MVTEC_CATEGORIES, "3x5") == expected
+
+    def test_one_category_per_step_is_the_identity(self):
+        names = ["a", "b", "c"]
+
+        assert compute_first_seen_step(names, [1, 1, 1]) == [0, 1, 2]
+
+    def test_rejecting_schedule_that_does_not_cover_all_categories(self):
+        with pytest.raises(ValueError):
+            compute_first_seen_step(["a", "b", "c"], "14-1")
+
+
+class TestFirstSeenStepForTestOrder:
+    def test_realigning_to_a_shuffled_test_order(self):
+        train_order = ["a", "b", "c"]
+        test_order = ["c", "a", "b"]
+
+        assert first_seen_step_for_test_order(train_order, [2, 1], test_order) == [1, 0, 0]
+
+    def test_raising_for_a_test_concept_missing_from_training_order(self):
+        with pytest.raises(KeyError, match="unknown"):
+            first_seen_step_for_test_order(["a", "b"], [2], ["a", "unknown"])
+
+
+class TestApplyStepSchedule:
+    def _dataset(self, train_count: int = 5, test_count: int = 5) -> ConceptsDataset:
+        return ConceptsDataset(
+            name="toy",
+            train_concepts=[_concept(f"c{i}", rows=2) for i in range(train_count)],
+            test_concepts=[_concept(f"c{i}", rows=2, with_labels=True) for i in range(test_count)],
+        )
+
+    def test_grouping_train_concepts_while_keeping_test_concepts_per_category(self):
+        scheduled = apply_step_schedule(self._dataset(), "3-2")
+
+        assert len(scheduled.train_concepts()) == 2
+        assert len(scheduled.test_concepts()) == 5
+
+    def test_keeping_original_test_concept_objects_untouched(self):
+        dataset = self._dataset()
+
+        scheduled = apply_step_schedule(dataset, "3-2")
+
+        assert [c.name for c in scheduled.test_concepts()] == [c.name for c in dataset.test_concepts()]
+
+    def test_grouping_test_concepts_when_requested(self):
+        scheduled = apply_step_schedule(self._dataset(), "3-2", group_test=True)
+
+        assert len(scheduled.train_concepts()) == 2
+        assert len(scheduled.test_concepts()) == 2
+
+    def test_rejecting_group_test_when_train_and_test_do_not_align(self):
+        dataset = self._dataset(train_count=5, test_count=4)
+
+        with pytest.raises(ValueError, match="1:1"):
+            apply_step_schedule(dataset, "3-2", group_test=True)
+
+    def test_deriving_dataset_name_from_schedule(self):
+        scheduled = apply_step_schedule(self._dataset(), "3-2")
+
+        assert scheduled.name() == "toy__3-2"
+
+    def test_honouring_explicit_dataset_name(self):
+        scheduled = apply_step_schedule(self._dataset(), "3-2", dataset_name="custom")
+
+        assert scheduled.name() == "custom"
+
+    def test_exposing_the_schedule_and_the_pre_grouping_category_order(self):
+        scheduled = apply_step_schedule(self._dataset(), "3-2")
+
+        assert isinstance(scheduled, StepScheduledConceptsDataset)
+        assert scheduled.schedule() == [3, 2]
+        assert scheduled.category_order() == ["c0", "c1", "c2", "c3", "c4"]
+        assert scheduled.group_test() is False
+
+    def test_exposing_first_seen_step_keyed_by_category(self):
+        scheduled = apply_step_schedule(self._dataset(), "3-2")
+
+        assert scheduled.first_seen_step() == {"c0": 0, "c1": 0, "c2": 0, "c3": 1, "c4": 1}
+
+    def test_reporting_schedule_metadata_in_additional_info(self):
+        info = apply_step_schedule(self._dataset(), "3-2").additional_info()
+
+        assert info["step_schedule"] == "3-2"
+        assert info["step_schedule_parsed"] == [3, 2]
+        assert info["train_steps"] == ["step_0", "step_1"]
+        assert info["group_test"] is False
+        assert info["first_seen_step"] == {"c0": 0, "c1": 0, "c2": 0, "c3": 1, "c4": 1}
+
+    def test_rejecting_schedule_that_does_not_sum_to_train_concept_count(self):
+        with pytest.raises(ValueError, match="sums to"):
+            apply_step_schedule(self._dataset(), "4-2")

--- a/tests/data/test_grouping.py
+++ b/tests/data/test_grouping.py
@@ -293,3 +293,26 @@ class TestApplyStepSchedule:
     def test_rejecting_schedule_that_does_not_sum_to_train_concept_count(self):
         with pytest.raises(ValueError, match="sums to"):
             apply_step_schedule(self._dataset(), "4-2")
+
+
+class TestGroupTestGuards:
+    def _dataset(self, test_names):
+        return ConceptsDataset(
+            name="toy",
+            train_concepts=[_concept(f"c{i}", rows=2) for i in range(3)],
+            test_concepts=[_concept(name, rows=2, with_labels=True) for name in test_names],
+        )
+
+    def test_rejecting_group_test_when_test_concepts_are_a_different_set(self):
+        with pytest.raises(ValueError, match="1:1"):
+            apply_step_schedule(self._dataset(["c0", "c1", "other"]), "2-1", group_test=True)
+
+    def test_rejecting_group_test_when_test_concepts_are_in_a_different_order(self):
+        with pytest.raises(ValueError, match="1:1"):
+            apply_step_schedule(self._dataset(["c2", "c0", "c1"]), "2-1", group_test=True)
+
+    def test_first_seen_step_is_unavailable_when_test_concepts_were_grouped(self):
+        scheduled = apply_step_schedule(self._dataset(["c0", "c1", "c2"]), "2-1", group_test=True)
+
+        with pytest.raises(ValueError, match="group_test=True"):
+            scheduled.first_seen_step()

--- a/tests/metrics/continual/test_average_continual.py
+++ b/tests/metrics/continual/test_average_continual.py
@@ -19,7 +19,7 @@ def test_empty_matrix():
 
 def test_raises_exception_when_matrix_not_square():
     metric = ContinualAverage()
-    with pytest.raises(IndexError):
+    with pytest.raises(ValueError, match="square"):
         metric.compute([[1, 1, 1], [1, 1, 1], [1, 1]])
 
 

--- a/tests/metrics/continual/test_backward_transfer.py
+++ b/tests/metrics/continual/test_backward_transfer.py
@@ -21,7 +21,7 @@ def test_empty_matrix():
 
 def test_raises_exception_when_matrix_not_square():
     metric = BackwardTransfer()
-    with pytest.raises(IndexError):
+    with pytest.raises(ValueError, match="square"):
         metric.compute([[1, 1, 1], [1], [1, 1, 1]])
 
 

--- a/tests/metrics/continual/test_final_step_average.py
+++ b/tests/metrics/continual/test_final_step_average.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pytest
+
+from pyclad.metrics.continual.final_step_average import FinalStepAverage
+
+parameters = [
+    # Single concept, single step
+    ([[0.5]], 0.5),
+    # Square matrix: only the last row counts
+    ([[0.9, 0.9], [0.4, 0.6]], 0.5),
+    # Rectangular T x N matrix (step schedule "2-1" over 3 categories)
+    ([[0.9, 0.8, 0.1], [0.6, 0.4, 0.8]], 0.6),
+    # A single training step evaluated on every category
+    ([[0.2, 0.4, 0.6]], 0.4),
+]
+
+
+def test_empty_matrix():
+    assert FinalStepAverage().compute([]) == 0.0
+
+
+def test_matrix_without_columns():
+    assert FinalStepAverage().compute([[]]) == 0.0
+
+
+def test_name():
+    assert FinalStepAverage().name() == "FinalStepAverage"
+
+
+@pytest.mark.parametrize("matrix, expected", parameters)
+def test_averaging_the_final_row(matrix, expected):
+    assert FinalStepAverage().compute(matrix) == pytest.approx(expected)
+
+
+def test_ignoring_nan_entries():
+    assert FinalStepAverage().compute([[0.1, 0.2], [0.4, np.nan]]) == pytest.approx(0.4)

--- a/tests/metrics/continual/test_forward_transfer.py
+++ b/tests/metrics/continual/test_forward_transfer.py
@@ -19,7 +19,7 @@ def test_empty_matrix():
 
 def test_raises_exception_when_matrix_not_square():
     metric = ForwardTransfer()
-    with pytest.raises(IndexError):
+    with pytest.raises(ValueError, match="square"):
         metric.compute([[1, 1], [1, 1, 1], [1, 1]])
 
 

--- a/tests/metrics/continual/test_schedule_aware_forgetting_measure.py
+++ b/tests/metrics/continual/test_schedule_aware_forgetting_measure.py
@@ -1,0 +1,88 @@
+import numpy as np
+import pytest
+
+from pyclad.metrics.continual.schedule_aware_forgetting_measure import (
+    ScheduleAwareForgettingMeasure,
+)
+
+# Rectangular 2 x 3 matrix produced by the step schedule "2-1" over three categories.
+RECTANGULAR = [
+    [0.9, 0.8, 0.1],
+    [0.6, 0.4, 0.8],
+]
+RECTANGULAR_FIRST_SEEN = [0, 0, 1]
+
+SQUARE = [
+    [0.9, 0.5, 0.1],
+    [0.6, 0.8, 0.2],
+    [0.3, 0.4, 0.7],
+]
+SQUARE_FIRST_SEEN = [0, 1, 2]
+
+
+def test_name():
+    assert ScheduleAwareForgettingMeasure().name() == "ScheduleAwareForgettingMeasure"
+
+
+def test_empty_matrix():
+    assert ScheduleAwareForgettingMeasure().compute([], []) == 0.0
+
+
+def test_single_training_step_has_no_forgetting():
+    assert ScheduleAwareForgettingMeasure().compute([[0.5, 0.6]], [0, 0]) == 0.0
+
+
+def test_forgetting_on_a_rectangular_matrix():
+    # col0: max(rows [0, 0]) - final = 0.9 - 0.6 = 0.3
+    # col1: max(rows [0, 0]) - final = 0.8 - 0.4 = 0.4
+    # col2: first seen at the last step -> skipped
+    result = ScheduleAwareForgettingMeasure().compute(RECTANGULAR, RECTANGULAR_FIRST_SEEN)
+
+    assert result == pytest.approx(0.35)
+
+
+def test_forgetting_on_a_square_matrix():
+    # col0: max(0.9, 0.6) - 0.3 = 0.6
+    # col1: max(0.8) - 0.4 = 0.4
+    # col2: first seen at the last step -> skipped
+    result = ScheduleAwareForgettingMeasure().compute(SQUARE, SQUARE_FIRST_SEEN)
+
+    assert result == pytest.approx(0.5)
+
+
+def test_skipping_columns_first_seen_at_or_after_the_final_step():
+    # Every column enters training only at the final step: forgetting is undefined.
+    result = ScheduleAwareForgettingMeasure().compute(RECTANGULAR, [1, 1, 1])
+
+    assert result == 0.0
+
+
+def test_restricting_history_to_rows_after_the_column_was_first_seen():
+    matrix = [
+        [0.99, 0.99],  # pre-training row for col1, must be ignored
+        [0.50, 0.60],
+        [0.40, 0.50],
+    ]
+
+    result = ScheduleAwareForgettingMeasure().compute(matrix, [0, 1])
+
+    # col0: max(0.99, 0.50) - 0.40 = 0.59 ; col1: max(0.60) - 0.50 = 0.10
+    assert result == pytest.approx(0.345)
+
+
+def test_ignoring_nan_entries():
+    matrix = [
+        [np.nan, 0.8],
+        [0.9, 0.6],
+        [0.5, 0.4],
+    ]
+
+    result = ScheduleAwareForgettingMeasure().compute(matrix, [0, 0])
+
+    # col0: max(0.9) - 0.5 = 0.4 ; col1: max(0.8, 0.6) - 0.4 = 0.4
+    assert result == pytest.approx(0.4)
+
+
+def test_rejecting_first_seen_steps_of_the_wrong_length():
+    with pytest.raises(ValueError, match="first_seen_steps"):
+        ScheduleAwareForgettingMeasure().compute(RECTANGULAR, [0, 0])

--- a/tests/metrics/continual/test_schedule_aware_forward_transfer.py
+++ b/tests/metrics/continual/test_schedule_aware_forward_transfer.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pytest
+
+from pyclad.metrics.continual.schedule_aware_forward_transfer import (
+    ScheduleAwareForwardTransfer,
+)
+
+RECTANGULAR = [
+    [0.9, 0.8, 0.1],
+    [0.6, 0.4, 0.8],
+]
+
+SQUARE = [
+    [0.9, 0.5, 0.1],
+    [0.6, 0.8, 0.2],
+    [0.3, 0.4, 0.7],
+]
+
+
+def test_name():
+    assert ScheduleAwareForwardTransfer().name() == "ScheduleAwareForwardTransfer"
+
+
+def test_empty_matrix():
+    assert ScheduleAwareForwardTransfer().compute([], []) == 0.0
+
+
+def test_forward_transfer_on_a_rectangular_matrix():
+    # Only col2 has pre-training rows: mean(0.1) = 0.1
+    result = ScheduleAwareForwardTransfer().compute(RECTANGULAR, [0, 0, 1])
+
+    assert result == pytest.approx(0.1)
+
+
+def test_forward_transfer_on_a_square_matrix():
+    # col1: mean(0.5) = 0.5 ; col2: mean(0.1, 0.2) = 0.15 ; col0 has no pre-training rows
+    result = ScheduleAwareForwardTransfer().compute(SQUARE, [0, 1, 2])
+
+    assert result == pytest.approx(0.325)
+
+
+def test_skipping_columns_trained_from_the_very_first_step():
+    result = ScheduleAwareForwardTransfer().compute(RECTANGULAR, [0, 0, 0])
+
+    assert result == 0.0
+
+
+def test_ignoring_nan_entries():
+    matrix = [
+        [0.2, np.nan],
+        [0.4, 0.6],
+        [0.5, 0.5],
+    ]
+
+    # col1: pre-training rows are [nan, 0.6] -> mean(0.6) = 0.6
+    result = ScheduleAwareForwardTransfer().compute(matrix, [0, 2])
+
+    assert result == pytest.approx(0.6)
+
+
+def test_rejecting_first_seen_steps_of_the_wrong_length():
+    with pytest.raises(ValueError, match="first_seen_steps"):
+        ScheduleAwareForwardTransfer().compute(RECTANGULAR, [0, 1])

--- a/tests/metrics/continual/test_schedule_aware_new_task_acquisition.py
+++ b/tests/metrics/continual/test_schedule_aware_new_task_acquisition.py
@@ -1,0 +1,59 @@
+import numpy as np
+import pytest
+
+from pyclad.metrics.continual.schedule_aware_new_task_acquisition import (
+    ScheduleAwareNewTaskAcquisition,
+)
+
+RECTANGULAR = [
+    [0.9, 0.8, 0.1],
+    [0.6, 0.4, 0.8],
+]
+
+SQUARE = [
+    [0.9, 0.5, 0.1],
+    [0.6, 0.8, 0.2],
+    [0.3, 0.4, 0.7],
+]
+
+
+def test_name():
+    assert ScheduleAwareNewTaskAcquisition().name() == "ScheduleAwareNewTaskAcquisition"
+
+
+def test_empty_matrix():
+    assert ScheduleAwareNewTaskAcquisition().compute([], []) == 0.0
+
+
+def test_reading_the_value_at_the_step_each_category_was_first_seen():
+    # M[0][0]=0.9, M[0][1]=0.8, M[1][2]=0.8
+    result = ScheduleAwareNewTaskAcquisition().compute(RECTANGULAR, [0, 0, 1])
+
+    assert result == pytest.approx(0.8333333, abs=1e-6)
+
+
+def test_identity_first_seen_reads_the_diagonal():
+    result = ScheduleAwareNewTaskAcquisition().compute(SQUARE, [0, 1, 2])
+
+    assert result == pytest.approx((0.9 + 0.8 + 0.7) / 3)
+
+
+def test_ignoring_nan_entries():
+    matrix = [
+        [np.nan, 0.8],
+        [0.6, 0.4],
+    ]
+
+    result = ScheduleAwareNewTaskAcquisition().compute(matrix, [0, 0])
+
+    assert result == pytest.approx(0.8)
+
+
+def test_rejecting_first_seen_steps_of_the_wrong_length():
+    with pytest.raises(ValueError, match="first_seen_steps"):
+        ScheduleAwareNewTaskAcquisition().compute(RECTANGULAR, [0, 0])
+
+
+def test_rejecting_first_seen_step_outside_the_matrix():
+    with pytest.raises(ValueError, match="out of range"):
+        ScheduleAwareNewTaskAcquisition().compute(RECTANGULAR, [0, 0, 5])

--- a/tests/metrics/continual/test_square_matrix_validation.py
+++ b/tests/metrics/continual/test_square_matrix_validation.py
@@ -39,3 +39,10 @@ def test_accepting_square_matrix(metric):
 @pytest.mark.parametrize("metric", METRICS, ids=lambda m: m.name())
 def test_accepting_empty_matrix(metric):
     metric.compute([])
+
+
+@pytest.mark.parametrize("metric", METRICS, ids=lambda m: m.name())
+def test_rejecting_a_row_without_columns(metric):
+    """`[[]]` is not square either: one row, no columns."""
+    with pytest.raises(ValueError, match="square"):
+        metric.compute([[]])

--- a/tests/metrics/continual/test_square_matrix_validation.py
+++ b/tests/metrics/continual/test_square_matrix_validation.py
@@ -1,0 +1,41 @@
+"""Metrics that walk the diagonal or the triangles of the matrix require a square one.
+
+With a step schedule the metric matrix becomes rectangular (T x N, T < N). Without these
+guards the classic metrics silently return a number computed over meaningless cells --
+the kind of defect that survives review and ends up in a results table.
+"""
+
+import pytest
+
+from pyclad.metrics.continual.average_continual import ContinualAverage
+from pyclad.metrics.continual.backward_transfer import BackwardTransfer
+from pyclad.metrics.continual.forgetting_measure import ForgettingMeasure
+from pyclad.metrics.continual.forward_transfer import ForwardTransfer
+
+RECTANGULAR = [
+    [0.9, 0.8, 0.1],
+    [0.6, 0.4, 0.8],
+]
+
+SQUARE = [
+    [0.9, 0.5],
+    [0.6, 0.8],
+]
+
+METRICS = [ContinualAverage(), BackwardTransfer(), ForwardTransfer(), ForgettingMeasure()]
+
+
+@pytest.mark.parametrize("metric", METRICS, ids=lambda m: m.name())
+def test_rejecting_rectangular_matrix(metric):
+    with pytest.raises(ValueError, match="square"):
+        metric.compute(RECTANGULAR)
+
+
+@pytest.mark.parametrize("metric", METRICS, ids=lambda m: m.name())
+def test_accepting_square_matrix(metric):
+    metric.compute(SQUARE)
+
+
+@pytest.mark.parametrize("metric", METRICS, ids=lambda m: m.name())
+def test_accepting_empty_matrix(metric):
+    metric.compute([])

--- a/tests/scenarios/test_step_scheduled_scenario.py
+++ b/tests/scenarios/test_step_scheduled_scenario.py
@@ -1,0 +1,146 @@
+"""End-to-end check that a step-scheduled dataset runs through a scenario and reports metrics.
+
+Covers the seam between the three layers that grouping touches: the grouped dataset feeds
+the unchanged scenario, the scenario drives the callback with train-step names on one axis
+and category names on the other, and the schedule-aware metrics land in the output payload.
+"""
+
+import numpy as np
+import pytest
+
+from pyclad.callbacks.evaluation.concept_metric_evaluation import ConceptMetricCallback
+from pyclad.data.concept import Concept
+from pyclad.data.datasets.concepts_dataset import ConceptsDataset
+from pyclad.data.grouping import apply_step_schedule
+from pyclad.metrics.base.base_metric import BaseMetric
+from pyclad.metrics.continual.final_step_average import FinalStepAverage
+from pyclad.metrics.continual.forgetting_measure import ForgettingMeasure
+from pyclad.metrics.continual.schedule_aware_forgetting_measure import (
+    ScheduleAwareForgettingMeasure,
+)
+from pyclad.metrics.continual.schedule_aware_forward_transfer import (
+    ScheduleAwareForwardTransfer,
+)
+from pyclad.metrics.continual.schedule_aware_new_task_acquisition import (
+    ScheduleAwareNewTaskAcquisition,
+)
+from pyclad.models.model import Model
+from pyclad.output.prediction_results import PredictionResults
+from pyclad.scenarios.concept_aware import ConceptAwareScenario
+from pyclad.strategies.baselines.naive import NaiveStrategy
+
+CATEGORIES = ["bottle", "cable", "capsule", "carpet", "grid"]
+
+
+class ConstantScoreModel(Model):
+    def fit(self, data: np.ndarray) -> None:
+        pass
+
+    def predict(self, data: np.ndarray) -> PredictionResults:
+        rows = len(data)
+        return PredictionResults(
+            y_pred=np.zeros(rows, dtype=np.int64),
+            anomaly_scores=np.linspace(0.0, 1.0, num=rows),
+        )
+
+    def name(self) -> str:
+        return "ConstantScoreModel"
+
+
+class ConstantBaseMetric(BaseMetric):
+    def compute(self, anomaly_scores, y_pred, y_true) -> float:
+        return 0.75
+
+    def name(self) -> str:
+        return "Constant"
+
+
+@pytest.fixture
+def dataset():
+    return ConceptsDataset(
+        name="toy",
+        train_concepts=[
+            Concept(name=category, data=np.zeros((4, 3), dtype=np.float64)) for category in CATEGORIES
+        ],
+        test_concepts=[
+            Concept(
+                name=category,
+                data=np.zeros((4, 3), dtype=np.float64),
+                labels=np.array([0, 0, 1, 1], dtype=np.int64),
+            )
+            for category in CATEGORIES
+        ],
+    )
+
+
+def _run_scenario(dataset, callbacks):
+    ConceptAwareScenario(
+        dataset=dataset, strategy=NaiveStrategy(ConstantScoreModel()), callbacks=callbacks
+    ).run()
+
+
+def test_step_scheduled_run_reports_a_rectangular_matrix(dataset):
+    scheduled = apply_step_schedule(dataset, "3-1-1")
+    callback = ConceptMetricCallback(
+        base_metric=ConstantBaseMetric(),
+        summarized_metrics=[FinalStepAverage()],
+        schedule_aware_metrics=[
+            ScheduleAwareForgettingMeasure(),
+            ScheduleAwareForwardTransfer(),
+            ScheduleAwareNewTaskAcquisition(),
+        ],
+        first_seen_step=scheduled.first_seen_step(),
+    )
+
+    _run_scenario(scheduled, [callback])
+    info = callback.info()["concept_metric_callback_Constant"]
+
+    assert info["concepts_order"] == ["step_0", "step_1", "step_2"]
+    assert info["test_order"] == CATEGORIES
+    assert info["first_seen_step"] == {"bottle": 0, "cable": 0, "capsule": 0, "carpet": 1, "grid": 2}
+    assert info["metrics"]["FinalStepAverage"] == pytest.approx(0.75)
+    assert set(info["schedule_aware_metrics"]) == {
+        "ScheduleAwareForgettingMeasure",
+        "ScheduleAwareForwardTransfer",
+        "ScheduleAwareNewTaskAcquisition",
+    }
+
+
+def test_dataset_info_carries_the_schedule(dataset):
+    scheduled = apply_step_schedule(dataset, "3-1-1")
+
+    info = scheduled.info()["dataset"]
+
+    assert info["name"] == "toy__3-1x2"
+    assert info["step_schedule_parsed"] == [3, 1, 1]
+    assert info["train_steps"] == ["step_0", "step_1", "step_2"]
+
+
+def test_square_metrics_reject_the_step_scheduled_matrix(dataset):
+    """A square-only metric must fail loudly rather than average meaningless cells."""
+    scheduled = apply_step_schedule(dataset, "3-1-1")
+    callback = ConceptMetricCallback(
+        base_metric=ConstantBaseMetric(),
+        summarized_metrics=[],
+        stepwise_metrics=[ForgettingMeasure()],
+    )
+
+    _run_scenario(scheduled, [callback])
+
+    with pytest.raises(ValueError, match="square"):
+        callback.info()
+
+
+def test_ungrouped_run_still_produces_a_square_matrix(dataset):
+    callback = ConceptMetricCallback(
+        base_metric=ConstantBaseMetric(),
+        summarized_metrics=[FinalStepAverage()],
+        stepwise_metrics=[ForgettingMeasure()],
+    )
+
+    _run_scenario(dataset, [callback])
+    info = callback.info()["concept_metric_callback_Constant"]
+
+    assert info["concepts_order"] == CATEGORIES
+    assert info["test_order"] == CATEGORIES
+    assert len(info["stepwise_metrics"]["ForgettingMeasure"]) == len(CATEGORIES)

--- a/tests/scenarios/test_step_scheduled_scenario.py
+++ b/tests/scenarios/test_step_scheduled_scenario.py
@@ -8,7 +8,10 @@ and category names on the other, and the schedule-aware metrics land in the outp
 import numpy as np
 import pytest
 
-from pyclad.callbacks.evaluation.concept_metric_evaluation import ConceptMetricCallback
+from pyclad.callbacks.evaluation.concept_metric_evaluation import (
+    ConceptMetricCallback,
+    ScheduleAwareConceptMetricCallback,
+)
 from pyclad.data.concept import Concept
 from pyclad.data.datasets.concepts_dataset import ConceptsDataset
 from pyclad.data.grouping import apply_step_schedule
@@ -59,9 +62,7 @@ class ConstantBaseMetric(BaseMetric):
 def dataset():
     return ConceptsDataset(
         name="toy",
-        train_concepts=[
-            Concept(name=category, data=np.zeros((4, 3), dtype=np.float64)) for category in CATEGORIES
-        ],
+        train_concepts=[Concept(name=category, data=np.zeros((4, 3), dtype=np.float64)) for category in CATEGORIES],
         test_concepts=[
             Concept(
                 name=category,
@@ -74,14 +75,12 @@ def dataset():
 
 
 def _run_scenario(dataset, callbacks):
-    ConceptAwareScenario(
-        dataset=dataset, strategy=NaiveStrategy(ConstantScoreModel()), callbacks=callbacks
-    ).run()
+    ConceptAwareScenario(dataset=dataset, strategy=NaiveStrategy(ConstantScoreModel()), callbacks=callbacks).run()
 
 
 def test_step_scheduled_run_reports_a_rectangular_matrix(dataset):
     scheduled = apply_step_schedule(dataset, "3-1-1")
-    callback = ConceptMetricCallback(
+    callback = ScheduleAwareConceptMetricCallback(
         base_metric=ConstantBaseMetric(),
         summarized_metrics=[FinalStepAverage()],
         schedule_aware_metrics=[

--- a/tests/vision/callbacks/test_rectangular_vision_pixel_callback.py
+++ b/tests/vision/callbacks/test_rectangular_vision_pixel_callback.py
@@ -4,6 +4,8 @@ import numpy as np
 import pytest
 
 from pyclad.data.concept import Concept
+from pyclad.data.datasets.concepts_dataset import ConceptsDataset
+from pyclad.data.grouping import apply_step_schedule
 from pyclad.metrics.base.base_metric import BaseMetric
 from pyclad.metrics.continual.concepts_metric import (
     ConceptLevelMatrix,
@@ -11,6 +13,7 @@ from pyclad.metrics.continual.concepts_metric import (
 )
 from pyclad.metrics.continual.final_step_average import FinalStepAverage
 from pyclad.vision.callbacks.vision_pixel_concept_metric_callback import (
+    ScheduleAwareVisionPixelConceptMetricCallback,
     VisionPixelConceptMetricCallback,
 )
 from pyclad.vision.data.vision_concept import VisionConcept
@@ -92,7 +95,7 @@ def test_reporting_train_and_test_order_separately():
 
 def test_passing_the_aligned_first_seen_steps_to_schedule_aware_metrics():
     metric = RecordingScheduleAwareMetric()
-    callback = VisionPixelConceptMetricCallback(
+    callback = ScheduleAwareVisionPixelConceptMetricCallback(
         base_metric=ScoreDrivenPixelMetric(),
         schedule_aware_metrics=[metric],
         first_seen_step=FIRST_SEEN,
@@ -107,7 +110,7 @@ def test_passing_the_aligned_first_seen_steps_to_schedule_aware_metrics():
 
 def test_rejecting_schedule_aware_metrics_without_a_first_seen_mapping():
     with pytest.raises(ValueError, match="first_seen_step"):
-        VisionPixelConceptMetricCallback(
+        ScheduleAwareVisionPixelConceptMetricCallback(
             base_metric=ScoreDrivenPixelMetric(),
             schedule_aware_metrics=[RecordingScheduleAwareMetric()],
         )
@@ -128,3 +131,25 @@ def test_reporting_nothing_when_no_pixel_evaluation_happened():
     callback.after_training(Concept(name="step_0", data=np.array([])))
 
     assert callback.info() == {}
+
+
+def test_accepting_a_step_scheduled_dataset_instead_of_a_mapping():
+    """Same wiring as the image-level callback, since both go through ScheduleAwareSupport."""
+    dataset = ConceptsDataset(
+        name="toy",
+        train_concepts=[Concept(name=c, data=np.zeros((2, 1))) for c in TEST_CATEGORIES],
+        test_concepts=[Concept(name=c, data=np.zeros((2, 1)), labels=np.zeros(2)) for c in TEST_CATEGORIES],
+    )
+    scheduled = apply_step_schedule(dataset, "2-1")
+    metric = RecordingScheduleAwareMetric()
+    callback = ScheduleAwareVisionPixelConceptMetricCallback(
+        base_metric=ScoreDrivenPixelMetric(),
+        schedule_aware_metrics=[metric],
+        first_seen_step=scheduled,
+    )
+
+    _run(callback, [[0.9, 0.8, 0.1], [0.6, 0.4, 0.7]])
+    info = _info(callback)
+
+    assert metric.received_first_seen == [0, 0, 1]
+    assert info["first_seen_step"] == {"bottle": 0, "cable": 0, "capsule": 1}

--- a/tests/vision/callbacks/test_rectangular_vision_pixel_callback.py
+++ b/tests/vision/callbacks/test_rectangular_vision_pixel_callback.py
@@ -1,0 +1,130 @@
+"""Pixel-level concept-metric callback under a step schedule (rectangular T x N matrix)."""
+
+import numpy as np
+import pytest
+
+from pyclad.data.concept import Concept
+from pyclad.metrics.base.base_metric import BaseMetric
+from pyclad.metrics.continual.concepts_metric import (
+    ConceptLevelMatrix,
+    ScheduleAwareMetric,
+)
+from pyclad.metrics.continual.final_step_average import FinalStepAverage
+from pyclad.vision.callbacks.vision_pixel_concept_metric_callback import (
+    VisionPixelConceptMetricCallback,
+)
+from pyclad.vision.data.vision_concept import VisionConcept
+
+TEST_CATEGORIES = ["bottle", "cable", "capsule"]
+TRAIN_STEPS = ["step_0", "step_1"]
+FIRST_SEEN = {"bottle": 0, "cable": 0, "capsule": 1}
+
+
+class ScoreDrivenPixelMetric(BaseMetric):
+    """Returns the constant the score map is filled with, so tests can pin matrix cells."""
+
+    def compute(self, anomaly_scores, y_pred, y_true) -> float:
+        return float(np.asarray(anomaly_scores).ravel()[0])
+
+    def name(self) -> str:
+        return "ScoreDrivenPixel"
+
+
+class RecordingScheduleAwareMetric(ScheduleAwareMetric):
+    def __init__(self):
+        self.received_matrix = None
+        self.received_first_seen = None
+
+    def compute(self, metric_matrix: ConceptLevelMatrix, first_seen_steps) -> float:
+        self.received_matrix = metric_matrix
+        self.received_first_seen = list(first_seen_steps)
+        return 0.42
+
+    def name(self) -> str:
+        return "RecordingScheduleAware"
+
+
+def _concept(name: str) -> VisionConcept:
+    return VisionConcept(
+        name=name,
+        data=np.zeros((2, 2, 2, 3), dtype=np.float32),
+        labels=np.array([1, 0], dtype=np.int64),
+        masks=np.zeros((2, 2, 2), dtype=np.uint8),
+    )
+
+
+def _info(callback):
+    return callback.info()["pixel_concept_metric_callback_ScoreDrivenPixel"]
+
+
+def _run(callback, cell_values, test_categories=TEST_CATEGORIES, train_steps=TRAIN_STEPS):
+    for step_index, step_name in enumerate(train_steps):
+        callback.after_training(Concept(name=step_name, data=np.array([])))
+        for category_index, category in enumerate(test_categories):
+            concept = _concept(category)
+            callback.after_evaluation(
+                evaluated_concept=concept,
+                y_true=concept.labels,
+                y_pred=np.array([0, 0], dtype=np.int64),
+                anomaly_scores=np.array([0.5, 0.5], dtype=np.float32),
+                score_maps=np.full((2, 2, 2), cell_values[step_index][category_index], dtype=np.float32),
+            )
+
+
+def test_building_a_rectangular_matrix_from_grouped_training_steps():
+    callback = VisionPixelConceptMetricCallback(
+        base_metric=ScoreDrivenPixelMetric(), summarized_metrics=[FinalStepAverage()]
+    )
+
+    _run(callback, [[0.9, 0.8, 0.1], [0.6, 0.4, 0.7]])
+
+    assert _info(callback)["metrics"]["FinalStepAverage"] == pytest.approx((0.6 + 0.4 + 0.7) / 3, abs=1e-6)
+
+
+def test_reporting_train_and_test_order_separately():
+    callback = VisionPixelConceptMetricCallback(base_metric=ScoreDrivenPixelMetric())
+
+    _run(callback, [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+
+    assert _info(callback)["concepts_order"] == TRAIN_STEPS
+    assert _info(callback)["test_order"] == TEST_CATEGORIES
+
+
+def test_passing_the_aligned_first_seen_steps_to_schedule_aware_metrics():
+    metric = RecordingScheduleAwareMetric()
+    callback = VisionPixelConceptMetricCallback(
+        base_metric=ScoreDrivenPixelMetric(),
+        schedule_aware_metrics=[metric],
+        first_seen_step=FIRST_SEEN,
+    )
+
+    _run(callback, [[0.9, 0.8, 0.1], [0.6, 0.4, 0.7]])
+    info = _info(callback)
+
+    assert metric.received_first_seen == [0, 0, 1]
+    assert info["schedule_aware_metrics"]["RecordingScheduleAware"] == 0.42
+
+
+def test_rejecting_schedule_aware_metrics_without_a_first_seen_mapping():
+    with pytest.raises(ValueError, match="first_seen_step"):
+        VisionPixelConceptMetricCallback(
+            base_metric=ScoreDrivenPixelMetric(),
+            schedule_aware_metrics=[RecordingScheduleAwareMetric()],
+        )
+
+
+def test_rejecting_a_matrix_with_a_missing_cell():
+    callback = VisionPixelConceptMetricCallback(base_metric=ScoreDrivenPixelMetric())
+    _run(callback, [[0.1, 0.2, 0.3]], train_steps=["step_0"])
+    # A second step during which the strategy produced no score maps at all.
+    callback.after_training(Concept(name="step_1", data=np.array([])))
+
+    with pytest.raises(ValueError, match="was not evaluated"):
+        callback.info()
+
+
+def test_reporting_nothing_when_no_pixel_evaluation_happened():
+    callback = VisionPixelConceptMetricCallback(base_metric=ScoreDrivenPixelMetric())
+    callback.after_training(Concept(name="step_0", data=np.array([])))
+
+    assert callback.info() == {}


### PR DESCRIPTION
Adds step scheduling: instead of one training step per concept, consecutive concepts are merged into multi-concept steps according to a schedule such as `"14-1"`, `"10-5"`, `"3x5"` or `"10-1x5"`, while evaluation stays per concept.