### PR TITLE
Add multidataset streams composed from vision datasets

### DIFF
--- a/examples/multi_dataset_example.py
+++ b/examples/multi_dataset_example.py
@@ -1,0 +1,102 @@
+import logging
+import pathlib
+
+from pyclad.callbacks.evaluation.concept_metric_evaluation import ConceptMetricCallback
+from pyclad.callbacks.evaluation.time_evaluation import TimeEvaluationCallback
+from pyclad.metrics.base.average_precision import AveragePrecision
+from pyclad.metrics.base.roc_auc import RocAuc
+from pyclad.metrics.continual.average_continual import ContinualAverage
+from pyclad.metrics.continual.backward_transfer import BackwardTransfer
+from pyclad.metrics.continual.forward_transfer import ForwardTransfer
+from pyclad.output.json_writer import JsonOutputWriter
+from pyclad.scenarios.concept_incremental import ConceptIncrementalScenario
+from pyclad.strategies.baselines.naive import NaiveStrategy
+from pyclad.vision.callbacks.vision_pixel_concept_metric_callback import (
+    VisionPixelConceptMetricCallback,
+)
+from pyclad.vision.data.multi_dataset import (
+    INCLAD_MD_SPEC,
+    load_inclad_md,
+    split_multi_dataset_concept_name,
+)
+from pyclad.vision.metrics.pixel_aupro import PixelAUPRO
+from pyclad.vision.metrics.pixel_roc_auc import PixelRocAuc
+from pyclad.vision.models.rd4ad.config import RD4ADConfig
+from pyclad.vision.models.rd4ad.rd4ad import RD4AD
+
+logging.basicConfig(level=logging.INFO)
+
+RESOURCES = pathlib.Path("resources/vision")
+ROOTS = {
+    "btech": RESOURCES / "BTech_Dataset_transformed",
+    "dagm": RESOURCES / "DAGM_KaggleUpload",
+    "mpdd": RESOURCES / "MPDD",
+    "mvtec": RESOURCES / "mvtec_ad",
+    "visa": RESOURCES / "VisA",
+}
+
+ORDERING = "easy_to_hard"
+
+if __name__ == "__main__":
+    """
+    This example runs InCLAD-MD, the published multidataset benchmark: a single continual
+    stream of 27 categories drawn from five source datasets at once -- BTech, MPDD, DAGM,
+    VisA and MVTec AD.
+
+    Unlike a single-source dataset there is no shared root: every source resolves its own
+    images. Concepts are named `<source>__<category>`, so categories that share a name across
+    datasets stay distinct.
+
+    To define your own stream instead, build a MultiDatasetSpec out of DatasetBlocks and pass
+    it to read_multi_dataset(); a spec round-trips through JSON, so a stream is reproducible
+    from a file. See docs/datasets.md.
+    """
+    print("InCLAD-MD concepts:", len(INCLAD_MD_SPEC.category_order()))
+    print("Stream:", INCLAD_MD_SPEC.category_order())
+
+    dataset = load_inclad_md(
+        roots=ROOTS,
+        ordering=ORDERING,
+        resize_to=(256, 256),
+        max_train_samples_per_category=100,
+    )
+
+    per_source: dict[str, int] = {}
+    for concept in dataset.train_concepts():
+        source, _ = split_multi_dataset_concept_name(concept.name)
+        per_source[source] = per_source.get(source, 0) + 1
+    print("Concepts per source dataset:", per_source)
+
+    model = RD4AD(
+        RD4ADConfig(
+            input_size=(256, 256),
+            backbone_name="resnet18",
+            pretrained_encoder=True,
+            freeze_encoder=True,
+            batch_size=16,
+            epochs=2,
+            learning_rate=5e-3,
+            score_smoothing_sigma=4.0,
+            score_mode="max",
+            threshold_quantile=0.99,
+            show_training_progress=True,
+        )
+    )
+    strategy = NaiveStrategy(model)
+    summarized_metrics = [ContinualAverage(), BackwardTransfer(), ForwardTransfer()]
+
+    callbacks = [
+        # Image-level
+        ConceptMetricCallback(base_metric=RocAuc(), summarized_metrics=summarized_metrics),
+        ConceptMetricCallback(base_metric=AveragePrecision(), summarized_metrics=summarized_metrics),
+        # Pixel-level
+        VisionPixelConceptMetricCallback(base_metric=PixelRocAuc(), summarized_metrics=summarized_metrics),
+        VisionPixelConceptMetricCallback(base_metric=PixelAUPRO(), summarized_metrics=summarized_metrics),
+        TimeEvaluationCallback(),
+    ]
+
+    scenario = ConceptIncrementalScenario(dataset=dataset, strategy=strategy, callbacks=callbacks)
+    scenario.run()
+
+    output_writer = JsonOutputWriter(pathlib.Path(f"output_inclad_md_{ORDERING}.json"))
+    output_writer.write([model, dataset, strategy, *callbacks])

--- a/examples/step_schedule_multi_dataset_example.py
+++ b/examples/step_schedule_multi_dataset_example.py
@@ -1,0 +1,137 @@
+import logging
+import pathlib
+
+from pyclad.callbacks.evaluation.concept_metric_evaluation import ConceptMetricCallback
+from pyclad.callbacks.evaluation.time_evaluation import TimeEvaluationCallback
+from pyclad.data.grouping import apply_step_schedule
+from pyclad.metrics.base.average_precision import AveragePrecision
+from pyclad.metrics.base.roc_auc import RocAuc
+from pyclad.metrics.continual.final_step_average import FinalStepAverage
+from pyclad.metrics.continual.schedule_aware_forgetting_measure import (
+    ScheduleAwareForgettingMeasure,
+)
+from pyclad.metrics.continual.schedule_aware_forward_transfer import (
+    ScheduleAwareForwardTransfer,
+)
+from pyclad.metrics.continual.schedule_aware_new_task_acquisition import (
+    ScheduleAwareNewTaskAcquisition,
+)
+from pyclad.output.json_writer import JsonOutputWriter
+from pyclad.scenarios.concept_incremental import ConceptIncrementalScenario
+from pyclad.strategies.baselines.naive import NaiveStrategy
+from pyclad.vision.callbacks.vision_pixel_concept_metric_callback import (
+    VisionPixelConceptMetricCallback,
+)
+from pyclad.vision.data.multi_dataset import (
+    load_inclad_md,
+    split_multi_dataset_concept_name,
+)
+from pyclad.vision.metrics.pixel_aupro import PixelAUPRO
+from pyclad.vision.metrics.pixel_roc_auc import PixelRocAuc
+from pyclad.vision.models.rd4ad.config import RD4ADConfig
+from pyclad.vision.models.rd4ad.rd4ad import RD4AD
+
+logging.basicConfig(level=logging.INFO)
+
+RESOURCES = pathlib.Path("resources/vision")
+ROOTS = {
+    "btech": RESOURCES / "BTech_Dataset_transformed",
+    "dagm": RESOURCES / "DAGM_KaggleUpload",
+    "mpdd": RESOURCES / "MPDD",
+    "mvtec": RESOURCES / "mvtec_ad",
+    "visa": RESOURCES / "VisA",
+}
+
+ORDERING = "easy_to_hard"
+STEP_SCHEDULE = "3x9"
+
+if __name__ == "__main__":
+    """
+    This example combines the two features: a multidataset stream and step scheduling.
+
+    InCLAD-MD contributes 27 categories from five source datasets. The schedule "3x9" merges
+    them into nine training steps of three categories each, while evaluation stays per
+    category -- so the metric matrix is 9 x 27 instead of 27 x 27.
+
+    Because consecutive concepts are merged, a training step can straddle a source-dataset
+    boundary: with "3x9" and the easy_to_hard ordering, step 1 holds the last BTech category
+    together with the first two MPDD ones. Schedules that align with the block sizes
+    (3 for BTech, 6 for the rest) keep steps within a single source.
+
+    Other schedules over 27 categories: "26-1", "9x3", "21-1x6", "15-6-6".
+    """
+    dataset = load_inclad_md(
+        roots=ROOTS,
+        ordering=ORDERING,
+        resize_to=(256, 256),
+        max_train_samples_per_category=100,
+    )
+
+    scheduled_dataset = apply_step_schedule(dataset, schedule=STEP_SCHEDULE)
+
+    print("Training steps:", [(c.name, c.data.shape[0]) for c in scheduled_dataset.train_concepts()])
+    print("Evaluated categories:", len(scheduled_dataset.test_concepts()))
+    for step_index, step_name in enumerate(c.name for c in scheduled_dataset.train_concepts()):
+        members = [name for name, step in scheduled_dataset.first_seen_step().items() if step == step_index]
+        sources = sorted({split_multi_dataset_concept_name(name)[0] for name in members})
+        print(f"  {step_name}: {members} (sources: {sources})")
+
+    model = RD4AD(
+        RD4ADConfig(
+            input_size=(256, 256),
+            backbone_name="resnet18",
+            pretrained_encoder=True,
+            freeze_encoder=True,
+            batch_size=16,
+            epochs=2,
+            learning_rate=5e-3,
+            score_smoothing_sigma=4.0,
+            score_mode="max",
+            threshold_quantile=0.99,
+            show_training_progress=True,
+        )
+    )
+    strategy = NaiveStrategy(model)
+    summarized_metrics = [FinalStepAverage()]
+    schedule_aware_metrics = [
+        ScheduleAwareForgettingMeasure(),
+        ScheduleAwareForwardTransfer(),
+        ScheduleAwareNewTaskAcquisition(),
+    ]
+    first_seen_step = scheduled_dataset.first_seen_step()
+
+    callbacks = [
+        # Image-level
+        ConceptMetricCallback(
+            base_metric=RocAuc(),
+            summarized_metrics=summarized_metrics,
+            schedule_aware_metrics=schedule_aware_metrics,
+            first_seen_step=first_seen_step,
+        ),
+        ConceptMetricCallback(
+            base_metric=AveragePrecision(),
+            summarized_metrics=summarized_metrics,
+            schedule_aware_metrics=schedule_aware_metrics,
+            first_seen_step=first_seen_step,
+        ),
+        # Pixel-level
+        VisionPixelConceptMetricCallback(
+            base_metric=PixelRocAuc(),
+            summarized_metrics=summarized_metrics,
+            schedule_aware_metrics=schedule_aware_metrics,
+            first_seen_step=first_seen_step,
+        ),
+        VisionPixelConceptMetricCallback(
+            base_metric=PixelAUPRO(),
+            summarized_metrics=summarized_metrics,
+            schedule_aware_metrics=schedule_aware_metrics,
+            first_seen_step=first_seen_step,
+        ),
+        TimeEvaluationCallback(),
+    ]
+
+    scenario = ConceptIncrementalScenario(dataset=scheduled_dataset, strategy=strategy, callbacks=callbacks)
+    scenario.run()
+
+    output_writer = JsonOutputWriter(pathlib.Path(f"output_inclad_md_{ORDERING}_{STEP_SCHEDULE}.json"))
+    output_writer.write([model, scheduled_dataset, strategy, *callbacks])

--- a/examples/step_schedule_multi_dataset_example.py
+++ b/examples/step_schedule_multi_dataset_example.py
@@ -1,7 +1,9 @@
 import logging
 import pathlib
 
-from pyclad.callbacks.evaluation.concept_metric_evaluation import ConceptMetricCallback
+from pyclad.callbacks.evaluation.concept_metric_evaluation import (
+    ScheduleAwareConceptMetricCallback,
+)
 from pyclad.callbacks.evaluation.time_evaluation import TimeEvaluationCallback
 from pyclad.data.grouping import apply_step_schedule
 from pyclad.metrics.base.average_precision import AveragePrecision
@@ -20,7 +22,7 @@ from pyclad.output.json_writer import JsonOutputWriter
 from pyclad.scenarios.concept_incremental import ConceptIncrementalScenario
 from pyclad.strategies.baselines.naive import NaiveStrategy
 from pyclad.vision.callbacks.vision_pixel_concept_metric_callback import (
-    VisionPixelConceptMetricCallback,
+    ScheduleAwareVisionPixelConceptMetricCallback,
 )
 from pyclad.vision.data.multi_dataset import (
     load_inclad_md,
@@ -102,26 +104,26 @@ if __name__ == "__main__":
 
     callbacks = [
         # Image-level
-        ConceptMetricCallback(
+        ScheduleAwareConceptMetricCallback(
             base_metric=RocAuc(),
             summarized_metrics=summarized_metrics,
             schedule_aware_metrics=schedule_aware_metrics,
             first_seen_step=first_seen_step,
         ),
-        ConceptMetricCallback(
+        ScheduleAwareConceptMetricCallback(
             base_metric=AveragePrecision(),
             summarized_metrics=summarized_metrics,
             schedule_aware_metrics=schedule_aware_metrics,
             first_seen_step=first_seen_step,
         ),
         # Pixel-level
-        VisionPixelConceptMetricCallback(
+        ScheduleAwareVisionPixelConceptMetricCallback(
             base_metric=PixelRocAuc(),
             summarized_metrics=summarized_metrics,
             schedule_aware_metrics=schedule_aware_metrics,
             first_seen_step=first_seen_step,
         ),
-        VisionPixelConceptMetricCallback(
+        ScheduleAwareVisionPixelConceptMetricCallback(
             base_metric=PixelAUPRO(),
             summarized_metrics=summarized_metrics,
             schedule_aware_metrics=schedule_aware_metrics,

--- a/src/pyclad/vision/data/base.py
+++ b/src/pyclad/vision/data/base.py
@@ -20,7 +20,7 @@ SUPPORTED_IMAGE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".bmp", ".tif", ".tiff")
 
 class VisionBenchmarkReader(ABC):
     def __init__(self, root: Union[str, Path], name: str):
-        self.root = Path(root)
+        self.root = Path(root) if root is not None else None
         self.name = name
 
     def available_categories(self) -> List[str]:

--- a/src/pyclad/vision/data/multi_dataset.py
+++ b/src/pyclad/vision/data/multi_dataset.py
@@ -1,0 +1,353 @@
+"""Multidataset: one concept stream drawn from several source datasets.
+
+A multidataset is described by an ordered list of :class:`DatasetBlock`, each contributing
+its categories under a ``<alias>__<category>`` name. Unlike a single-source dataset there
+is no shared root: every block resolves its images against its own root, so the same
+relative path in two sources refers to two different files.
+
+Blocks delegate to the existing per-dataset readers, so every layout that
+:func:`~pyclad.vision.data.benchmarks.readers.build_vision_benchmark_reader` understands --
+including a hand-written :class:`FolderBenchmarkSpec` or :class:`CsvBenchmarkSpec` -- is a
+valid block without any extra code.
+"""
+
+import json
+from dataclasses import asdict, dataclass, field, fields
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+
+from pyclad.data.datasets.concepts_dataset import ConceptsDataset
+from pyclad.vision.data.base import VisionBenchmarkReader
+from pyclad.vision.data.benchmarks.readers import (
+    CsvBenchmarkSpec,
+    FolderBenchmarkSpec,
+    VisionBenchmarkSpec,
+    build_vision_benchmark_reader,
+)
+from pyclad.vision.data.sample import VisionSample
+
+DEFAULT_NAME_SEPARATOR = "__"
+
+
+@dataclass(frozen=True)
+class DatasetBlock:
+    """One source dataset's contribution to a multidataset.
+
+    :param dataset: source dataset key (``"mvtec"``, ``"visa"``, ...) or an explicit
+        :class:`FolderBenchmarkSpec` / :class:`CsvBenchmarkSpec` for a custom layout.
+    :param root: this block's dataset root. When omitted it is looked up in the ``roots``
+        mapping passed to :func:`read_multi_dataset`, keyed by the source dataset name.
+    :param categories: categories to take, in order. ``None`` takes every category the
+        source reader reports, in its own order.
+    :param alias: name used to prefix this block's concepts; defaults to the dataset name.
+    """
+
+    dataset: Union[str, VisionBenchmarkSpec]
+    root: Optional[Union[str, Path]] = None
+    categories: Optional[Sequence[str]] = None
+    alias: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "root", None if self.root is None else str(self.root))
+        if self.categories is not None:
+            object.__setattr__(self, "categories", tuple(self.categories))
+
+    def dataset_name(self) -> str:
+        """Name of the source dataset, used to look this block's root up in ``roots``."""
+        return self.dataset if isinstance(self.dataset, str) else self.dataset.name
+
+    def prefix(self) -> str:
+        return self.alias or self.dataset_name()
+
+    def concept_names(self, separator: str = DEFAULT_NAME_SEPARATOR) -> List[str]:
+        if self.categories is None:
+            raise ValueError(
+                f"Block {self.prefix()!r} does not list its categories, so its concept names are "
+                "only known after reading its root. List them explicitly to use this."
+            )
+        return [f"{self.prefix()}{separator}{category}" for category in self.categories]
+
+    def reversed(self) -> "DatasetBlock":
+        if self.categories is None:
+            raise ValueError(
+                f"Block {self.prefix()!r} does not list its categories, so it cannot be reversed. "
+                "List them explicitly to use this."
+            )
+        return DatasetBlock(
+            dataset=self.dataset,
+            root=self.root,
+            categories=tuple(reversed(self.categories)),
+            alias=self.alias,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"dataset": _benchmark_to_payload(self.dataset)}
+        if self.root is not None:
+            payload["root"] = self.root
+        if self.categories is not None:
+            payload["categories"] = list(self.categories)
+        if self.alias is not None:
+            payload["alias"] = self.alias
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "DatasetBlock":
+        return cls(
+            dataset=_benchmark_from_payload(payload["dataset"]),
+            root=payload.get("root"),
+            categories=payload.get("categories"),
+            alias=payload.get("alias"),
+        )
+
+
+@dataclass(frozen=True)
+class MultiDatasetSpec:
+    """An ordered, reproducible description of a multidataset concept stream.
+
+    Block order is the order of ``blocks``; category order within a block is the order of
+    that block's ``categories``. Both survive all the way into
+    :meth:`~pyclad.data.datasets.concepts_dataset.ConceptsDataset.train_concepts`, so this
+    object alone determines the continual sequence.
+    """
+
+    name: str
+    blocks: Sequence[DatasetBlock] = field(default_factory=tuple)
+    name_separator: str = DEFAULT_NAME_SEPARATOR
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "blocks", tuple(self.blocks))
+        if not self.blocks:
+            raise ValueError(f"Multidataset {self.name!r} must contain at least one block.")
+
+        seen: Dict[str, str] = {}
+        for block in self.blocks:
+            if block.categories is None:
+                continue
+            for concept_name in block.concept_names(self.name_separator):
+                if concept_name in seen:
+                    raise ValueError(
+                        f"Duplicate concept name {concept_name!r} in multidataset {self.name!r}. "
+                        "Give one of the blocks a distinct alias."
+                    )
+                seen[concept_name] = block.prefix()
+
+    def category_order(self) -> List[str]:
+        """Full concept sequence, prefixed and in stream order."""
+        order: List[str] = []
+        for block in self.blocks:
+            order.extend(block.concept_names(self.name_separator))
+        return order
+
+    def reversed(self) -> "MultiDatasetSpec":
+        """Reverse the stream at both levels: block order and category order within blocks."""
+        return MultiDatasetSpec(
+            name=f"{self.name}_reversed",
+            blocks=tuple(block.reversed() for block in reversed(self.blocks)),
+            name_separator=self.name_separator,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "name_separator": self.name_separator,
+            "blocks": [block.to_dict() for block in self.blocks],
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "MultiDatasetSpec":
+        return cls(
+            name=payload["name"],
+            blocks=[DatasetBlock.from_dict(block) for block in payload["blocks"]],
+            name_separator=payload.get("name_separator", DEFAULT_NAME_SEPARATOR),
+        )
+
+    def to_json(self, path: Union[str, Path]) -> Path:
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(self.to_dict(), indent=2))
+        return target
+
+    @classmethod
+    def from_json(cls, path: Union[str, Path]) -> "MultiDatasetSpec":
+        return cls.from_dict(json.loads(Path(path).read_text()))
+
+
+class MultiDatasetReader(VisionBenchmarkReader):
+    """Reads a multidataset by delegating each block to its own source-dataset reader.
+
+    Samples are emitted in block order, and each block's samples in its category order, which
+    is what fixes the concept order downstream: ``build_concepts_dataset_from_samples`` infers
+    the order from sample occurrence when no explicit category list is given.
+    """
+
+    def __init__(self, spec: MultiDatasetSpec, roots: Optional[Mapping[str, Union[str, Path]]] = None):
+        super().__init__(root=None, name=spec.name)
+        self.spec = spec
+        self._roots = {key: Path(value) for key, value in (roots or {}).items()}
+
+    def available_categories(self) -> List[str]:
+        names: List[str] = []
+        for block in self.spec.blocks:
+            reader = self._reader_for(block)
+            categories = block.categories if block.categories is not None else reader.available_categories()
+            names.extend(f"{block.prefix()}{self.spec.name_separator}{category}" for category in categories)
+        return names
+
+    def index_samples(
+        self,
+        categories: Optional[Sequence[str]] = None,
+        max_train_samples_per_category: Optional[int] = None,
+        max_test_samples_per_category: Optional[int] = None,
+    ) -> List[VisionSample]:
+        samples: List[VisionSample] = []
+        for block in self.spec.blocks:
+            reader = self._reader_for(block)
+            try:
+                block_samples = reader.index_samples(
+                    categories=block.categories,
+                    max_train_samples_per_category=max_train_samples_per_category,
+                    max_test_samples_per_category=max_test_samples_per_category,
+                )
+            except ValueError as error:
+                raise ValueError(f"Multidataset block {block.prefix()!r}: {error}") from error
+
+            prefix = f"{block.prefix()}{self.spec.name_separator}"
+            samples.extend(
+                VisionSample(
+                    category=f"{prefix}{sample.category}",
+                    split=sample.split,
+                    image_path=sample.image_path,
+                    image_label=sample.image_label,
+                    mask_path=sample.mask_path,
+                    defect_type=sample.defect_type,
+                )
+                for sample in block_samples
+            )
+
+        if categories is not None:
+            requested = set(categories)
+            samples = [sample for sample in samples if sample.category in requested]
+        return samples
+
+    def _reader_for(self, block: DatasetBlock) -> VisionBenchmarkReader:
+        return build_vision_benchmark_reader(root=self._resolve_root(block), benchmark=block.dataset)
+
+    def _resolve_root(self, block: DatasetBlock) -> Path:
+        if block.root is not None:
+            return Path(block.root)
+
+        dataset_name = block.dataset_name()
+        if dataset_name in self._roots:
+            return self._roots[dataset_name]
+
+        raise ValueError(
+            f"No root for multidataset block {block.prefix()!r} (source dataset {dataset_name!r}). "
+            f"Set it on the block, or pass roots={{{dataset_name!r}: ...}}. "
+            f"Known roots: {sorted(self._roots)}."
+        )
+
+
+def read_multi_dataset(
+    spec: Optional[MultiDatasetSpec] = None,
+    roots: Optional[Mapping[str, Union[str, Path]]] = None,
+    dataset_name: Optional[str] = None,
+    categories: Optional[Sequence[str]] = None,
+    data_mode: str = "numpy",
+    resize_to: Optional[Tuple[int, int]] = None,
+    color_mode: str = "rgb",
+    max_train_samples_per_category: Optional[int] = None,
+    max_test_samples_per_category: Optional[int] = None,
+) -> ConceptsDataset:
+    """Read a multidataset into a :class:`ConceptsDataset`, one concept per source category.
+
+    Defaults to the published :data:`INCLAD_MD_SPEC`. Test concepts carrying ground-truth
+    masks come back as :class:`~pyclad.vision.data.vision_concept.VisionConcept`, with masks
+    resolved against each block's own root.
+
+    :param roots: source dataset name -> root, used for blocks that do not set ``root``.
+    :param categories: optional subset of prefixed concept names, e.g. ``["mvtec__bottle"]``,
+        which also fixes their order.
+    """
+    resolved_spec = INCLAD_MD_SPEC if spec is None else spec
+    reader = MultiDatasetReader(spec=resolved_spec, roots=roots)
+    return reader.read_dataset(
+        dataset_name=dataset_name or resolved_spec.name,
+        categories=categories,
+        data_mode=data_mode,
+        resize_to=resize_to,
+        color_mode=color_mode,
+        max_train_samples_per_category=max_train_samples_per_category,
+        max_test_samples_per_category=max_test_samples_per_category,
+    )
+
+
+def split_multi_dataset_concept_name(concept_name: str, separator: str = DEFAULT_NAME_SEPARATOR) -> Tuple[str, str]:
+    """Split ``"mvtec__bottle"`` into ``("mvtec", "bottle")``, for per-source reporting.
+
+    Splits on the first separator, so underscores inside a category name survive.
+    """
+    if separator not in concept_name:
+        raise ValueError(f"Concept name {concept_name!r} does not contain the separator {separator!r}.")
+    source, category = concept_name.split(separator, 1)
+    return source, category
+
+INCLAD_MD_SOURCE_DATASETS = ("btech", "dagm", "mpdd", "mvtec", "visa")
+INCLAD_MD_ORDERINGS = ("easy_to_hard", "hard_to_easy")
+
+INCLAD_MD_SPEC = MultiDatasetSpec(
+    name="inclad-md",
+    blocks=(
+        DatasetBlock(dataset="btech", categories=("03", "01", "02")),
+        DatasetBlock(
+            dataset="mpdd",
+            categories=("connector", "bracket_brown", "metal_plate", "bracket_white", "tubes", "bracket_black"),
+        ),
+        DatasetBlock(dataset="dagm", categories=("Class4", "Class9", "Class7", "Class3", "Class5", "Class8")),
+        DatasetBlock(dataset="visa", categories=("pcb4", "chewinggum", "fryum", "pcb2", "macaroni2", "capsules")),
+        DatasetBlock(dataset="mvtec", categories=("bottle", "leather", "toothbrush", "carpet", "screw", "pill")),
+    ),
+)
+
+
+def load_inclad_md(
+    roots: Mapping[str, Union[str, Path]],
+    ordering: str = "easy_to_hard",
+    **kwargs: Any,
+) -> ConceptsDataset:
+    """Load the published InCLAD-MD benchmark.
+
+    :param roots: source dataset name -> root, e.g. ``{"mvtec": "/data/mvtec_ad", ...}``.
+    :param ordering: ``"easy_to_hard"`` or ``"hard_to_easy"``. Unlike InCLAD-Bench, InCLAD-MD
+        has no ``"random"`` ordering.
+    """
+    if ordering not in INCLAD_MD_ORDERINGS:
+        raise ValueError(
+            f"Unsupported InCLAD-MD ordering {ordering!r}. Available: {list(INCLAD_MD_ORDERINGS)}. "
+            "Note that InCLAD-MD has no 'random' ordering, unlike InCLAD-Bench."
+        )
+
+    spec = INCLAD_MD_SPEC if ordering == "easy_to_hard" else INCLAD_MD_SPEC.reversed()
+    return read_multi_dataset(spec=spec, roots=roots, dataset_name=f"inclad-md-{ordering}", **kwargs)
+
+
+_BENCHMARK_SPEC_TYPES = {"folder": FolderBenchmarkSpec, "csv": CsvBenchmarkSpec}
+_TUPLE_SPEC_FIELDS = {"image_extensions"}
+
+
+def _benchmark_to_payload(benchmark: Union[str, VisionBenchmarkSpec]) -> Union[str, Dict[str, Any]]:
+    if isinstance(benchmark, str):
+        return benchmark
+    kind = "folder" if isinstance(benchmark, FolderBenchmarkSpec) else "csv"
+    return {"kind": kind, **asdict(benchmark)}
+
+
+def _benchmark_from_payload(payload: Union[str, Mapping[str, Any]]) -> Union[str, VisionBenchmarkSpec]:
+    if isinstance(payload, str):
+        return payload
+
+    values = dict(payload)
+    spec_type = _BENCHMARK_SPEC_TYPES[values.pop("kind")]
+    known = {f.name for f in fields(spec_type)}
+    return spec_type(
+        **{key: tuple(value) if key in _TUPLE_SPEC_FIELDS else value for key, value in values.items() if key in known}
+    )

--- a/tests/vision/data/test_multi_dataset.py
+++ b/tests/vision/data/test_multi_dataset.py
@@ -1,0 +1,296 @@
+"""Multidatasets: one concept stream drawn from several source datasets.
+
+Each block contributes its categories under a ``<alias>__<category>`` name, and each block
+resolves its images against its own root -- there is no single shared root.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from pyclad.data.grouping import apply_step_schedule
+from pyclad.vision.data.benchmarks.readers import FolderBenchmarkSpec
+from pyclad.vision.data.multi_dataset import (
+    INCLAD_MD_ORDERINGS,
+    INCLAD_MD_SPEC,
+    DatasetBlock,
+    MultiDatasetSpec,
+    load_inclad_md,
+    read_multi_dataset,
+    split_multi_dataset_concept_name,
+)
+from pyclad.vision.data.vision_concept import VisionConcept
+from tests.vision._helpers import write_mask, write_rgb_image
+
+
+def _mvtec_like_tree(root: Path, categories, with_masks: bool = True, color_seed: int = 0) -> Path:
+    """Write a minimal MVTec-layout tree: train/good, test/good, test/crack (+ ground_truth)."""
+    for index, category in enumerate(categories):
+        shade = (color_seed + index) % 256
+        write_rgb_image(root / category / "train" / "good" / "000.png", color=(shade, 20, 30))
+        write_rgb_image(root / category / "test" / "good" / "100.png", color=(shade, 30, 40))
+        write_rgb_image(root / category / "test" / "crack" / "101.png", color=(shade, 40, 50))
+        if with_masks:
+            write_mask(root / category / "ground_truth" / "crack" / "101_mask.png")
+    return root
+
+
+@pytest.fixture
+def two_sources(tmp_path):
+    """Two independent roots, deliberately sharing the category name 'bottle'."""
+    first = _mvtec_like_tree(tmp_path / "alpha", ["bottle", "cable"], color_seed=0)
+    second = _mvtec_like_tree(tmp_path / "beta", ["bottle", "widget"], color_seed=100)
+    return first, second
+
+
+class TestSpec:
+    def test_category_order_follows_blocks_then_categories(self):
+        spec = MultiDatasetSpec(
+            name="toy",
+            blocks=[
+                DatasetBlock(dataset="mvtec", root="/a", categories=["cable", "bottle"]),
+                DatasetBlock(dataset="visa", root="/b", categories=["pcb4"]),
+            ],
+        )
+
+        assert spec.category_order() == ["mvtec__cable", "mvtec__bottle", "visa__pcb4"]
+
+    def test_alias_overrides_the_name_prefix(self):
+        spec = MultiDatasetSpec(
+            name="toy",
+            blocks=[DatasetBlock(dataset="mvtec", root="/a", categories=["bottle"], alias="factory")],
+        )
+
+        assert spec.category_order() == ["factory__bottle"]
+
+    def test_reversing_flips_both_block_and_category_order(self):
+        spec = MultiDatasetSpec(
+            name="toy",
+            blocks=[
+                DatasetBlock(dataset="mvtec", root="/a", categories=["a", "b"]),
+                DatasetBlock(dataset="visa", root="/b", categories=["x", "y"]),
+            ],
+        )
+
+        assert spec.reversed().category_order() == ["visa__y", "visa__x", "mvtec__b", "mvtec__a"]
+
+    def test_rejecting_a_spec_without_blocks(self):
+        with pytest.raises(ValueError, match="at least one block"):
+            MultiDatasetSpec(name="toy", blocks=[])
+
+    def test_rejecting_duplicate_concept_names(self):
+        with pytest.raises(ValueError, match="Duplicate"):
+            MultiDatasetSpec(
+                name="toy",
+                blocks=[
+                    DatasetBlock(dataset="mvtec", root="/a", categories=["bottle"]),
+                    DatasetBlock(dataset="mvtec", root="/b", categories=["bottle"]),
+                ],
+            )
+
+    def test_round_trip_through_a_dict(self):
+        spec = MultiDatasetSpec(
+            name="toy",
+            blocks=[
+                DatasetBlock(dataset="mvtec", root="/a", categories=["bottle"], alias="factory"),
+                DatasetBlock(dataset="visa", root="/b"),
+            ],
+        )
+
+        assert MultiDatasetSpec.from_dict(spec.to_dict()) == spec
+
+    def test_round_trip_of_a_block_using_a_custom_benchmark_spec(self):
+        spec = MultiDatasetSpec(
+            name="toy",
+            blocks=[DatasetBlock(dataset=FolderBenchmarkSpec(name="inhouse", train_split_dir="TRAIN"), root="/a")],
+        )
+
+        restored = MultiDatasetSpec.from_dict(spec.to_dict())
+
+        assert restored == spec
+        assert restored.blocks[0].dataset.train_split_dir == "TRAIN"
+
+    def test_round_trip_through_a_json_file(self, tmp_path):
+        spec = MultiDatasetSpec(name="toy", blocks=[DatasetBlock(dataset="mvtec", root="/a", categories=["bottle"])])
+        path = tmp_path / "spec.json"
+
+        spec.to_json(path)
+
+        assert MultiDatasetSpec.from_json(path) == spec
+
+
+class TestReading:
+    def test_preserving_block_order_and_within_block_order(self, two_sources):
+        first, second = two_sources
+        spec = MultiDatasetSpec(
+            name="toy",
+            blocks=[
+                DatasetBlock(dataset="mvtec", root=second, categories=["widget", "bottle"], alias="beta"),
+                DatasetBlock(dataset="mvtec", root=first, categories=["cable", "bottle"], alias="alpha"),
+            ],
+        )
+
+        dataset = read_multi_dataset(spec, resize_to=(4, 4))
+
+        assert [c.name for c in dataset.train_concepts()] == [
+            "beta__widget",
+            "beta__bottle",
+            "alpha__cable",
+            "alpha__bottle",
+        ]
+
+    def test_prefixing_keeps_colliding_category_names_apart(self, two_sources):
+        first, second = two_sources
+        spec = MultiDatasetSpec(
+            name="toy",
+            blocks=[
+                DatasetBlock(dataset="mvtec", root=first, categories=["bottle"], alias="alpha"),
+                DatasetBlock(dataset="mvtec", root=second, categories=["bottle"], alias="beta"),
+            ],
+        )
+
+        dataset = read_multi_dataset(spec, resize_to=(4, 4))
+        names = [c.name for c in dataset.train_concepts()]
+
+        assert names == ["alpha__bottle", "beta__bottle"]
+        # Same relative path in both sources must resolve to two different images.
+        first_pixels = dataset.train_concepts()[0].data[0]
+        second_pixels = dataset.train_concepts()[1].data[0]
+        assert not np.array_equal(first_pixels, second_pixels)
+
+    def test_test_concepts_carry_masks_resolved_against_their_own_root(self, two_sources):
+        first, second = two_sources
+        spec = MultiDatasetSpec(
+            name="toy",
+            blocks=[
+                DatasetBlock(dataset="mvtec", root=first, categories=["bottle"], alias="alpha"),
+                DatasetBlock(dataset="mvtec", root=second, categories=["widget"], alias="beta"),
+            ],
+        )
+
+        dataset = read_multi_dataset(spec, resize_to=(4, 4))
+
+        for concept in dataset.test_concepts():
+            assert isinstance(concept, VisionConcept)
+            assert concept.masks is not None
+            assert concept.masks.shape[0] == concept.data.shape[0]
+
+    def test_taking_every_category_when_the_block_lists_none(self, two_sources):
+        first, _ = two_sources
+        spec = MultiDatasetSpec(name="toy", blocks=[DatasetBlock(dataset="mvtec", root=first, alias="alpha")])
+
+        dataset = read_multi_dataset(spec, resize_to=(4, 4))
+
+        assert [c.name for c in dataset.train_concepts()] == ["alpha__bottle", "alpha__cable"]
+
+    def test_resolving_roots_from_the_roots_mapping(self, two_sources):
+        first, _ = two_sources
+        spec = MultiDatasetSpec(name="toy", blocks=[DatasetBlock(dataset="mvtec", categories=["bottle"])])
+
+        dataset = read_multi_dataset(spec, roots={"mvtec": first}, resize_to=(4, 4))
+
+        assert [c.name for c in dataset.train_concepts()] == ["mvtec__bottle"]
+
+    def test_rejecting_a_block_without_a_resolvable_root(self):
+        spec = MultiDatasetSpec(name="toy", blocks=[DatasetBlock(dataset="mvtec", categories=["bottle"])])
+
+        with pytest.raises(ValueError, match="mvtec"):
+            read_multi_dataset(spec, roots={"visa": "/b"})
+
+    def test_rejecting_an_unknown_category(self, two_sources):
+        first, _ = two_sources
+        spec = MultiDatasetSpec(
+            name="toy", blocks=[DatasetBlock(dataset="mvtec", root=first, categories=["nonexistent"])]
+        )
+
+        with pytest.raises(ValueError, match="nonexistent"):
+            read_multi_dataset(spec, resize_to=(4, 4))
+
+    def test_applying_sample_limits_per_category(self, two_sources):
+        first, _ = two_sources
+        spec = MultiDatasetSpec(name="toy", blocks=[DatasetBlock(dataset="mvtec", root=first, alias="alpha")])
+
+        dataset = read_multi_dataset(spec, resize_to=(4, 4), max_test_samples_per_category=1)
+
+        assert all(c.data.shape[0] == 1 for c in dataset.test_concepts())
+
+
+class TestConceptNames:
+    def test_splitting_a_prefixed_concept_name(self):
+        assert split_multi_dataset_concept_name("mvtec__bottle") == ("mvtec", "bottle")
+
+    def test_splitting_keeps_underscores_inside_the_category(self):
+        assert split_multi_dataset_concept_name("mpdd__bracket_brown") == ("mpdd", "bracket_brown")
+
+    def test_rejecting_an_unprefixed_name(self):
+        with pytest.raises(ValueError, match="separator"):
+            split_multi_dataset_concept_name("bottle")
+
+
+class TestInCladMd:
+    def test_spec_holds_the_published_27_categories(self):
+        assert len(INCLAD_MD_SPEC.category_order()) == 27
+
+    def test_block_order_is_easiest_first(self):
+        assert [block.alias or block.dataset for block in INCLAD_MD_SPEC.blocks] == [
+            "btech",
+            "mpdd",
+            "dagm",
+            "visa",
+            "mvtec",
+        ]
+
+    def test_btech_contributes_all_three_categories(self):
+        btech = [name for name in INCLAD_MD_SPEC.category_order() if name.startswith("btech__")]
+
+        assert btech == ["btech__03", "btech__01", "btech__02"]
+
+    def test_every_other_source_contributes_six_categories(self):
+        for source in ("mpdd", "dagm", "visa", "mvtec"):
+            selected = [n for n in INCLAD_MD_SPEC.category_order() if n.startswith(f"{source}__")]
+            assert len(selected) == 6, source
+
+    def test_supported_orderings(self):
+        assert INCLAD_MD_ORDERINGS == ("easy_to_hard", "hard_to_easy")
+
+    def test_hard_to_easy_is_the_exact_reverse(self, two_sources):
+        assert INCLAD_MD_SPEC.reversed().category_order() == list(reversed(INCLAD_MD_SPEC.category_order()))
+
+    def test_rejecting_the_random_ordering(self):
+        with pytest.raises(ValueError, match="random"):
+            load_inclad_md(roots={}, ordering="random")
+
+
+class TestCompositionWithStepSchedule:
+    def test_grouping_a_multidataset_stream(self, two_sources):
+        first, second = two_sources
+        spec = MultiDatasetSpec(
+            name="toy",
+            blocks=[
+                DatasetBlock(dataset="mvtec", root=first, categories=["bottle", "cable"], alias="alpha"),
+                DatasetBlock(dataset="mvtec", root=second, categories=["widget"], alias="beta"),
+            ],
+        )
+
+        dataset = read_multi_dataset(spec, resize_to=(4, 4))
+        scheduled = apply_step_schedule(dataset, "2-1")
+
+        assert [c.name for c in scheduled.train_concepts()] == ["step_0", "step_1"]
+        assert scheduled.first_seen_step() == {"alpha__bottle": 0, "alpha__cable": 0, "beta__widget": 1}
+
+
+class TestCategoryFilter:
+    def test_selecting_a_subset_of_the_stream(self, two_sources):
+        first, second = two_sources
+        spec = MultiDatasetSpec(
+            name="toy",
+            blocks=[
+                DatasetBlock(dataset="mvtec", root=first, categories=["bottle", "cable"], alias="alpha"),
+                DatasetBlock(dataset="mvtec", root=second, categories=["widget"], alias="beta"),
+            ],
+        )
+
+        dataset = read_multi_dataset(spec, categories=["beta__widget", "alpha__bottle"], resize_to=(4, 4))
+
+        assert [c.name for c in dataset.train_concepts()] == ["beta__widget", "alpha__bottle"]


### PR DESCRIPTION
Adds multidatasets: one continual stream whose concepts come from several source datasets at once. Unlike a single-source dataset there is no shared root. Each block resolves its own images, and concepts are named `<source>__<category>`, so categories sharing a name across datasets stay distinct.  

Builds on #57. The features are independent in code.