### PR TITLE
Add ReplayCAD strategy and PatchCore model

### DIFF
--- a/docs/vision.md
+++ b/docs/vision.md
@@ -142,3 +142,167 @@ callbacks = [
     # ... PixelAveragePrecision, PixelF1Score, PixelIoU, PixelDiceScore
 ]
 ```
+
+## PatchCore
+
+PatchCore is a memory-bank detector: a frozen, pretrained backbone extracts mid-level patch
+features (`layer2` + `layer3`) for every training image, a greedy coreset subsamples them into a
+small memory bank, and each test patch is scored by nearest-neighbour distance to that bank. No
+gradient training happens — `fit()` only extracts features and builds the memory bank.
+
+The image-level score is the maximum over **raw** patch distances; the segmentation map is those
+same distances bilinearly upsampled to `input_size` and Gaussian-smoothed with `smoothing_sigma`.
+Because the image score is taken before smoothing, it is generally **larger** than the maximum of
+the returned map — see divergence 6 below if you're comparing against ADer's published numbers.
+
+### Config (`PatchCoreConfig`)
+
+Defaults match the reference implementation behind ReplayCAD's PatchCore benchmark row (ADer's
+`model/patchcore.py`), constant-for-constant.
+
+| Field | Default | Meaning |
+|---|---|---|
+| `input_size` | `(256, 256)` | Images are resized to this H×W before feature extraction |
+| `backbone_name` | `"wide_resnet50_2"` | Any torchvision backbone supported by the shared feature extractor |
+| `backbone_return_nodes` | `None` | Explicit override; `None` picks `layer2`/`layer3` automatically |
+| `pretrained_backbone` | `True` | Load pretrained ImageNet weights |
+| `freeze_backbone` | `True` | Backbone parameters are never updated (PatchCore never trains it) |
+| `pretrained_weights` | `"IMAGENET1K_V1"` | Not torchvision's `DEFAULT` (`IMAGENET1K_V2`) — the reference implementation loads the V1 checkpoint |
+| `pretrain_embed_dimension` | `1024` | Per-layer patch feature dimension after mean-mapping |
+| `target_embed_dimension` | `1024` | Final aggregated patch embedding dimension |
+| `patchsize` | `3` | Side length (in feature-map cells) of each patch |
+| `patchstride` | `1` | Stride between patches |
+| `coreset_sampling_ratio` | `0.1` | Fraction of training patches kept in the memory bank |
+| `coreset_projection_dimension` | `128` | Random projection dimension used by the greedy coreset selector |
+| `coreset_starting_points` | `10` | Number of random seed points for the greedy coreset search |
+| `n_neighbors` | `1` | Neighbours averaged for the nearest-neighbour patch distance |
+| `smoothing_sigma` | `4.0` | Gaussian smoothing sigma applied to the segmentation map only |
+
+### Running the example
+
+```bash
+cd examples/models/vision
+python patchcore_torch_example.py
+```
+
+Like the other examples, this reads a dataset via `read_vision_dataset` (see
+[Datasets](#datasets) above), wraps the model in a replay strategy, attaches the same image- and
+pixel-level metric callbacks, and writes results to `output.json`.
+
+## ReplayCAD
+
+ReplayCAD (Hu et al., *ReplayCAD: Generative Diffusion Replay for Continual Anomaly Detection*,
+IJCAI 2025, arXiv:2505.06603) is a generative-replay strategy: instead of storing real images from
+earlier concepts, it compresses each one into a small, frozen-diffusion-model conditioning (a
+learned semantic embedding plus a mask-projection MLP) that can regenerate representative images
+on demand, and replays those alongside new data when refitting the detector.
+
+`ReplayCADStrategy(model, memory)` is detector-agnostic — `model` is any pyCLAD vision model (e.g.
+PatchCore above, RD4AD, FastFlow, PaSTe). It needs the concept id on every call, so it runs under
+`ConceptAwareScenario` (`pyclad.scenarios.concept_aware`), not `ConceptIncrementalScenario`.
+
+### Default profile
+
+`ReplayCADConfig.for_benchmark(benchmark, artifact_dir, **overrides)` builds the paper's section
+5.1 uniform profile: MVTec AD gets the LDM-256 profile below, VisA gets SD1.5-512, and any other
+benchmark (BTech, DAGM, MPDD, multidataset streams) falls back to LDM-256 with a neutral
+initializer, since the authors publish no configuration for those.
+
+| | MVTec / LDM-256 | VisA / SD1.5-512 |
+|---|---|---|
+| model id | `CompVis/ldm-text2im-large-256` | `stable-diffusion-v1-5/stable-diffusion-v1-5` |
+| resolution | 256 | 512 |
+| conditioning dim `C` | 1280 | 768 |
+| mask latent | 32×32×4 = 4096 | 64×64×4 = 16384 |
+| MLP `(g, p)` | (128, 200) | (128, 192) |
+| spatial tokens `M` (derived) | 5 | 32 |
+| compression steps | 20 000 | 30 000 |
+| compression batch size | 16 | 2 |
+| MLP / embedding learning rate (derived) | 1.6e-3 / 1.6e-1 | 2.0e-4 / 2.0e-2 |
+
+Shared by both profiles: `semantic_tokens=20`, AdamW `weight_decay=1e-2`,
+`timestep_sampling="uniform"`, DDIM sampling (50 steps, `eta=0.0`), `guidance_scale=10.0`,
+`replay_samples_per_concept=800`, up to 10 stored masks per concept.
+
+`M` and the learning rates are derived, not typed in directly, and aren't guessable from the
+config's field list alone:
+
+- **`M`** = `(latent_values / mask_group_width) * mask_projection_width / condition_dim`.
+  `ReplayCADConfig` validates that this divides evenly and rejects presets that don't — which is
+  also why VisA's MLP width is `(128, 192)` here, not the paper's printed `(128, 196)` (not
+  reshapeable: `128 * 196 / 768` isn't an integer).
+- **Learning rates** come from three separate fields — `base_learning_rate` (`5e-5`),
+  `learning_rate_scale` (the frozen `ngpu * batch_size` product) and `semantic_lr_multiplier`
+  (`100.0`) — kept apart so the published rates don't silently rescale if you override
+  `compression_batch_size` for your own hardware.
+
+### Masks, augmentation and caching
+
+ReplayCAD conditions generation on an object mask, but anomaly-detection datasets ship masks only
+for anomalous *test* images — never for the normal training images compression learns from. The
+authors ran Segment Anything over the training sets instead and publish the result as `SAM.zip`
+for MVTec and VisA. For any other dataset you run SAM yourself: download a checkpoint from
+[facebookresearch/segment-anything](https://github.com/facebookresearch/segment-anything#model-checkpoints)
+(`sam_vit_h_4b8939.pth`, ~2.4 GB, is the `vit_h` variant the authors used; `vit_l` and `vit_b` are
+smaller and also accepted) and point `sam_checkpoint` at it. Both `sam_checkpoint` and
+`sam_model_type` are part of the compression cache key, so switching either invalidates every
+artifact already computed — at 20000-30000 diffusion steps per concept, that is not a cheap
+mistake.
+
+`mask_backend` (default `"sam"`) selects `"sam"` (Segment Anything, needs `sam_checkpoint`),
+`"precomputed"` (the authors' own masks, matched to training images by sorted filename order —
+raises on a count mismatch), or `"full-frame"` (all-object mask, for texture concepts). Route
+individual categories to a different backend with `mask_modes` — needed for MVTec's `zipper` and
+VisA's `pipe_fryum`, which the authors' precomputed archive doesn't cover.
+
+`mask_augmentation` (default `"none"`) jitters a stored mask at *replay* time — `"paper"`
+(rotate + shift) or five class-specific transforms reproduced from the release's
+`mask_transfor.py`; see `pyclad.vision.strategies.replaycad.masks` and `per_class.py` for which
+class uses which.
+
+Compressed artifacts (`embedding.pt`, `projection.pt`, up to `masks_per_concept` masks,
+`meta.json`) are cached under `<artifact_dir>/<benchmark>/<concept_slug>/`, enabled by default.
+The cache key (`meta.json`'s `config_hash`) covers everything that changes the compressed
+representation and excludes concept ordering, the detector, and replay-only settings, so one
+compression pass serves an entire benchmark sweep. `train_augmentation` (compression-time) is
+hashed; `mask_augmentation` (replay-time) is not, since it jitters an already-compressed artifact
+rather than changing it. A hash mismatch logs a warning and recompresses by default;
+`strict_cache=True` raises instead.
+
+### Per-class overrides
+
+The authors' released scripts hand-tune every class instead of using the paper's uniform profile.
+`apply_per_class(config, concept_id, benchmark)` (`pyclad.vision.strategies.replaycad.per_class`)
+returns that alternative, re-validated profile for one concept, for inspection — it cannot drive a
+live run end to end (divergence 2 below).
+
+### Installation
+
+```bash
+pip install -e ".[replaycad]"
+```
+
+Installs `diffusers`, `transformers`, `accelerate`, `safetensors` and `segment-anything` on top of
+the vision stack described in Setup above. They're imported lazily, so importing `pyclad` without
+the extra keeps working; a missing import raises a message naming the extra.
+
+### Differences from the original
+
+This follows the authors' released hyperparameters but is not a bit-for-bit port. It runs on
+`diffusers` instead of their vendored `ldm/`, trains a pyCLAD vision model instead of InvAD, and
+defaults to the paper's uniform per-dataset profile rather than their per-class tuning — which
+`per_class.py` records as a reference table. Several smaller behavioural differences exist in mask
+handling and scoring. Check them before reporting a run here as a reproduction of the paper.
+
+### Running the example
+
+```bash
+cd examples/strategies
+python replaycad_example.py
+```
+
+Same pattern as the PatchCore example above — `read_vision_dataset`, the same metric callbacks,
+`output.json` — plus a `ReplayCADConfig`/`ReplayCADMemory` built with `mask_backend="precomputed"`
+against the authors' `SAM.zip` extracted to `./SAM/data` (pass `mask_backend="sam"` with a
+`sam_checkpoint` instead if you don't have it) and `device="cuda"` (use `"cpu"` or `"mps"` if you
+don't have one; compression is slow either way, so shrink `compression_steps` for a smoke test).

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -197,6 +197,11 @@ earlier concepts, it compresses each one into a small, frozen-diffusion-model co
 learned semantic embedding plus a mask-projection MLP) that can regenerate representative images
 on demand, and replays those alongside new data when refitting the detector.
 
+Line references to the authors' code in this package's docstrings — `personalized.py`,
+`embedding_manager.py`, `ddim.py`, `ddpm2.py` — point at
+[HULEI7/ReplayCAD](https://github.com/HULEI7/ReplayCAD) at commit `acc6195` (2026-08-16), where
+the vendored textual-inversion tree lives under `textual_inversion-main/`.
+
 `ReplayCADStrategy(model, memory)` is detector-agnostic — `model` is any pyCLAD vision model (e.g.
 PatchCore above, RD4AD, FastFlow, PaSTe). It needs the concept id on every call, so it runs under
 `ConceptAwareScenario` (`pyclad.scenarios.concept_aware`), not `ConceptIncrementalScenario`.
@@ -286,14 +291,6 @@ Installs `diffusers`, `transformers`, `accelerate`, `safetensors` and `segment-a
 the vision stack described in Setup above. They're imported lazily, so importing `pyclad` without
 the extra keeps working; a missing import raises a message naming the extra.
 
-### Differences from the original
-
-This follows the authors' released hyperparameters but is not a bit-for-bit port. It runs on
-`diffusers` instead of their vendored `ldm/`, trains a pyCLAD vision model instead of InvAD, and
-defaults to the paper's uniform per-dataset profile rather than their per-class tuning — which
-`per_class.py` records as a reference table. Several smaller behavioural differences exist in mask
-handling and scoring. Check them before reporting a run here as a reproduction of the paper.
-
 ### Running the example
 
 ```bash
@@ -306,3 +303,60 @@ Same pattern as the PatchCore example above — `read_vision_dataset`, the same 
 against the authors' `SAM.zip` extracted to `./SAM/data` (pass `mask_backend="sam"` with a
 `sam_checkpoint` instead if you don't have it) and `device="cuda"` (use `"cpu"` or `"mps"` if you
 don't have one; compression is slow either way, so shrink `compression_steps` for a smoke test).
+
+## Differences from the original
+
+Neither model here is a bit-for-bit port. PatchCore matches the reference implementation behind
+ReplayCAD's benchmark row (ADer's `model/patchcore.py`) constant-for-constant; ReplayCAD follows
+the authors' released hyperparameters. Where either departs from its source, it is listed below.
+Check this list before reporting a run here as a reproduction of the paper. The entries are
+numbered so that docstrings and the sections above can point at one of them ("divergence 6
+below"); keep the numbering stable, or fix the callouts with it.
+
+1. **Detector.** `ReplayCADStrategy` refits any pyCLAD vision model — PatchCore above, RD4AD,
+   FastFlow, PaSTe — while the authors train InvAD. Replay quality is therefore measured through a
+   different detector than the paper's tables, so absolute numbers are not comparable even where
+   the replay itself matches.
+
+2. **Per-class tuning is a reference table, not a runnable mode.** The default is the paper's
+   section 5.1 uniform per-dataset profile, built by `ReplayCADConfig.for_benchmark`.
+   `apply_per_class` returns the authors' released hand-tuned settings for one concept, for
+   inspection only: it varies `model_id`, `condition_dim` and `resolution` per class, while
+   `ReplayCADMemory` and `DiffusersBackend` each hold one config for the whole stream. A live run
+   driven through it would fail on a shape mismatch — VisA alone mixes the LDM-256 and SD1.5-512
+   families.
+
+3. **Diffusion stack.** Compression and generation run on `diffusers`, not the release's vendored
+   `ldm/` tree, and the learned semantic embedding is injected through a forward hook on the text
+   encoder's embedded output rather than trained in place.
+
+4. **VisA mask-projection width** is `(128, 192)`, not the paper's printed `(128, 196)`. The
+   derived token count `M` must divide evenly, and `128 * 196 / 768` is not an integer;
+   `ReplayCADConfig` rejects presets that cannot be reshaped rather than silently truncating.
+
+5. **Benchmarks without a published profile.** The authors publish configurations for MVTec and
+   VisA only. BTech, DAGM, MPDD and multidataset streams fall back to the LDM-256 preset with a
+   neutral initializer, and `for_benchmark` logs a warning when that happens. Those runs reproduce
+   nothing published — they are the method applied to a new dataset.
+
+6. **PatchCore's image-level score is taken before smoothing.** It is the maximum over raw patch
+   distances, while the returned segmentation map is those same distances bilinearly upsampled and
+   Gaussian-smoothed with `smoothing_sigma`. The image score is therefore generally larger than the
+   maximum of the map — which matters when comparing against ADer's published numbers.
+
+7. **`random_reset` drops a component rather than misplacing it.** Both implementations give each
+   connected component 100 attempts to find a non-overlapping position. When one exhausts them, the
+   release records no position for it and then pastes through `zip(objects, positions)`, which
+   shifts every later component onto another component's position and drops the last one; this port
+   drops only the component that failed. Not reachable by any released class configuration.
+
+8. **Connected components** are found with `scipy.ndimage.label` (4-connectivity) instead of the
+   release's `cv2.findContours(RETR_EXTERNAL)` (8-connectivity, filled contours), in the transform
+   mirroring `visa_candle`. Equivalent for the hole-free, non-diagonally-touching components the
+   affected VisA masks actually have.
+
+9. **Inconsistencies in the released scripts are recorded, not resolved.** Three of them:
+   generation checkpoints past their training config's `max_steps`, an `--init_word` phrase
+   truncated to its first word by a single-value argparse option, and two dead, mutually
+   contradictory `macaroni2` branches. The module docstring of
+   `pyclad.vision.strategies.replaycad.per_class` says which value this port takes, and why.

--- a/examples/models/vision/patchcore_torch_example.py
+++ b/examples/models/vision/patchcore_torch_example.py
@@ -1,0 +1,85 @@
+import logging
+import pathlib
+
+from pyclad.callbacks.evaluation.concept_metric_evaluation import ConceptMetricCallback
+from pyclad.callbacks.evaluation.time_evaluation import TimeEvaluationCallback
+from pyclad.metrics.base.average_precision import AveragePrecision
+from pyclad.metrics.base.f1_score import F1Score
+from pyclad.metrics.base.roc_auc import RocAuc
+from pyclad.metrics.continual.average_continual import ContinualAverage
+from pyclad.metrics.continual.backward_transfer import BackwardTransfer
+from pyclad.metrics.continual.forward_transfer import ForwardTransfer
+from pyclad.output.json_writer import JsonOutputWriter
+from pyclad.scenarios.concept_incremental import ConceptIncrementalScenario
+from pyclad.strategies.replay.buffers.adaptive_balanced import (
+    AdaptiveBalancedReplayBuffer,
+)
+from pyclad.strategies.replay.replay import ReplayEnhancedStrategy
+from pyclad.strategies.replay.selection.random import RandomSelection
+from pyclad.vision.callbacks.vision_pixel_concept_metric_callback import (
+    VisionPixelConceptMetricCallback,
+)
+from pyclad.vision.data.readers.vision_reader import read_vision_dataset
+from pyclad.vision.metrics.pixel_aupro import PixelAUPRO
+from pyclad.vision.metrics.pixel_average_precision import PixelAveragePrecision
+from pyclad.vision.metrics.pixel_dice_score import PixelDiceScore
+from pyclad.vision.metrics.pixel_f1_score import PixelF1Score
+from pyclad.vision.metrics.pixel_iou import PixelIoU
+from pyclad.vision.metrics.pixel_roc_auc import PixelRocAuc
+from pyclad.vision.models.patchcore.config import PatchCoreConfig
+from pyclad.vision.models.patchcore.patchcore import PatchCore
+
+logging.basicConfig(level=logging.INFO)
+
+if __name__ == "__main__":
+    """
+    This example showcases how to use the PatchCore model for continual vision anomaly detection.
+    """
+    dataset = read_vision_dataset(
+        root=pathlib.Path("../../resources/vision/BTech_Dataset_transformed"),
+        benchmark="btech",
+        resize_to=(256, 256),
+        data_mode="numpy",
+        color_mode="rgb",
+        # max_train_samples_per_category=150,
+        # max_test_samples_per_category=150,
+    )
+
+    model_config = PatchCoreConfig(
+        input_size=(256, 256),
+        backbone_name="wide_resnet50_2",
+        pretrained_backbone=True,
+        pretrained_weights="IMAGENET1K_V1",
+        batch_size=2,
+        coreset_sampling_ratio=0.1,
+        smoothing_sigma=4.0,
+        threshold_quantile=0.99,
+        seed=42,
+    )
+    model = PatchCore(model_config)
+
+    replay_buffer = AdaptiveBalancedReplayBuffer(selection_method=RandomSelection(), max_size=100)
+    strategy = ReplayEnhancedStrategy(model, replay_buffer)
+
+    summarized_metrics = [ContinualAverage(), BackwardTransfer(), ForwardTransfer()]
+
+    callbacks = [
+        # Image-level
+        ConceptMetricCallback(base_metric=RocAuc(), summarized_metrics=summarized_metrics),
+        ConceptMetricCallback(base_metric=F1Score(), summarized_metrics=summarized_metrics),
+        ConceptMetricCallback(base_metric=AveragePrecision(), summarized_metrics=summarized_metrics),
+        # Pixel-level
+        VisionPixelConceptMetricCallback(base_metric=PixelRocAuc(), summarized_metrics=summarized_metrics),
+        VisionPixelConceptMetricCallback(base_metric=PixelAveragePrecision(), summarized_metrics=summarized_metrics),
+        VisionPixelConceptMetricCallback(base_metric=PixelAUPRO(), summarized_metrics=summarized_metrics),
+        VisionPixelConceptMetricCallback(base_metric=PixelF1Score(), summarized_metrics=summarized_metrics),
+        VisionPixelConceptMetricCallback(base_metric=PixelDiceScore(), summarized_metrics=summarized_metrics),
+        VisionPixelConceptMetricCallback(base_metric=PixelIoU(), summarized_metrics=summarized_metrics),
+        TimeEvaluationCallback(),
+    ]
+
+    scenario = ConceptIncrementalScenario(dataset=dataset, strategy=strategy, callbacks=callbacks)
+    scenario.run()
+
+    output_writer = JsonOutputWriter(pathlib.Path("output.json"))
+    output_writer.write([model, dataset, strategy, *callbacks])

--- a/examples/strategies/replaycad_example.py
+++ b/examples/strategies/replaycad_example.py
@@ -1,0 +1,103 @@
+import logging
+import pathlib
+
+from pyclad.callbacks.evaluation.concept_metric_evaluation import ConceptMetricCallback
+from pyclad.callbacks.evaluation.time_evaluation import TimeEvaluationCallback
+from pyclad.metrics.base.average_precision import AveragePrecision
+from pyclad.metrics.base.f1_score import F1Score
+from pyclad.metrics.base.roc_auc import RocAuc
+from pyclad.metrics.continual.average_continual import ContinualAverage
+from pyclad.metrics.continual.backward_transfer import BackwardTransfer
+from pyclad.metrics.continual.forward_transfer import ForwardTransfer
+from pyclad.output.json_writer import JsonOutputWriter
+from pyclad.scenarios.concept_aware import ConceptAwareScenario
+from pyclad.vision.callbacks.vision_pixel_concept_metric_callback import (
+    VisionPixelConceptMetricCallback,
+)
+from pyclad.vision.data.readers.vision_reader import read_vision_dataset
+from pyclad.vision.metrics.pixel_aupro import PixelAUPRO
+from pyclad.vision.metrics.pixel_average_precision import PixelAveragePrecision
+from pyclad.vision.metrics.pixel_dice_score import PixelDiceScore
+from pyclad.vision.metrics.pixel_f1_score import PixelF1Score
+from pyclad.vision.metrics.pixel_iou import PixelIoU
+from pyclad.vision.metrics.pixel_roc_auc import PixelRocAuc
+from pyclad.vision.models.patchcore.config import PatchCoreConfig
+from pyclad.vision.models.patchcore.patchcore import PatchCore
+from pyclad.vision.strategies.replaycad.backend import DiffusersBackend
+from pyclad.vision.strategies.replaycad.config import ReplayCADConfig
+from pyclad.vision.strategies.replaycad.memory import ReplayCADMemory
+from pyclad.vision.strategies.replaycad.strategy import ReplayCADStrategy
+
+logging.basicConfig(level=logging.INFO)
+
+if __name__ == "__main__":
+    """
+    This example showcases ReplayCAD -- diffusion-based generative replay -- with PatchCore as the
+    (detector-agnostic) anomaly detector. It uses ConceptAwareScenario, not
+    ConceptIncrementalScenario, since ReplayCAD needs the concept id on every call.
+
+    Requires the 'replaycad' extra (pip install -e ".[replaycad]") and either a SAM checkpoint
+    (mask_backend="sam") or the authors' precomputed SAM.zip masks (mask_backend="precomputed",
+    used below). See docs/vision.md for mask backends and the divergences from the paper.
+    """
+    dataset = read_vision_dataset(
+        root=pathlib.Path("../resources/vision/mvtec_ad"),
+        benchmark="mvtec",
+        resize_to=(256, 256),
+        data_mode="numpy",
+        color_mode="rgb",
+        # max_train_samples_per_category=150,
+        # max_test_samples_per_category=150,
+    )
+
+    model = PatchCore(
+        PatchCoreConfig(
+            input_size=(256, 256),
+            backbone_name="wide_resnet50_2",
+            pretrained_backbone=True,
+            pretrained_weights="IMAGENET1K_V1",
+            batch_size=2,
+            seed=42,
+        )
+    )
+
+    replaycad_config = ReplayCADConfig.for_benchmark(
+        "mvtec",
+        artifact_dir=pathlib.Path("./replaycad-artifacts"),
+        mask_backend="precomputed",
+        precomputed_mask_root=pathlib.Path("./SAM/data"),
+        # The authors' SAM.zip has no masks for "zipper"; route it to the full-frame fallback
+        # instead of letting PrecomputedMaskProvider raise on it.
+        mask_modes={"zipper": "full-frame"},
+        device="cuda",
+        seed=42,
+    )
+    memory = ReplayCADMemory(
+        config=replaycad_config,
+        backend=DiffusersBackend(replaycad_config),
+        benchmark="mvtec",
+    )
+    strategy = ReplayCADStrategy(model, memory)
+
+    summarized_metrics = [ContinualAverage(), BackwardTransfer(), ForwardTransfer()]
+
+    callbacks = [
+        # Image-level
+        ConceptMetricCallback(base_metric=RocAuc(), summarized_metrics=summarized_metrics),
+        ConceptMetricCallback(base_metric=F1Score(), summarized_metrics=summarized_metrics),
+        ConceptMetricCallback(base_metric=AveragePrecision(), summarized_metrics=summarized_metrics),
+        # Pixel-level
+        VisionPixelConceptMetricCallback(base_metric=PixelRocAuc(), summarized_metrics=summarized_metrics),
+        VisionPixelConceptMetricCallback(base_metric=PixelAveragePrecision(), summarized_metrics=summarized_metrics),
+        VisionPixelConceptMetricCallback(base_metric=PixelAUPRO(), summarized_metrics=summarized_metrics),
+        VisionPixelConceptMetricCallback(base_metric=PixelF1Score(), summarized_metrics=summarized_metrics),
+        VisionPixelConceptMetricCallback(base_metric=PixelDiceScore(), summarized_metrics=summarized_metrics),
+        VisionPixelConceptMetricCallback(base_metric=PixelIoU(), summarized_metrics=summarized_metrics),
+        TimeEvaluationCallback(),
+    ]
+
+    scenario = ConceptAwareScenario(dataset=dataset, strategy=strategy, callbacks=callbacks)
+    scenario.run()
+
+    output_writer = JsonOutputWriter(pathlib.Path("output.json"))
+    output_writer.write([model, dataset, strategy, *callbacks])

--- a/examples/strategies/replaycad_example.py
+++ b/examples/strategies/replaycad_example.py
@@ -38,7 +38,8 @@ if __name__ == "__main__":
 
     Requires the 'replaycad' extra (pip install -e ".[replaycad]") and either a SAM checkpoint
     (mask_backend="sam") or the authors' precomputed SAM.zip masks (mask_backend="precomputed",
-    used below). See docs/vision.md for mask backends and the divergences from the paper.
+    used below). See "Masks, augmentation and caching" in docs/vision.md for the backends, and
+    "Differences from the original" in docs/vision.md for how this port departs from the paper.
     """
     dataset = read_vision_dataset(
         root=pathlib.Path("../resources/vision/mvtec_ad"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,13 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = ["black>=24.4", "flake8>=7.1.0", "isort>=5.13.0", "pytest>=8.2.2"]
+replaycad = [
+    "diffusers>=0.31",
+    "transformers>=4.44",
+    "accelerate>=0.34",
+    "safetensors>=0.4",
+    "segment-anything>=1.0",
+]
 
 [tool.black]
 line-length = 120

--- a/src/pyclad/vision/models/fastflow/backbones.py
+++ b/src/pyclad/vision/models/fastflow/backbones.py
@@ -1,37 +1,10 @@
 from __future__ import annotations
 
-from collections import OrderedDict
-from typing import Sequence
-
-import torch
-from torch import nn
-from torchvision.models.feature_extraction import create_feature_extractor
-
-from pyclad.vision.models.utilities.backbones import (
-    EFFICIENTNET_BACKBONES,
-    MOBILENET_BACKBONES,
-    RESNET_BACKBONES,
-    create_torchvision_model,
+from pyclad.vision.models.utilities.backbones import (  # noqa: F401  (re-exported for FastFlow callers)
+    TorchvisionFeatureExtractor,
+    default_backbone_return_nodes,
+    supported_backbone_names,
 )
-
-_RESNET_RETURN_NODES = ["relu", "layer1", "layer2", "layer3", "layer4"]
-_EFFICIENTNET_RETURN_NODES = ["features.1", "features.2", "features.3", "features.5", "features.7"]
-
-_DEFAULT_RETURN_NODES: dict[str, list[str]] = {
-    **{name: _RESNET_RETURN_NODES for name in RESNET_BACKBONES},
-    **{name: ["features.1", "features.3", "features.6", "features.13", "features.18"] for name in MOBILENET_BACKBONES},
-    **{name: _EFFICIENTNET_RETURN_NODES for name in EFFICIENTNET_BACKBONES},
-}
-
-
-def supported_backbone_names() -> tuple[str, ...]:
-    return tuple(_DEFAULT_RETURN_NODES.keys())
-
-
-def default_backbone_return_nodes(backbone_name: str) -> list[str]:
-    if backbone_name not in _DEFAULT_RETURN_NODES:
-        raise ValueError(f"No default return nodes for '{backbone_name}'. Set backbone_return_nodes explicitly.")
-    return _DEFAULT_RETURN_NODES[backbone_name]
 
 
 def default_fastflow_return_nodes(backbone_name: str) -> tuple[str, ...]:
@@ -52,36 +25,3 @@ def default_fastflow_return_nodes(backbone_name: str) -> tuple[str, ...]:
     if len(default_nodes) >= 1:
         return default_nodes
     raise ValueError(f"Backbone '{backbone_name}' did not expose any default feature nodes")
-
-
-class TorchvisionFeatureExtractor(nn.Module):
-    def __init__(
-        self,
-        backbone_name: str,
-        return_nodes: Sequence[str],
-        pretrained: bool,
-        freeze: bool,
-    ):
-        super().__init__()
-
-        self._nodes = tuple(return_nodes)
-        if len(self._nodes) == 0:
-            raise ValueError("return_nodes must contain at least one feature node")
-
-        backbone = create_torchvision_model(backbone_name, pretrained=pretrained)
-        self._extractor = create_feature_extractor(
-            model=backbone,
-            return_nodes=OrderedDict((node, node) for node in self._nodes),
-        )
-
-        if freeze:
-            for parameter in self._extractor.parameters():
-                parameter.requires_grad = False
-
-    @property
-    def return_nodes(self) -> tuple[str, ...]:
-        return self._nodes
-
-    def forward(self, x: torch.Tensor) -> list[torch.Tensor]:
-        features = self._extractor(x)
-        return [features[name] for name in self._nodes]

--- a/src/pyclad/vision/models/patchcore/config.py
+++ b/src/pyclad/vision/models/patchcore/config.py
@@ -1,0 +1,34 @@
+from typing import Optional
+
+from pydantic import Field
+
+from pyclad.vision.models.utilities.config import ImageSize, VisionConfig
+
+
+class PatchCoreConfig(VisionConfig):
+    """Configuration for the PatchCore memory-bank detector.
+
+    Defaults follow the reference implementation used by ReplayCAD's benchmark
+    (ADer ``model/patchcore.py``): 1024-dimensional patch embeddings, 3x3 patches,
+    a single nearest neighbour and a 10% greedy coreset.
+    """
+
+    input_size: ImageSize = (256, 256)
+    batch_size: int = Field(default=32, gt=0)
+
+    backbone_name: str = "wide_resnet50_2"
+    backbone_return_nodes: Optional[tuple[str, ...]] = None
+    pretrained_backbone: bool = True
+    freeze_backbone: bool = True
+    pretrained_weights: Optional[str] = "IMAGENET1K_V1"
+
+    pretrain_embed_dimension: int = Field(default=1024, gt=0)
+    target_embed_dimension: int = Field(default=1024, gt=0)
+    patchsize: int = Field(default=3, gt=0)
+    patchstride: int = Field(default=1, gt=0)
+    coreset_sampling_ratio: float = Field(default=0.1, gt=0.0, le=1.0)
+    coreset_projection_dimension: int = Field(default=128, gt=0)
+    coreset_starting_points: int = Field(default=10, gt=0)
+    n_neighbors: int = Field(default=1, gt=0)
+
+    smoothing_sigma: float = Field(default=4.0, ge=0.0)

--- a/src/pyclad/vision/models/patchcore/patchcore.py
+++ b/src/pyclad/vision/models/patchcore/patchcore.py
@@ -1,0 +1,331 @@
+from typing import Optional, Sequence
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from scipy import ndimage
+from sklearn.neighbors import NearestNeighbors
+from torch import nn
+
+from pyclad.vision.models.patchcore.config import PatchCoreConfig
+from pyclad.vision.models.utilities.backbones import (
+    TorchvisionFeatureExtractor,
+    default_backbone_return_nodes,
+)
+from pyclad.vision.models.utilities.base_model import VisionScoringBase
+
+
+class MeanMapper(nn.Module):
+    def __init__(self, preprocessing_dim: int):
+        super().__init__()
+        self.preprocessing_dim = preprocessing_dim
+
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        features = features.reshape(len(features), 1, -1)
+        return F.adaptive_avg_pool1d(features, self.preprocessing_dim).squeeze(1)
+
+
+class FeaturePreprocessor(nn.Module):
+    def __init__(self, input_dims: Sequence[int], output_dim: int):
+        super().__init__()
+        self.input_dims = tuple(input_dims)
+        self.output_dim = output_dim
+        self.preprocessing_modules = nn.ModuleList([MeanMapper(output_dim) for _ in input_dims])
+
+    def forward(self, features: Sequence[torch.Tensor]) -> torch.Tensor:
+        reduced = [module(feature) for module, feature in zip(self.preprocessing_modules, features)]
+        return torch.stack(reduced, dim=1)
+
+
+class FeatureAggregator(nn.Module):
+    def __init__(self, target_dim: int):
+        super().__init__()
+        self.target_dim = target_dim
+
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        features = features.reshape(len(features), 1, -1)
+        features = F.adaptive_avg_pool1d(features, self.target_dim)
+        return features.reshape(len(features), -1)
+
+
+class PatchMaker:
+    def __init__(self, patchsize: int, stride: int):
+        self.patchsize = patchsize
+        self.stride = stride
+
+    def patchify(self, features: torch.Tensor, return_spatial_info: bool = False):
+        padding = int((self.patchsize - 1) / 2)
+        unfolder = nn.Unfold(kernel_size=self.patchsize, stride=self.stride, padding=padding, dilation=1)
+        unfolded_features = unfolder(features)
+
+        number_of_total_patches = []
+        for spatial_size in features.shape[-2:]:
+            n_patches = (spatial_size + 2 * padding - (self.patchsize - 1) - 1) / self.stride + 1
+            number_of_total_patches.append(int(n_patches))
+
+        unfolded_features = unfolded_features.reshape(*features.shape[:2], self.patchsize, self.patchsize, -1)
+        unfolded_features = unfolded_features.permute(0, 4, 1, 2, 3)
+
+        if return_spatial_info:
+            return unfolded_features, number_of_total_patches
+        return unfolded_features
+
+    @staticmethod
+    def unpatch_scores(scores: np.ndarray, batch_size: int) -> np.ndarray:
+        return scores.reshape(batch_size, -1, *scores.shape[1:])
+
+    @staticmethod
+    def score(x: np.ndarray) -> np.ndarray:
+        x_t = torch.from_numpy(x) if isinstance(x, np.ndarray) else x
+        while x_t.ndim > 1:
+            x_t = torch.max(x_t, dim=-1).values
+        return x_t.numpy() if isinstance(x, np.ndarray) else x_t
+
+
+class RescaleSegmentor:
+    def __init__(self, device: torch.device, target_size: tuple[int, int], smoothing: float):
+        self.device = device
+        self.target_size = target_size
+        self.smoothing = smoothing
+
+    def convert_to_segmentation(self, patch_scores: np.ndarray) -> np.ndarray:
+        with torch.no_grad():
+            if isinstance(patch_scores, np.ndarray):
+                patch_scores = torch.from_numpy(patch_scores)
+
+            scores = patch_scores.to(self.device).unsqueeze(1)
+            scores = F.interpolate(scores, size=self.target_size, mode="bilinear", align_corners=False)
+            scores = scores.squeeze(1).cpu().numpy()
+
+        if self.smoothing <= 0:
+            return scores.astype(np.float32, copy=False)
+        return np.asarray(
+            [ndimage.gaussian_filter(score, sigma=self.smoothing) for score in scores],
+            dtype=np.float32,
+        )
+
+
+class ApproximateGreedyCoresetSampler:
+    def __init__(
+        self,
+        percentage: float,
+        device: torch.device,
+        number_of_starting_points: int = 10,
+        dimension_to_project_features_to: int = 128,
+        random_seed: int = 0,
+    ):
+        if percentage <= 0.0 or percentage > 1.0:
+            raise ValueError("percentage must be in (0, 1]")
+
+        self.percentage = percentage
+        self.device = device
+        self.number_of_starting_points = number_of_starting_points
+        self.dimension_to_project_features_to = dimension_to_project_features_to
+        self.random_seed = random_seed
+
+    def _reduce_features(self, features: torch.Tensor) -> torch.Tensor:
+        if features.shape[1] == self.dimension_to_project_features_to:
+            return features.to(self.device)
+
+        with torch.random.fork_rng():
+            torch.manual_seed(self.random_seed)
+            mapper = nn.Linear(features.shape[1], self.dimension_to_project_features_to, bias=False).to(self.device)
+        return mapper(features.to(self.device))
+
+    @staticmethod
+    def _compute_batchwise_differences(matrix_a: torch.Tensor, matrix_b: torch.Tensor) -> torch.Tensor:
+        a_times_a = matrix_a.unsqueeze(1).bmm(matrix_a.unsqueeze(2)).reshape(-1, 1)
+        b_times_b = matrix_b.unsqueeze(1).bmm(matrix_b.unsqueeze(2)).reshape(1, -1)
+        a_times_b = matrix_a.mm(matrix_b.T)
+        return (-2 * a_times_b + a_times_a + b_times_b).clamp(0, None).sqrt()
+
+    def _compute_greedy_coreset_indices(self, features: torch.Tensor) -> np.ndarray:
+        """Greedy coreset selection: repeatedly pick the point with the largest approximate
+        min-distance to the points already selected.
+        """
+        number_of_starting_points = min(self.number_of_starting_points, len(features))
+        rng = np.random.default_rng(self.random_seed)
+        start_points = rng.choice(len(features), number_of_starting_points, replace=False).tolist()
+
+        approximate_distance_matrix = self._compute_batchwise_differences(features, features[start_points])
+        approximate_coreset_anchor_distances = torch.mean(approximate_distance_matrix, axis=-1).reshape(-1, 1)
+
+        coreset_indices = []
+        num_coreset_samples = max(1, int(len(features) * self.percentage))
+
+        with torch.no_grad():
+            for _ in range(num_coreset_samples):
+                select_idx = torch.argmax(approximate_coreset_anchor_distances.squeeze(-1)).item()
+                coreset_indices.append(select_idx)
+
+                coreset_select_distance = self._compute_batchwise_differences(
+                    features, features[select_idx : select_idx + 1]
+                )
+                approximate_coreset_anchor_distances = torch.cat(
+                    [approximate_coreset_anchor_distances, coreset_select_distance],
+                    dim=-1,
+                )
+                approximate_coreset_anchor_distances = torch.min(
+                    approximate_coreset_anchor_distances, dim=1
+                ).values.reshape(-1, 1)
+
+        return np.array(coreset_indices)
+
+    def run(self, features: np.ndarray) -> np.ndarray:
+        if self.percentage == 1.0:
+            return features
+
+        feature_tensor = torch.from_numpy(features.astype(np.float32, copy=False))
+        reduced_features = self._reduce_features(feature_tensor)
+        sample_indices = self._compute_greedy_coreset_indices(reduced_features)
+        return feature_tensor[sample_indices].cpu().numpy().astype(np.float32, copy=False)
+
+
+class PatchCore(VisionScoringBase):
+    """PatchCore: nearest-neighbour scoring against a coreset memory bank of patch features."""
+
+    config: PatchCoreConfig
+
+    def __init__(self, config: Optional[PatchCoreConfig] = None):
+        super().__init__(config or PatchCoreConfig())
+
+        self._apply_seed()  # before backbone construction: its init is random when not pretrained
+        nodes = self.config.backbone_return_nodes or self._require_nodes(self.config.backbone_name)
+        self.module = TorchvisionFeatureExtractor(
+            backbone_name=self.config.backbone_name,
+            return_nodes=nodes,
+            pretrained=self.config.pretrained_backbone,
+            freeze=self.config.freeze_backbone,
+            weights_name=self.config.pretrained_weights,
+        ).to(self._device)
+        self.module.eval()
+
+        self._patch_maker = PatchMaker(patchsize=self.config.patchsize, stride=self.config.patchstride)
+        feature_dimensions = self.module.infer_out_channels(self.config.input_size)
+        self._feature_preprocessor = FeaturePreprocessor(
+            input_dims=feature_dimensions,
+            output_dim=self.config.pretrain_embed_dimension,
+        ).to(self._device)
+        self._feature_aggregator = FeatureAggregator(target_dim=self.config.target_embed_dimension).to(self._device)
+        self._segmentor = RescaleSegmentor(
+            device=self._device,
+            target_size=self.config.input_size,
+            smoothing=self.config.smoothing_sigma,
+        )
+
+        self._memory_bank: Optional[np.ndarray] = None
+        self._nn_index: Optional[NearestNeighbors] = None
+        self._cached_image_scores: Optional[torch.Tensor] = None
+
+    @staticmethod
+    def _require_nodes(backbone_name: str) -> tuple[str, ...]:
+        # PatchCore uses the two mid-level residual stages, as in the reference implementation.
+        nodes = default_backbone_return_nodes(backbone_name)
+        return tuple(node for node in nodes if node in ("layer2", "layer3")) or tuple(nodes[1:3])
+
+    # --- feature extraction --------------------------------------------------
+    @staticmethod
+    def _align_feature_maps(features: list[torch.Tensor], patch_shapes: list[list[int]]) -> list[torch.Tensor]:
+        """Resample every feature level onto the first level's patch grid."""
+        reference_shape = patch_shapes[0]
+        for index in range(1, len(features)):
+            feat = features[index]
+            dims = patch_shapes[index]
+
+            feat = feat.reshape(feat.shape[0], dims[0], dims[1], *feat.shape[2:])
+            feat = feat.permute(0, -3, -2, -1, 1, 2)
+            permuted_shape = feat.shape
+            feat = feat.reshape(-1, *feat.shape[-2:])
+            feat = F.interpolate(
+                feat.unsqueeze(1),
+                size=(reference_shape[0], reference_shape[1]),
+                mode="bilinear",
+                align_corners=False,
+            ).squeeze(1)
+            feat = feat.reshape(*permuted_shape[:-2], reference_shape[0], reference_shape[1])
+            feat = feat.permute(0, -2, -1, 1, 2, 3)
+            features[index] = feat.reshape(len(feat), -1, *feat.shape[-3:])
+
+        return features
+
+    def _embed(self, images: torch.Tensor) -> tuple[np.ndarray, list[list[int]]]:
+        with torch.no_grad():
+            features = self.module(images)
+            patches_with_shapes = [self._patch_maker.patchify(f, return_spatial_info=True) for f in features]
+            patch_shapes = [shape for _, shape in patches_with_shapes]
+            features = [patch for patch, _ in patches_with_shapes]
+
+            features = self._align_feature_maps(features, patch_shapes)
+            features = [f.reshape(-1, *f.shape[-3:]) for f in features]
+            features = self._feature_aggregator(self._feature_preprocessor(features))
+
+        return features.detach().cpu().numpy().astype(np.float32, copy=False), patch_shapes
+
+    # --- fit -----------------------------------------------------------------
+    def fit(self, data: np.ndarray):
+        if len(data) == 0:
+            return
+
+        self._apply_seed()  # before coreset subsampling: its projection and start points are random
+
+        embeddings = []
+        for (batch_x,) in self._prepare_batches(data, shuffle=False):
+            batch_embeddings, _ = self._embed(batch_x.to(self._device, dtype=torch.float32))
+            embeddings.append(batch_embeddings)
+
+        sampler = ApproximateGreedyCoresetSampler(
+            percentage=self.config.coreset_sampling_ratio,
+            device=self._device,
+            number_of_starting_points=self.config.coreset_starting_points,
+            dimension_to_project_features_to=self.config.coreset_projection_dimension,
+            random_seed=self.config.seed if self.config.seed is not None else 0,
+        )
+        self._memory_bank = sampler.run(np.concatenate(embeddings, axis=0))
+        self._nn_index = NearestNeighbors(n_neighbors=min(self.config.n_neighbors, len(self._memory_bank)), n_jobs=1)
+        self._nn_index.fit(self._memory_bank)
+
+        self._calibrate_threshold(data)
+
+    # --- inference -----------------------------------------------------------
+    def _inference_maps(self, batch: torch.Tensor) -> torch.Tensor:
+        if self._memory_bank is None or self._nn_index is None:
+            raise RuntimeError("PatchCore must be fitted before scoring or predicting")
+
+        embeddings, patch_shapes = self._embed(batch)
+        distances, _ = self._nn_index.kneighbors(embeddings)
+        # sklearn returns plain Euclidean distances; the reference (ADer's FaissNN -> IndexFlatL2)
+        # returns SQUARED L2, and squaring isn't a monotone transform after Gaussian smoothing -- so
+        # every downstream quantity here uses the reference's squared scale, not sklearn's.
+        distances = np.square(distances)
+        patch_scores = np.mean(distances, axis=-1).astype(np.float32, copy=False)
+
+        batch_size = batch.shape[0]
+        unpatched = self._patch_maker.unpatch_scores(patch_scores, batch_size=batch_size)
+
+        # Image score: max over RAW patch scores, before any smoothing (reference behaviour).
+        image_scores = self._patch_maker.score(unpatched.reshape(*unpatched.shape[:2], -1))
+        self._cached_image_scores = torch.from_numpy(np.asarray(image_scores, dtype=np.float32).reshape(batch_size)).to(
+            batch.device
+        )
+
+        scales = patch_shapes[0]
+        maps = self._segmentor.convert_to_segmentation(
+            unpatched.reshape(batch_size, scales[0], scales[1]).astype(np.float32, copy=False)
+        )
+        return torch.from_numpy(maps).to(batch.device)
+
+    def _aggregate_scores(self, score_maps: torch.Tensor) -> torch.Tensor:
+        cached, self._cached_image_scores = self._cached_image_scores, None
+        if cached is not None and cached.shape[0] == score_maps.shape[0]:
+            return cached
+        return super()._aggregate_scores(score_maps)
+
+    def name(self) -> str:
+        return "PatchCore"
+
+    def _extra_info(self) -> dict:
+        return {
+            "device": str(self._device),
+            "feature_layers": list(self.module.return_nodes),
+            "memory_bank_size": None if self._memory_bank is None else int(len(self._memory_bank)),
+        }

--- a/src/pyclad/vision/models/patchcore/patchcore.py
+++ b/src/pyclad/vision/models/patchcore/patchcore.py
@@ -3,7 +3,6 @@ from typing import Optional, Sequence
 import numpy as np
 import torch
 import torch.nn.functional as F
-from scipy import ndimage
 from sklearn.neighbors import NearestNeighbors
 from torch import nn
 
@@ -13,6 +12,10 @@ from pyclad.vision.models.utilities.backbones import (
     default_backbone_return_nodes,
 )
 from pyclad.vision.models.utilities.base_model import VisionScoringBase
+from pyclad.vision.models.utilities.coreset import (
+    ApproximateGreedyCoresetSampler,
+    RescaleSegmentor,
+)
 
 
 class MeanMapper(nn.Module):
@@ -80,105 +83,6 @@ class PatchMaker:
         while x_t.ndim > 1:
             x_t = torch.max(x_t, dim=-1).values
         return x_t.numpy() if isinstance(x, np.ndarray) else x_t
-
-
-class RescaleSegmentor:
-    def __init__(self, device: torch.device, target_size: tuple[int, int], smoothing: float):
-        self.device = device
-        self.target_size = target_size
-        self.smoothing = smoothing
-
-    def convert_to_segmentation(self, patch_scores: np.ndarray) -> np.ndarray:
-        with torch.no_grad():
-            if isinstance(patch_scores, np.ndarray):
-                patch_scores = torch.from_numpy(patch_scores)
-
-            scores = patch_scores.to(self.device).unsqueeze(1)
-            scores = F.interpolate(scores, size=self.target_size, mode="bilinear", align_corners=False)
-            scores = scores.squeeze(1).cpu().numpy()
-
-        if self.smoothing <= 0:
-            return scores.astype(np.float32, copy=False)
-        return np.asarray(
-            [ndimage.gaussian_filter(score, sigma=self.smoothing) for score in scores],
-            dtype=np.float32,
-        )
-
-
-class ApproximateGreedyCoresetSampler:
-    def __init__(
-        self,
-        percentage: float,
-        device: torch.device,
-        number_of_starting_points: int = 10,
-        dimension_to_project_features_to: int = 128,
-        random_seed: int = 0,
-    ):
-        if percentage <= 0.0 or percentage > 1.0:
-            raise ValueError("percentage must be in (0, 1]")
-
-        self.percentage = percentage
-        self.device = device
-        self.number_of_starting_points = number_of_starting_points
-        self.dimension_to_project_features_to = dimension_to_project_features_to
-        self.random_seed = random_seed
-
-    def _reduce_features(self, features: torch.Tensor) -> torch.Tensor:
-        if features.shape[1] == self.dimension_to_project_features_to:
-            return features.to(self.device)
-
-        with torch.random.fork_rng():
-            torch.manual_seed(self.random_seed)
-            mapper = nn.Linear(features.shape[1], self.dimension_to_project_features_to, bias=False).to(self.device)
-        return mapper(features.to(self.device))
-
-    @staticmethod
-    def _compute_batchwise_differences(matrix_a: torch.Tensor, matrix_b: torch.Tensor) -> torch.Tensor:
-        a_times_a = matrix_a.unsqueeze(1).bmm(matrix_a.unsqueeze(2)).reshape(-1, 1)
-        b_times_b = matrix_b.unsqueeze(1).bmm(matrix_b.unsqueeze(2)).reshape(1, -1)
-        a_times_b = matrix_a.mm(matrix_b.T)
-        return (-2 * a_times_b + a_times_a + b_times_b).clamp(0, None).sqrt()
-
-    def _compute_greedy_coreset_indices(self, features: torch.Tensor) -> np.ndarray:
-        """Greedy coreset selection: repeatedly pick the point with the largest approximate
-        min-distance to the points already selected.
-        """
-        number_of_starting_points = min(self.number_of_starting_points, len(features))
-        rng = np.random.default_rng(self.random_seed)
-        start_points = rng.choice(len(features), number_of_starting_points, replace=False).tolist()
-
-        approximate_distance_matrix = self._compute_batchwise_differences(features, features[start_points])
-        approximate_coreset_anchor_distances = torch.mean(approximate_distance_matrix, axis=-1).reshape(-1, 1)
-
-        coreset_indices = []
-        num_coreset_samples = max(1, int(len(features) * self.percentage))
-
-        with torch.no_grad():
-            for _ in range(num_coreset_samples):
-                select_idx = torch.argmax(approximate_coreset_anchor_distances.squeeze(-1)).item()
-                coreset_indices.append(select_idx)
-
-                coreset_select_distance = self._compute_batchwise_differences(
-                    features, features[select_idx : select_idx + 1]
-                )
-                approximate_coreset_anchor_distances = torch.cat(
-                    [approximate_coreset_anchor_distances, coreset_select_distance],
-                    dim=-1,
-                )
-                approximate_coreset_anchor_distances = torch.min(
-                    approximate_coreset_anchor_distances, dim=1
-                ).values.reshape(-1, 1)
-
-        return np.array(coreset_indices)
-
-    def run(self, features: np.ndarray) -> np.ndarray:
-        if self.percentage == 1.0:
-            return features
-
-        feature_tensor = torch.from_numpy(features.astype(np.float32, copy=False))
-        reduced_features = self._reduce_features(feature_tensor)
-        sample_indices = self._compute_greedy_coreset_indices(reduced_features)
-        return feature_tensor[sample_indices].cpu().numpy().astype(np.float32, copy=False)
 
 
 class PatchCore(VisionScoringBase):

--- a/src/pyclad/vision/models/utilities/backbones.py
+++ b/src/pyclad/vision/models/utilities/backbones.py
@@ -1,7 +1,11 @@
 import inspect
+from collections import OrderedDict
+from typing import Optional, Sequence
 
+import torch
 import torchvision.models as tv_models
 from torch import nn
+from torchvision.models.feature_extraction import create_feature_extractor
 
 RESNET_BACKBONES: tuple[str, ...] = ("resnet18", "resnet34", "resnet50", "wide_resnet50_2")
 MOBILENET_BACKBONES: tuple[str, ...] = ("mobilenet_v2",)
@@ -18,29 +22,123 @@ EFFICIENTNET_BACKBONES: tuple[str, ...] = (
 SUPPORTED_BACKBONES: tuple[str, ...] = RESNET_BACKBONES + MOBILENET_BACKBONES + EFFICIENTNET_BACKBONES
 
 
-def _resolve_torchvision_weights(model_fn, backbone_name: str):
+def _weights_enum(model_fn, backbone_name: str):
     get_model_weights = getattr(tv_models, "get_model_weights", None)
     if get_model_weights is not None:
-        return get_model_weights(model_fn).DEFAULT
+        # By registered name, not model_fn: torchvision resolves via the `weights` parameter's
+        # type annotation, which breaks for callers (e.g. tests) using an unannotated stand-in.
+        return get_model_weights(backbone_name)
 
     attr_name = f"{backbone_name}_weights".lower()
     for attr in dir(tv_models):
         if attr.lower() == attr_name:
-            enum_cls = getattr(tv_models, attr)
-            if hasattr(enum_cls, "DEFAULT"):
-                return enum_cls.DEFAULT
-            if hasattr(enum_cls, "IMAGENET1K_V1"):
-                return enum_cls.IMAGENET1K_V1
+            return getattr(tv_models, attr)
     return None
 
 
-def create_torchvision_model(backbone_name: str, pretrained: bool) -> nn.Module:
+def _resolve_torchvision_weights(model_fn, backbone_name: str, weights_name: Optional[str]):
+    enum_cls = _weights_enum(model_fn, backbone_name)
+    if enum_cls is None:
+        return None
+
+    if weights_name is None:
+        if hasattr(enum_cls, "DEFAULT"):
+            return enum_cls.DEFAULT
+        return getattr(enum_cls, "IMAGENET1K_V1", None)
+
+    if not hasattr(enum_cls, weights_name):
+        available = ", ".join(member.name for member in enum_cls)
+        raise ValueError(
+            f"Unknown pretrained weights '{weights_name}' for backbone '{backbone_name}'. Available: {available}"
+        )
+    return getattr(enum_cls, weights_name)
+
+
+def create_torchvision_model(
+    backbone_name: str,
+    pretrained: bool,
+    weights_name: Optional[str] = None,
+) -> nn.Module:
+    """Build a torchvision backbone.
+
+    ``weights_name`` selects an explicit member of the backbone's weight enum, e.g.
+    ``"IMAGENET1K_V1"``. Leave it ``None`` to keep torchvision's ``DEFAULT``, which is a moving
+    pointer: for ``wide_resnet50_2`` it currently resolves to ``IMAGENET1K_V2``, while reference
+    anomaly-detection implementations load the ``IMAGENET1K_V1`` checkpoint
+    (``wide_resnet50_2-95faca4d.pth``).
+    """
     model_fn = getattr(tv_models, backbone_name, None)
     if model_fn is None:
         raise ValueError(f"Unsupported backbone '{backbone_name}'")
 
     params = inspect.signature(model_fn).parameters
     if "weights" in params:
-        weights = _resolve_torchvision_weights(model_fn, backbone_name) if pretrained else None
+        weights = _resolve_torchvision_weights(model_fn, backbone_name, weights_name) if pretrained else None
         return model_fn(weights=weights)
     return model_fn(pretrained=pretrained)
+
+
+_RESNET_RETURN_NODES = ["relu", "layer1", "layer2", "layer3", "layer4"]
+_EFFICIENTNET_RETURN_NODES = ["features.1", "features.2", "features.3", "features.5", "features.7"]
+
+_DEFAULT_RETURN_NODES: dict[str, list[str]] = {
+    **{name: _RESNET_RETURN_NODES for name in RESNET_BACKBONES},
+    **{name: ["features.1", "features.3", "features.6", "features.13", "features.18"] for name in MOBILENET_BACKBONES},
+    **{name: _EFFICIENTNET_RETURN_NODES for name in EFFICIENTNET_BACKBONES},
+}
+
+
+def supported_backbone_names() -> tuple[str, ...]:
+    return tuple(_DEFAULT_RETURN_NODES.keys())
+
+
+def default_backbone_return_nodes(backbone_name: str) -> list[str]:
+    if backbone_name not in _DEFAULT_RETURN_NODES:
+        raise ValueError(f"No default return nodes for '{backbone_name}'. Set backbone_return_nodes explicitly.")
+    return _DEFAULT_RETURN_NODES[backbone_name]
+
+
+class TorchvisionFeatureExtractor(nn.Module):
+    def __init__(
+        self,
+        backbone_name: str,
+        return_nodes: Sequence[str],
+        pretrained: bool,
+        freeze: bool,
+        weights_name: Optional[str] = None,
+    ):
+        super().__init__()
+
+        self._nodes = tuple(return_nodes)
+        if len(self._nodes) == 0:
+            raise ValueError("return_nodes must contain at least one feature node")
+
+        backbone = create_torchvision_model(backbone_name, pretrained=pretrained, weights_name=weights_name)
+        self._extractor = create_feature_extractor(
+            model=backbone,
+            return_nodes=OrderedDict((node, node) for node in self._nodes),
+        )
+
+        if freeze:
+            for parameter in self._extractor.parameters():
+                parameter.requires_grad = False
+
+    @property
+    def return_nodes(self) -> tuple[str, ...]:
+        return self._nodes
+
+    def infer_out_channels(self, input_size: tuple[int, int]) -> tuple[int, ...]:
+        """Channel count of each returned feature map, probed with a single dummy forward."""
+        was_training = self.training
+        self.eval()
+        try:
+            device = next(self.parameters()).device
+            with torch.no_grad():
+                features = self.forward(torch.zeros(1, 3, input_size[0], input_size[1], device=device))
+        finally:
+            self.train(was_training)
+        return tuple(feature.shape[1] for feature in features)
+
+    def forward(self, x: torch.Tensor) -> list[torch.Tensor]:
+        features = self._extractor(x)
+        return [features[name] for name in self._nodes]

--- a/src/pyclad/vision/models/utilities/coreset.py
+++ b/src/pyclad/vision/models/utilities/coreset.py
@@ -1,0 +1,149 @@
+"""Coreset sampling and anomaly-map rescaling, shared by the patch-memory models.
+
+These two helpers originate in PatchCore and are needed verbatim by every model that scores
+patches against a subsampled memory bank. They live here, in ``utilities``, rather than inside
+one model's package so that no model has to import from another -- the same layering rule that
+keeps models from importing strategy packages.
+
+Two sizings are offered because the callers ask for different things: PatchCore keeps a
+fraction of its feature pool (``run``), UCAD keeps an exact count (``run_with_target_size``).
+Both go through the same greedy selection.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from scipy import ndimage
+from torch import nn
+
+
+class RescaleSegmentor:
+    def __init__(self, device: torch.device, target_size: tuple[int, int], smoothing: float):
+        self.device = device
+        self.target_size = target_size
+        self.smoothing = smoothing
+
+    def convert_to_segmentation(self, patch_scores: np.ndarray) -> np.ndarray:
+        with torch.no_grad():
+            if isinstance(patch_scores, np.ndarray):
+                patch_scores = torch.from_numpy(patch_scores)
+
+            scores = patch_scores.to(self.device).unsqueeze(1)
+            scores = F.interpolate(scores, size=self.target_size, mode="bilinear", align_corners=False)
+            scores = scores.squeeze(1).cpu().numpy()
+
+        if self.smoothing <= 0:
+            return scores.astype(np.float32, copy=False)
+        return np.asarray(
+            [ndimage.gaussian_filter(score, sigma=self.smoothing) for score in scores],
+            dtype=np.float32,
+        )
+
+
+class ApproximateGreedyCoresetSampler:
+    """Greedy coreset subsampling: repeatedly keep the point farthest from what is already kept.
+
+    ``percentage`` is only read by ``run``; a caller that sizes its coreset absolutely uses
+    ``run_with_target_size`` and leaves it unset.
+    """
+
+    def __init__(
+        self,
+        device: torch.device,
+        percentage: Optional[float] = None,
+        number_of_starting_points: int = 10,
+        dimension_to_project_features_to: int = 128,
+        random_seed: int = 0,
+    ):
+        if percentage is not None and not 0.0 < percentage <= 1.0:
+            raise ValueError("percentage must be in (0, 1]")
+
+        self.device = device
+        self.percentage = percentage
+        self.number_of_starting_points = number_of_starting_points
+        self.dimension_to_project_features_to = dimension_to_project_features_to
+        self.random_seed = random_seed
+
+    def _reduce_features(self, features: torch.Tensor) -> torch.Tensor:
+        if features.shape[1] == self.dimension_to_project_features_to:
+            return features.to(self.device)
+
+        with torch.random.fork_rng():
+            torch.manual_seed(self.random_seed)
+            mapper = nn.Linear(features.shape[1], self.dimension_to_project_features_to, bias=False).to(self.device)
+        return mapper(features.to(self.device))
+
+    @staticmethod
+    def _compute_batchwise_differences(matrix_a: torch.Tensor, matrix_b: torch.Tensor) -> torch.Tensor:
+        a_times_a = matrix_a.unsqueeze(1).bmm(matrix_a.unsqueeze(2)).reshape(-1, 1)
+        b_times_b = matrix_b.unsqueeze(1).bmm(matrix_b.unsqueeze(2)).reshape(1, -1)
+        a_times_b = matrix_a.mm(matrix_b.T)
+        return (-2 * a_times_b + a_times_a + b_times_b).clamp(0, None).sqrt()
+
+    def _compute_greedy_coreset_indices(self, features: torch.Tensor, num_samples: int) -> np.ndarray:
+        """Greedy coreset selection: repeatedly pick the point farthest from the selected set.
+
+        "Farthest" is approximated via mean distance to a random subset of starting points,
+        updated incrementally as each new point is selected.
+        """
+        number_of_starting_points = min(self.number_of_starting_points, len(features))
+        rng = np.random.default_rng(self.random_seed)
+        start_points = rng.choice(len(features), number_of_starting_points, replace=False).tolist()
+
+        approximate_distance_matrix = self._compute_batchwise_differences(features, features[start_points])
+        approximate_coreset_anchor_distances = torch.mean(approximate_distance_matrix, axis=-1).reshape(-1, 1)
+
+        coreset_indices = []
+
+        with torch.no_grad():
+            for _ in range(num_samples):
+                scores = approximate_coreset_anchor_distances.squeeze(-1)
+                select_idx = torch.argmax(scores).item()
+                coreset_indices.append(select_idx)
+
+                coreset_select_distance = self._compute_batchwise_differences(
+                    features, features[select_idx : select_idx + 1]
+                )
+                approximate_coreset_anchor_distances = torch.cat(
+                    [approximate_coreset_anchor_distances, coreset_select_distance],
+                    dim=-1,
+                )
+                approximate_coreset_anchor_distances = torch.min(
+                    approximate_coreset_anchor_distances, dim=1
+                ).values.reshape(-1, 1)
+
+        return np.array(coreset_indices)
+
+    def run(self, features: np.ndarray) -> np.ndarray:
+        """Keep ``percentage`` of ``features``, at least one point."""
+        if self.percentage is None:
+            raise ValueError("run() needs a percentage; pass one to the constructor or call run_with_target_size()")
+        if self.percentage == 1.0:
+            return features
+
+        feature_tensor = torch.from_numpy(features.astype(np.float32, copy=False))
+        reduced_features = self._reduce_features(feature_tensor)
+        num_samples = max(1, int(len(features) * self.percentage))
+        sample_indices = self._compute_greedy_coreset_indices(reduced_features, num_samples=num_samples)
+        return feature_tensor[sample_indices].cpu().numpy().astype(np.float32, copy=False)
+
+    def run_with_target_size(self, features: np.ndarray, target_size: int) -> np.ndarray:
+        """Select exactly ``target_size`` coreset points, or all of them when there are fewer.
+
+        UCAD specifies its key and knowledge banks as an absolute number of vectors (196);
+        expressing that as a percentage of a varying pool size could round down by one, so
+        this samples an exact count directly instead.
+        """
+        if target_size <= 0:
+            raise ValueError("target_size must be positive")
+        if len(features) <= target_size:
+            return features.astype(np.float32, copy=False)
+
+        feature_tensor = torch.from_numpy(features.astype(np.float32, copy=False))
+        reduced_features = self._reduce_features(feature_tensor)
+        sample_indices = self._compute_greedy_coreset_indices(reduced_features, num_samples=target_size)
+        return feature_tensor[sample_indices].cpu().numpy().astype(np.float32, copy=False)

--- a/src/pyclad/vision/strategies/replaycad/artifacts.py
+++ b/src/pyclad/vision/strategies/replaycad/artifacts.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import torch
+from PIL import Image
+
+from pyclad.vision.strategies.replaycad.config import ReplayCADConfig
+
+MECHANISM_VERSION = 2
+
+_HASHED_FIELDS = (
+    "model_id",
+    "resolution",
+    "condition_dim",
+    "latent_scaling_factor",
+    "semantic_tokens",
+    "mask_group_width",
+    "mask_projection_width",
+    "use_spatial_conditioning",
+    "compression_steps",
+    "compression_batch_size",
+    "base_learning_rate",
+    "learning_rate_scale",
+    "semantic_lr_multiplier",
+    "weight_decay",
+    "initializer_word",
+    "prompt_templates",
+    "timestep_sampling",
+    "train_augmentation",
+    "masks_per_concept",
+    "mask_backend",
+    "mask_modes",
+    "sam_checkpoint",
+    "sam_model_type",
+    "precomputed_mask_root",
+    "seed",
+    "torch_dtype",
+)
+
+
+def concept_slug(concept_id: str) -> str:
+    """Filesystem-safe directory name for a concept.
+
+    Multidataset concepts arrive as ``<alias>__<category>`` (see
+    ``pyclad/vision/data/multi_dataset.py``), and category names can contain spaces or slashes.
+    """
+    slug = re.sub(r"[\\/]+", "_", concept_id.strip())
+    slug = re.sub(r"\s+", "-", slug)
+    slug = re.sub(r"[^A-Za-z0-9_.-]", "-", slug)
+    if not slug:
+        raise ValueError(f"Concept id {concept_id!r} does not produce a usable directory name")
+    return slug
+
+
+def compression_config_hash(config: ReplayCADConfig) -> str:
+    payload = {"mechanism_version": MECHANISM_VERSION}
+    for field in _HASHED_FIELDS:
+        value = getattr(config, field)
+        if isinstance(value, tuple):
+            value = list(value)
+        payload[field] = value
+    encoded = json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+@dataclass
+class ConceptArtifact:
+    """Everything ReplayCAD stores for one historical concept."""
+
+    concept_id: str
+    embedding: torch.Tensor
+    projection_state: Optional[dict]
+    masks: np.ndarray
+    config_hash: str
+    spatial_tokens: int
+
+
+def save_artifact(artifact: ConceptArtifact, root: Path) -> Path:
+    directory = Path(root) / concept_slug(artifact.concept_id)
+    masks_dir = directory / "masks"
+    masks_dir.mkdir(parents=True, exist_ok=True)
+
+    (directory / "meta.json").unlink(missing_ok=True)
+
+    for existing in masks_dir.glob("*.png"):
+        existing.unlink()
+
+    torch.save(artifact.embedding.detach().cpu(), directory / "embedding.pt")
+    if artifact.projection_state is None:
+        (directory / "projection.pt").unlink(missing_ok=True)
+    else:
+        torch.save(
+            {key: value.detach().cpu() for key, value in artifact.projection_state.items()},
+            directory / "projection.pt",
+        )
+
+    for index, mask in enumerate(artifact.masks):
+        Image.fromarray(np.asarray(mask, dtype=np.uint8)).save(masks_dir / f"{index:03d}.png")
+
+    # Written to a temp file and renamed into place: meta.json is the crash-safety marker itself
+    # (above), so a crash mid-write must not leave a truncated file that passes is_file() in
+    # load_artifact() and then raises JSONDecodeError on every later run.
+    meta_path = directory / "meta.json"
+    meta_tmp_path = directory / "meta.json.tmp"
+    meta_tmp_path.write_text(
+        json.dumps(
+            {
+                "concept_id": artifact.concept_id,
+                "config_hash": artifact.config_hash,
+                "spatial_tokens": artifact.spatial_tokens,
+                "mechanism_version": MECHANISM_VERSION,
+                "semantic_tokens": int(artifact.embedding.shape[0]),
+                "condition_dim": int(artifact.embedding.shape[1]),
+                "mask_count": int(len(artifact.masks)),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    os.replace(meta_tmp_path, meta_path)
+    return directory
+
+
+def load_artifact(concept_id: str, root: Path) -> Optional[ConceptArtifact]:
+    directory = Path(root) / concept_slug(concept_id)
+    meta_path = directory / "meta.json"
+    if not meta_path.is_file():
+        return None
+
+    meta = json.loads(meta_path.read_text())
+    embedding = torch.load(directory / "embedding.pt", map_location="cpu", weights_only=True)
+
+    projection_path = directory / "projection.pt"
+    projection_state = (
+        torch.load(projection_path, map_location="cpu", weights_only=True) if projection_path.is_file() else None
+    )
+
+    mask_paths = sorted((directory / "masks").glob("*.png"))
+    masks = (
+        np.stack([np.asarray(Image.open(path).convert("L"), dtype=np.uint8) for path in mask_paths])
+        if mask_paths
+        else np.zeros((0, 0, 0), dtype=np.uint8)
+    )
+
+    return ConceptArtifact(
+        concept_id=meta["concept_id"],
+        embedding=embedding,
+        projection_state=projection_state,
+        masks=masks,
+        config_hash=meta["config_hash"],
+        spatial_tokens=int(meta["spatial_tokens"]),
+    )

--- a/src/pyclad/vision/strategies/replaycad/artifacts.py
+++ b/src/pyclad/vision/strategies/replaycad/artifacts.py
@@ -14,7 +14,9 @@ from PIL import Image
 
 from pyclad.vision.strategies.replaycad.config import ReplayCADConfig
 
-MECHANISM_VERSION = 2
+# Bumped whenever a change makes previously written artifacts unreadable or wrong to reuse;
+# a mismatch invalidates the cache rather than silently loading a stale representation.
+MECHANISM_VERSION = 1
 
 _HASHED_FIELDS = (
     "model_id",

--- a/src/pyclad/vision/strategies/replaycad/backend.py
+++ b/src/pyclad/vision/strategies/replaycad/backend.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Optional, Protocol
+
+import numpy as np
+import torch
+
+from pyclad.vision.strategies.replaycad.artifacts import ConceptArtifact
+from pyclad.vision.strategies.replaycad.config import ReplayCADConfig
+from pyclad.vision.strategies.replaycad.masks import augment_mask, augment_training_pair
+from pyclad.vision.strategies.replaycad.spatial import MaskProjection
+
+logger = logging.getLogger(__name__)
+
+
+class DiffusionBackend(Protocol):
+    def compress(self, concept_id: str, images: np.ndarray, masks: np.ndarray) -> tuple[torch.Tensor, Optional[dict]]:
+        """Learn the concept's semantic embedding and mask projection."""
+
+    def generate(self, artifact: ConceptArtifact, count: int, seed: int) -> np.ndarray:
+        """Generate ``count`` normal images for the concept described by ``artifact``."""
+
+    def release_device_memory(self) -> None:
+        """Move accelerator state off the device between ReplayCAD phases."""
+
+
+class DiffusersBackend:
+    """ReplayCAD stage 1 and 2 on frozen Diffusers components.
+
+    Only the semantic placeholder vectors and the mask projection are trained; VAE, text encoder
+    and U-Net (including its embedding matrix) stay frozen. Placeholders are substituted into the
+    text encoder's embedded output via a forward hook rather than trained in place, mirroring the
+    released ``EmbeddingManager`` -- which is what makes a shared, nonzero ``weight_decay`` safe:
+    it never touches the untrained vocabulary rows.
+    """
+
+    def __init__(self, config: ReplayCADConfig):
+        self.config = config
+        self._pipeline = None
+        self._placeholder_ids: Optional[list[int]] = None
+
+    def _load(self):
+        if self._pipeline is not None:
+            self._pipeline.to(self.config.device)
+            return self._pipeline
+
+        try:
+            from diffusers import DDIMScheduler, DiffusionPipeline
+        except ImportError as exc:
+            raise ImportError(
+                "ReplayCAD's diffusion backend requires diffusers and transformers. "
+                "Install pyclad with the 'replaycad' extra: pip install -e '.[replaycad]'"
+            ) from exc
+
+        dtype = {"float32": torch.float32, "float16": torch.float16, "bfloat16": torch.bfloat16}[
+            self.config.torch_dtype
+        ]
+        pipeline = DiffusionPipeline.from_pretrained(
+            self.config.model_id,
+            torch_dtype=dtype,
+            local_files_only=self.config.local_files_only,
+            safety_checker=None,
+            requires_safety_checker=False,
+        )
+        pipeline.scheduler = DDIMScheduler.from_config(pipeline.scheduler.config)
+        pipeline.to(self.config.device)
+
+        for module in (self._text_encoder(pipeline), pipeline.unet, self._vae(pipeline)):
+            module.eval()
+            for parameter in module.parameters():
+                parameter.requires_grad_(False)
+
+        cross_attention_dim = int(getattr(pipeline.unet.config, "cross_attention_dim", self.config.condition_dim))
+        if cross_attention_dim != self.config.condition_dim:
+            raise ValueError(
+                f"ReplayCAD preset expects condition_dim={self.config.condition_dim}, but "
+                f"'{self.config.model_id}' exposes {cross_attention_dim}"
+            )
+
+        self._pipeline = pipeline
+        return pipeline
+
+    def _text_encoder(self, pipeline):
+        return getattr(pipeline, "text_encoder", None) or pipeline.bert
+
+    def _vae(self, pipeline):
+        return getattr(pipeline, "vae", None) or pipeline.vqvae
+
+    def release_device_memory(self) -> None:
+        if self._pipeline is None or not self.config.device.startswith("cuda"):
+            return
+        self._pipeline.to("cpu")
+        torch.cuda.empty_cache()
+        logger.info("ReplayCAD diffusion pipeline moved to CPU")
+
+    def _install_placeholders(self, pipeline, concept_id: str) -> list[int]:
+        """Register K placeholder tokens and initialize their embeddings.
+
+        The authors repeat one initializer word's embedding K times (``embedding_manager.py:80``);
+        the paper instead says the embedding is randomly initialized. ``initializer_word=None``
+        (the default) follows the paper.
+        """
+        tokenizer = pipeline.tokenizer
+        text_encoder = self._text_encoder(pipeline)
+
+        tokens = [f"<replaycad-{concept_id}-{index}>" for index in range(self.config.semantic_tokens)]
+        known_vocabulary = tokenizer.get_vocab()
+        missing = [token for token in tokens if token not in known_vocabulary]
+        if missing:
+            added = tokenizer.add_tokens(missing)
+            if added != len(missing):
+                raise RuntimeError(f"Tokenizer refused {len(missing) - added} ReplayCAD placeholder token(s)")
+            text_encoder.resize_token_embeddings(len(tokenizer))
+
+        token_ids = tokenizer.convert_tokens_to_ids(tokens)
+        embedding_layer = text_encoder.get_input_embeddings()
+        with torch.no_grad():
+            if self.config.initializer_word is None:
+                generator = torch.Generator(device="cpu").manual_seed(self.config.seed)
+                init = torch.rand(
+                    self.config.semantic_tokens,
+                    embedding_layer.weight.shape[1],
+                    generator=generator,
+                ).to(device=embedding_layer.weight.device, dtype=embedding_layer.weight.dtype)
+            else:
+                word_ids = tokenizer(self.config.initializer_word, add_special_tokens=False)["input_ids"]
+                if len(word_ids) != 1:
+                    raise ValueError(
+                        f"initializer_word '{self.config.initializer_word}' must map to exactly one token, "
+                        f"got {len(word_ids)}"
+                    )
+                init = embedding_layer.weight[word_ids[0]].unsqueeze(0).repeat(self.config.semantic_tokens, 1)
+            embedding_layer.weight[token_ids] = init
+
+        self._placeholder_ids = list(token_ids)
+        return list(token_ids)
+
+    def _conditioning(self, pipeline, prompts: list[str]) -> torch.Tensor:
+        """Encode prompts into the U-Net's cross-attention conditioning.
+
+        ``max_length`` uses the text encoder's own position-embedding limit, not
+        ``tokenizer.model_max_length`` -- for LDM-Bert those disagree (77 vs. an effectively
+        unbounded default) and exceeding 77 raises ``IndexError``. The encoded dict is also
+        filtered to the keys the encoder's ``forward`` accepts, since ``BertTokenizer`` emits
+        ``token_type_ids`` that ``LDMBertModel.forward`` doesn't take. Both are no-ops for Stable
+        Diffusion/CLIP.
+        """
+        tokenizer, text_encoder = pipeline.tokenizer, self._text_encoder(pipeline)
+        placeholders = " ".join(tokenizer.convert_ids_to_tokens(self._placeholder_ids) if self._placeholder_ids else [])
+        texts = [prompt.replace("*", placeholders) for prompt in prompts]
+
+        max_length = getattr(text_encoder.config, "max_position_embeddings", tokenizer.model_max_length)
+        encoded = tokenizer(texts, padding="max_length", truncation=True, max_length=max_length, return_tensors="pt")
+
+        accepted = set(inspect.signature(text_encoder.forward).parameters) & set(tokenizer.model_input_names)
+        encoded = {key: value.to(text_encoder.device) for key, value in encoded.items() if key in accepted}
+        return text_encoder(**encoded)[0]
+
+    def _encode(self, pipeline, batch: torch.Tensor) -> torch.Tensor:
+        """Encode NCHW images in [-1, 1] into scaled latents."""
+        vae = self._vae(pipeline)
+        posterior = vae.encode(batch)
+        latents = posterior.latent_dist.sample() if hasattr(posterior, "latent_dist") else posterior.latents
+        return latents * self.config.latent_scaling_factor
+
+    @staticmethod
+    def _pad_unconditional(uncond: torch.Tensor, target_tokens: int) -> torch.Tensor:
+        """Left-pad the unconditional embedding with zero tokens to ``target_tokens``.
+
+        Matches ``ldm/models/diffusion/ddim.py:183-184``: the zero tokens participate in the
+        unconditional branch's cross-attention softmax, so dropping them changes the guidance
+        signal, not just the shape. The pad goes in front, as it does there.
+        """
+        missing = target_tokens - uncond.shape[1]
+        if missing <= 0:
+            return uncond
+        padding = torch.zeros(uncond.shape[0], missing, uncond.shape[2], device=uncond.device, dtype=uncond.dtype)
+        return torch.cat([padding, uncond], dim=1)
+
+    def _sample_timesteps(self, pipeline, batch_size: int, device) -> torch.Tensor:
+        """Draw training timesteps as in the released implementation (ddpm2.py:984).
+
+        ``uniform`` matches ``average_t=True`` (the class default); ``cubic`` matches
+        ``average_t=False`` -- ``probs = arange(T) ** 3`` normalized -- used only for pcb1-4 and fryum.
+        """
+        num_train_timesteps = pipeline.scheduler.config.num_train_timesteps
+        if self.config.timestep_sampling == "uniform":
+            return torch.randint(0, num_train_timesteps, (batch_size,), device=device, dtype=torch.long)
+
+        probabilities = torch.arange(0, num_train_timesteps, dtype=torch.float) ** 3
+        probabilities = probabilities / probabilities.sum()
+        return torch.multinomial(probabilities, batch_size, replacement=True).to(device=device, dtype=torch.long)
+
+    @staticmethod
+    def _to_model_input(array: np.ndarray, device, dtype) -> torch.Tensor:
+        """(N, H, W, C) uint8 -> (N, C, H, W) float in [-1, 1], the LDM convention."""
+        tensor = torch.from_numpy(np.asarray(array, dtype=np.float32) / 127.5 - 1.0)
+        if tensor.ndim == 3:
+            tensor = tensor.unsqueeze(-1).repeat(1, 1, 1, 3)
+        return tensor.permute(0, 3, 1, 2).to(device=device, dtype=dtype)
+
+    @staticmethod
+    def _install_substitution_hook(embedding_layer, token_ids: list[int], placeholder: torch.Tensor):
+        """Register a forward hook substituting ``placeholder``'s rows for ``token_ids``' rows in
+        the embedding layer's output; ``embedding_layer.weight`` itself is never written.
+
+        The caller must remove the returned handle, including on failure: hooks stack rather than
+        replace, and the embedding layer is shared across concepts, so a leaked hook would keep
+        substituting this concept's stale rows into every later concept's forward passes.
+        """
+        vocab_size = embedding_layer.weight.shape[0]
+        placeholder_row = torch.full((vocab_size,), -1, dtype=torch.long, device=embedding_layer.weight.device)
+        placeholder_row[torch.as_tensor(token_ids, device=embedding_layer.weight.device)] = torch.arange(
+            len(token_ids), device=embedding_layer.weight.device
+        )
+
+        def _substitute_placeholders(module, args, kwargs, output):
+            input_ids = args[0] if args else kwargs["input"]
+            row = placeholder_row[input_ids]
+            is_placeholder = row >= 0
+            if not bool(is_placeholder.any()):
+                return output
+            substituted = placeholder[row.clamp(min=0)].to(output.dtype)
+            return torch.where(is_placeholder.unsqueeze(-1), substituted, output)
+
+        return embedding_layer.register_forward_hook(_substitute_placeholders, with_kwargs=True)
+
+    def compress(self, concept_id: str, images: np.ndarray, masks: np.ndarray):
+        pipeline = self._load()
+        if len(images) == 0:
+            raise ValueError(f"Cannot compress empty concept '{concept_id}'")
+        # A zero-length mask array means spatial conditioning is off; any other mismatch is a bug.
+        if len(masks) != 0 and len(images) != len(masks):
+            raise ValueError(f"ReplayCAD got {len(images)} images and {len(masks)} masks for '{concept_id}'")
+
+        torch.manual_seed(self.config.seed)
+        token_ids = self._install_placeholders(pipeline, concept_id)
+        text_encoder = self._text_encoder(pipeline)
+        embedding_layer = text_encoder.get_input_embeddings()
+
+        placeholder = torch.nn.Parameter(embedding_layer.weight[token_ids].detach().clone())
+        hook = self._install_substitution_hook(embedding_layer, token_ids, placeholder)
+
+        try:
+            projection = None
+            parameter_groups = [{"params": [placeholder], "lr": self.config.semantic_learning_rate}]
+            if self.config.use_spatial_conditioning:
+                projection = MaskProjection(
+                    self.config.mask_group_width, self.config.mask_projection_width, self.config.condition_dim
+                ).to(device=embedding_layer.weight.device, dtype=embedding_layer.weight.dtype)
+                parameter_groups.append(
+                    {"params": list(projection.parameters()), "lr": self.config.spatial_learning_rate}
+                )
+            optimizer = torch.optim.AdamW(parameter_groups, weight_decay=self.config.weight_decay)
+
+            rng = np.random.default_rng(self.config.seed)
+            device, dtype = embedding_layer.weight.device, embedding_layer.weight.dtype
+            batch_size = min(self.config.compression_batch_size, len(images))
+
+            self._run_compression_loop(
+                pipeline, projection, optimizer, images, masks, rng, device, dtype, batch_size, concept_id
+            )
+        finally:
+            hook.remove()
+
+        learned = placeholder.detach().cpu().clone()
+        projection_state = (
+            None if projection is None else {k: v.detach().cpu() for k, v in projection.state_dict().items()}
+        )
+        return learned, projection_state
+
+    def _run_compression_loop(
+        self, pipeline, projection, optimizer, images, masks, rng, device, dtype, batch_size, concept_id
+    ):
+        for step in range(self.config.compression_steps):
+            indices = rng.choice(len(images), size=batch_size, replace=len(images) < batch_size)
+            if projection is not None:
+                pairs = [
+                    augment_training_pair(images[index], masks[index], self.config.train_augmentation, rng)
+                    for index in indices
+                ]
+                augmented_images = [pair[0] for pair in pairs]
+            else:
+                augmented_images = [
+                    augment_training_pair(images[index], images[index], self.config.train_augmentation, rng)[0]
+                    for index in indices
+                ]
+            image_batch = self._to_model_input(np.stack(augmented_images), device, dtype)
+            latents = self._encode(pipeline, image_batch)
+
+            noise = torch.randn_like(latents)
+            timesteps = self._sample_timesteps(pipeline, batch_size, device)
+            noisy = pipeline.scheduler.add_noise(latents, noise, timesteps)
+
+            prompts = [str(rng.choice(self.config.prompt_templates)).format("*") for _ in range(batch_size)]
+            conditioning = self._conditioning(pipeline, prompts)
+            if projection is not None:
+                mask_batch = self._to_model_input(np.stack([pair[1] for pair in pairs]), device, dtype)
+                mask_latents = self._encode(pipeline, mask_batch)
+                conditioning = torch.cat([conditioning, projection(mask_latents)], dim=1)
+
+            predicted = pipeline.unet(noisy, timesteps, encoder_hidden_states=conditioning).sample
+            loss = torch.nn.functional.mse_loss(predicted.float(), noise.float())
+
+            optimizer.zero_grad(set_to_none=True)
+            loss.backward()
+            optimizer.step()
+
+            if step % 500 == 0:
+                logger.info(
+                    "ReplayCAD compression %s step %d/%d loss %.5f",
+                    concept_id,
+                    step,
+                    self.config.compression_steps,
+                    loss.item(),
+                )
+
+    def generate(self, artifact: ConceptArtifact, count: int, seed: int) -> np.ndarray:
+        pipeline = self._load()
+        token_ids = self._install_placeholders(pipeline, artifact.concept_id)
+        text_encoder = self._text_encoder(pipeline)
+        embedding_layer = text_encoder.get_input_embeddings()
+        device, dtype = embedding_layer.weight.device, embedding_layer.weight.dtype
+
+        with torch.no_grad():
+            embedding_layer.weight[token_ids] = artifact.embedding.to(device=device, dtype=dtype)
+
+        projection = None
+        if artifact.projection_state is not None:
+            projection = MaskProjection(
+                self.config.mask_group_width, self.config.mask_projection_width, self.config.condition_dim
+            ).to(device=device, dtype=dtype)
+            projection.load_state_dict(artifact.projection_state)
+            projection.eval()
+
+        pipeline.scheduler.set_timesteps(self.config.inference_steps, device=device)
+        rng = np.random.default_rng(seed)
+        generator = torch.Generator(device="cpu").manual_seed(seed)
+        latent_side = self.config.resolution // 8
+
+        produced = []
+        with torch.no_grad():
+            while sum(len(chunk) for chunk in produced) < count:
+                batch = min(self.config.generation_batch_size, count - sum(len(c) for c in produced))
+
+                conditioning = self._conditioning(pipeline, [self.config.generation_prompt] * batch)
+                if projection is not None and len(artifact.masks):
+                    chosen = np.stack(
+                        [
+                            augment_mask(artifact.masks[rng.integers(len(artifact.masks))], self.config, rng)
+                            for _ in range(batch)
+                        ]
+                    )
+                    mask_latents = self._encode(pipeline, self._to_model_input(chosen, device, dtype))
+                    conditioning = torch.cat([conditioning, projection(mask_latents)], dim=1)
+
+                uncond = self._conditioning(pipeline, [""] * batch)
+                uncond = self._pad_unconditional(uncond, conditioning.shape[1])
+
+                latents = torch.randn(
+                    (batch, pipeline.unet.config.in_channels, latent_side, latent_side), generator=generator
+                ).to(device=device, dtype=dtype)
+                latents = latents * pipeline.scheduler.init_noise_sigma
+
+                for timestep in pipeline.scheduler.timesteps:
+                    model_input = pipeline.scheduler.scale_model_input(latents, timestep)
+                    noise_cond = pipeline.unet(model_input, timestep, encoder_hidden_states=conditioning).sample
+                    noise_uncond = pipeline.unet(model_input, timestep, encoder_hidden_states=uncond).sample
+                    guided = noise_uncond + self.config.guidance_scale * (noise_cond - noise_uncond)
+                    latents = pipeline.scheduler.step(
+                        guided, timestep, latents, eta=self.config.ddim_eta, generator=generator
+                    ).prev_sample
+
+                decoded = self._vae(pipeline).decode(latents / self.config.latent_scaling_factor).sample
+                decoded = ((decoded.clamp(-1.0, 1.0) + 1.0) * 127.5).round()
+                produced.append(decoded.permute(0, 2, 3, 1).to(torch.uint8).cpu().numpy())
+
+        return np.concatenate(produced, axis=0)[:count]

--- a/src/pyclad/vision/strategies/replaycad/backend.py
+++ b/src/pyclad/vision/strategies/replaycad/backend.py
@@ -1,3 +1,10 @@
+"""Diffusion compression and generation -- the ``diffusers`` stand-in for the release's ``ldm/``.
+
+Docstrings below cite the authors' code by file and line (``embedding_manager.py:80``
+and the like). Those files are not in this repository; they live in the authors' release,
+pinned to a commit under "ReplayCAD" in docs/vision.md.
+"""
+
 from __future__ import annotations
 
 import inspect
@@ -169,7 +176,7 @@ class DiffusersBackend:
     def _pad_unconditional(uncond: torch.Tensor, target_tokens: int) -> torch.Tensor:
         """Left-pad the unconditional embedding with zero tokens to ``target_tokens``.
 
-        Matches ``ldm/models/diffusion/ddim.py:183-184``: the zero tokens participate in the
+        Matches ``textual_inversion-main/ldm/models/diffusion/ddim.py:183-184``: the zero tokens participate in the
         unconditional branch's cross-attention softmax, so dropping them changes the guidance
         signal, not just the shape. The pad goes in front, as it does there.
         """

--- a/src/pyclad/vision/strategies/replaycad/config.py
+++ b/src/pyclad/vision/strategies/replaycad/config.py
@@ -1,0 +1,251 @@
+import logging
+from pathlib import Path
+from typing import Dict, Literal, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+from pyclad.vision.strategies.replaycad.spatial import spatial_token_count
+
+logger = logging.getLogger(__name__)
+
+# Prompt templates from rinongal/textual_inversion (MIT, Rinon Gal et al.). ReplayCAD samples one
+# uniformly per training step (personalized.py:218); generation instead uses a fixed prompt.
+IMAGENET_TEMPLATES_SMALL: tuple[str, ...] = (
+    "a photo of a {}",
+    "a rendering of a {}",
+    "a cropped photo of the {}",
+    "the photo of a {}",
+    "a photo of a clean {}",
+    "a photo of a dirty {}",
+    "a dark photo of the {}",
+    "a photo of my {}",
+    "a photo of the cool {}",
+    "a close-up photo of a {}",
+    "a bright photo of the {}",
+    "a cropped photo of a {}",
+    "a photo of the {}",
+    "a good photo of the {}",
+    "a photo of one {}",
+    "a close-up photo of the {}",
+    "a rendition of the {}",
+    "a photo of the clean {}",
+    "a rendition of a {}",
+    "a photo of a nice {}",
+    "a good photo of a {}",
+    "a photo of the nice {}",
+    "a photo of the small {}",
+    "a photo of the weird {}",
+    "a photo of the large {}",
+    "a photo of a cool {}",
+    "a photo of a small {}",
+    "an illustration of a {}",
+    "a rendering of a {}",
+    "a cropped photo of the {}",
+    "the photo of a {}",
+    "an illustration of a clean {}",
+    "an illustration of a dirty {}",
+    "a dark photo of the {}",
+    "an illustration of my {}",
+    "an illustration of the cool {}",
+    "a close-up photo of a {}",
+    "a bright photo of the {}",
+    "a cropped photo of a {}",
+    "an illustration of the {}",
+    "a good photo of the {}",
+    "an illustration of one {}",
+    "a close-up photo of the {}",
+    "a rendition of the {}",
+    "an illustration of the clean {}",
+    "a rendition of a {}",
+    "an illustration of a nice {}",
+    "a good photo of a {}",
+    "an illustration of the nice {}",
+    "an illustration of the small {}",
+    "an illustration of the weird {}",
+    "an illustration of the large {}",
+    "an illustration of a cool {}",
+    "an illustration of a small {}",
+    "a depiction of a {}",
+    "a rendering of a {}",
+    "a cropped photo of the {}",
+    "the photo of a {}",
+    "a depiction of a clean {}",
+    "a depiction of a dirty {}",
+    "a dark photo of the {}",
+    "a depiction of my {}",
+    "a depiction of the cool {}",
+    "a close-up photo of a {}",
+    "a bright photo of the {}",
+    "a cropped photo of a {}",
+    "a depiction of the {}",
+    "a good photo of the {}",
+    "a depiction of one {}",
+    "a close-up photo of the {}",
+    "a rendition of the {}",
+    "a depiction of the clean {}",
+    "a rendition of a {}",
+    "a depiction of a nice {}",
+    "a good photo of a {}",
+    "a depiction of the nice {}",
+    "a depiction of the small {}",
+    "a depiction of the weird {}",
+    "a depiction of the large {}",
+    "a depiction of a cool {}",
+    "a depiction of a small {}",
+)
+
+ReplayCADProfile = Literal["ldm-256", "sd-512"]
+MaskBackendName = Literal["sam", "precomputed", "full-frame"]
+MaskMode = Literal["object", "full-frame"]
+MaskAugmentation = Literal[
+    "none",
+    "paper",
+    "random_rotate",
+    "random_3directions_rotate",
+    "little_rotate_and_move",
+    "visa_candle",
+    "random_reset",
+]
+TrainAugmentation = Literal["none", "rotate_180", "rotate_3_directions", "rotate_all_directions"]
+
+
+class ReplayCADConfig(BaseModel):
+    """Faithful configuration of the ReplayCAD mechanism (Hu et al., IJCAI 2025).
+
+    Defaults follow the paper's section 5.1 uniform profile. The authors' per-class tuning is
+    reachable through ``pyclad.vision.strategies.replaycad.per_class``.
+    """
+
+    profile: ReplayCADProfile
+    model_id: str
+    resolution: int = Field(gt=0)
+    condition_dim: int = Field(gt=0)
+    latent_scaling_factor: float = Field(default=0.18215, gt=0.0)
+
+    semantic_tokens: int = Field(default=20, gt=0)
+    mask_group_width: int = Field(gt=0)
+    mask_projection_width: int = Field(gt=0)
+    use_spatial_conditioning: bool = True
+
+    compression_steps: int = Field(gt=0)
+    compression_batch_size: int = Field(gt=0)
+    base_learning_rate: float = Field(default=5e-5, gt=0.0)
+    learning_rate_scale: int = Field(gt=0)
+    semantic_lr_multiplier: float = Field(default=100.0, gt=0.0)
+    weight_decay: float = Field(default=1e-2, ge=0.0)
+    initializer_word: Optional[str] = None
+    train_augmentation: TrainAugmentation = "none"
+    prompt_templates: tuple[str, ...] = IMAGENET_TEMPLATES_SMALL
+    generation_prompt: str = "a photo of *"
+    timestep_sampling: Literal["uniform", "cubic"] = "uniform"
+
+    inference_steps: int = Field(default=50, gt=0)
+    ddim_eta: float = Field(default=0.0, ge=0.0)
+    guidance_scale: float = Field(default=10.0, ge=1.0)
+    replay_samples_per_concept: int = Field(default=800, gt=0)
+    generation_batch_size: int = Field(default=8, gt=0)
+
+    masks_per_concept: int = Field(default=10, ge=1, le=10)
+    mask_backend: MaskBackendName = "sam"
+    sam_checkpoint: Optional[Path] = None
+    sam_model_type: Literal["vit_h", "vit_l", "vit_b"] = "vit_h"
+    precomputed_mask_root: Optional[Path] = None
+    mask_modes: Dict[str, MaskMode] = Field(default_factory=dict)
+    mask_augmentation: MaskAugmentation = "none"
+    max_mask_rotation_degrees: float = Field(default=360.0, ge=0.0)
+    max_mask_shift_fraction: float = Field(default=0.05, ge=0.0, le=1.0)
+    mask_transform_angles: int = Field(default=2, ge=0)
+    mask_transform_distance: float = Field(default=0.05, ge=0.0)
+    mask_transform_transpose: bool = False
+    visa_candle_shift_pixels: int = Field(default=20, ge=0)
+    visa_candle_rotate: bool = False
+
+    artifact_dir: Path
+    strict_cache: bool = False
+
+    device: str = "cuda"
+    torch_dtype: Literal["float32", "float16", "bfloat16"] = "float32"
+    local_files_only: bool = False
+    seed: int = 42
+
+    @property
+    def latent_size(self) -> int:
+        """Number of values in the four-channel VAE latent of one mask."""
+        return (self.resolution // 8) * (self.resolution // 8) * 4
+
+    @property
+    def spatial_tokens(self) -> int:
+        return spatial_token_count(
+            self.latent_size, self.mask_group_width, self.mask_projection_width, self.condition_dim
+        )
+
+    @property
+    def spatial_learning_rate(self) -> float:
+        return self.base_learning_rate * self.learning_rate_scale
+
+    @property
+    def semantic_learning_rate(self) -> float:
+        return self.spatial_learning_rate * self.semantic_lr_multiplier
+
+    @model_validator(mode="after")
+    def _validate_shapes(self):
+        if self.latent_size % self.mask_group_width:
+            raise ValueError(
+                "The flattened four-channel mask latent must be divisible by mask_group_width: "
+                f"{self.latent_size} % {self.mask_group_width} != 0"
+            )
+        projected = (self.latent_size // self.mask_group_width) * self.mask_projection_width
+        if projected % self.condition_dim:
+            raise ValueError(
+                "Projected mask features cannot be reshaped into conditioning tokens: "
+                f"{projected} % {self.condition_dim} != 0. Adjust mask_group_width "
+                f"({self.mask_group_width}) or mask_projection_width ({self.mask_projection_width})."
+            )
+        if self.mask_backend == "sam" and self.sam_checkpoint is None:
+            raise ValueError("sam_checkpoint is required when mask_backend='sam'")
+        if self.mask_backend == "precomputed" and self.precomputed_mask_root is None:
+            raise ValueError("precomputed_mask_root is required when mask_backend='precomputed'")
+        return self
+
+    @classmethod
+    def for_benchmark(cls, benchmark: str, artifact_dir: Path, **overrides) -> "ReplayCADConfig":
+        """Build the paper's uniform profile for a benchmark.
+
+        MVTec AD uses the LDM-256 profile and VisA the SD-512 profile, as in section 5.1. Every
+        other benchmark (BTech, DAGM, MPDD, multidataset streams) uses the LDM-256 profile with a
+        neutral initializer, since the authors publish no configuration for them.
+        """
+        presets = {
+            "visa": dict(
+                profile="sd-512",
+                model_id="stable-diffusion-v1-5/stable-diffusion-v1-5",
+                resolution=512,
+                condition_dim=768,
+                mask_group_width=128,
+                mask_projection_width=192,
+                compression_steps=30_000,
+                compression_batch_size=2,
+                learning_rate_scale=4,
+                generation_batch_size=2,
+            ),
+        }
+        ldm_256 = dict(
+            profile="ldm-256",
+            model_id="CompVis/ldm-text2im-large-256",
+            resolution=256,
+            condition_dim=1280,
+            mask_group_width=128,
+            mask_projection_width=200,
+            compression_steps=20_000,
+            compression_batch_size=16,
+            learning_rate_scale=32,
+            generation_batch_size=8,
+        )
+        preset = presets.get(benchmark.lower(), ldm_256)
+        if benchmark.lower() not in presets and benchmark.lower() != "mvtec":
+            logger.info(
+                "ReplayCAD has no published profile for benchmark '%s'; using the MVTec LDM-256 "
+                "profile with a neutral initializer",
+                benchmark,
+            )
+        return cls(artifact_dir=artifact_dir, **{**preset, **overrides})

--- a/src/pyclad/vision/strategies/replaycad/config.py
+++ b/src/pyclad/vision/strategies/replaycad/config.py
@@ -1,3 +1,10 @@
+"""ReplayCAD's configuration and the paper's per-benchmark presets.
+
+Comments below cite the authors' code by file and line (``personalized.py:218``
+and the like). Those files are not in this repository; they live in the authors' release,
+pinned to a commit under "ReplayCAD" in docs/vision.md.
+"""
+
 import logging
 from pathlib import Path
 from typing import Dict, Literal, Optional

--- a/src/pyclad/vision/strategies/replaycad/masks.py
+++ b/src/pyclad/vision/strategies/replaycad/masks.py
@@ -1,0 +1,401 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+import numpy as np
+from PIL import Image
+from scipy import ndimage
+
+from pyclad.vision.strategies.replaycad.config import ReplayCADConfig, TrainAugmentation
+
+_MULTIDATASET_SEPARATOR = "__"
+
+
+def category_of(concept_id: str) -> str:
+    """Category part of a concept id, dropping a multidataset ``<alias>__`` prefix."""
+    return concept_id.rsplit(_MULTIDATASET_SEPARATOR, 1)[-1]
+
+
+class MaskProvider(Protocol):
+    def masks_for(self, concept_id: str, images: np.ndarray) -> np.ndarray:
+        """Return ``(N, H, W)`` uint8 masks aligned with ``images`` on the batch dimension."""
+
+
+class FullFrameMaskProvider:
+    """All-ones masks, for texture concepts where SAM returns no object mask."""
+
+    def masks_for(self, concept_id: str, images: np.ndarray) -> np.ndarray:
+        height, width = images.shape[1], images.shape[2]
+        return np.full((len(images), height, width), 255, dtype=np.uint8)
+
+
+class PrecomputedMaskProvider:
+    """Loads the ReplayCAD authors' SAM masks from ``<root>/<benchmark>/<category>/*.png``."""
+
+    def __init__(self, root: Path, benchmark: str):
+        self.root = Path(root)
+        self.benchmark = benchmark
+
+    def masks_for(self, concept_id: str, images: np.ndarray) -> np.ndarray:
+        directory = self.root / self.benchmark / category_of(concept_id)
+        if not directory.is_dir():
+            raise ValueError(f"No precomputed masks for concept '{concept_id}' at {directory}")
+
+        paths = sorted(directory.glob("*.png"))
+        if len(paths) != len(images):
+            raise ValueError(
+                f"Concept '{concept_id}' has {len(images)} training images but "
+                f"{len(paths)} precomputed mask(s) in {directory}. Masks are matched by sorted "
+                "filename order, so the counts must be equal."
+            )
+
+        height, width = images.shape[1], images.shape[2]
+        masks = []
+        for path in paths:
+            mask = Image.open(path).convert("L")
+            if mask.size != (width, height):
+                mask = mask.resize((width, height), resample=Image.Resampling.NEAREST)
+            masks.append(np.where(np.asarray(mask, dtype=np.uint8) >= 128, 255, 0).astype(np.uint8))
+        return np.stack(masks)
+
+
+class SamMaskProvider:
+    """Computes object masks with Segment Anything, keeping the largest returned region."""
+
+    def __init__(self, checkpoint: Path, model_type: str, device: str):
+        self.checkpoint = Path(checkpoint)
+        self.model_type = model_type
+        self.device = device
+        self._generator = None
+
+    def _load(self):
+        if self._generator is not None:
+            return self._generator
+        try:
+            from segment_anything import SamAutomaticMaskGenerator, sam_model_registry
+        except ImportError as exc:
+            raise ImportError(
+                "ReplayCAD's SAM mask backend requires segment-anything. " "Install pyclad with the 'replaycad' extra."
+            ) from exc
+
+        sam = sam_model_registry[self.model_type](checkpoint=str(self.checkpoint))
+        sam.to(self.device)
+        self._generator = SamAutomaticMaskGenerator(sam)
+        return self._generator
+
+    def masks_for(self, concept_id: str, images: np.ndarray) -> np.ndarray:
+        generator = self._load()
+        height, width = images.shape[1], images.shape[2]
+
+        masks = []
+        for image in images:
+            rgb = np.asarray(image, dtype=np.uint8)
+            if rgb.ndim == 2:
+                rgb = np.repeat(rgb[..., None], 3, axis=-1)
+            regions = generator.generate(rgb[..., :3])
+            if not regions:
+                masks.append(np.full((height, width), 255, dtype=np.uint8))
+                continue
+            largest = max(regions, key=lambda region: int(region["area"]))
+            masks.append((np.asarray(largest["segmentation"], dtype=bool) * 255).astype(np.uint8))
+        return np.stack(masks)
+
+
+class MaskModeRouter:
+    """Sends concepts listed as ``full-frame`` in ``mask_modes`` to the full-frame provider."""
+
+    def __init__(self, base: MaskProvider, full_frame_categories: frozenset[str]):
+        self.base = base
+        self.full_frame = FullFrameMaskProvider()
+        self.full_frame_categories = full_frame_categories
+
+    def masks_for(self, concept_id: str, images: np.ndarray) -> np.ndarray:
+        if category_of(concept_id) in self.full_frame_categories:
+            return self.full_frame.masks_for(concept_id, images)
+        return self.base.masks_for(concept_id, images)
+
+
+def build_mask_provider(config: ReplayCADConfig, benchmark: str) -> MaskProvider:
+    if config.mask_backend == "full-frame":
+        return FullFrameMaskProvider()
+    if config.mask_backend == "precomputed":
+        base: MaskProvider = PrecomputedMaskProvider(root=config.precomputed_mask_root, benchmark=benchmark)
+    else:
+        base = SamMaskProvider(checkpoint=config.sam_checkpoint, model_type=config.sam_model_type, device=config.device)
+
+    full_frame = frozenset(name for name, mode in config.mask_modes.items() if mode == "full-frame")
+    return MaskModeRouter(base, full_frame) if full_frame else base
+
+
+def augment_mask(mask: np.ndarray, config: ReplayCADConfig, rng: np.random.Generator) -> np.ndarray:
+    """Apply this concept's generation-time mask transform, dispatched on ``config.mask_augmentation``.
+
+    ``"paper"`` is the paper's own prose description ("randomly rotate and shift the stored
+    masks"), distinct from the five named transforms below, which reproduce the release's
+    ``mask_transfor.py``; see ``per_class.py`` for which class uses which. ``"none"`` is the
+    default and covers the rest.
+    """
+    mode = config.mask_augmentation
+    if mode == "none":
+        return mask
+    elif mode == "random_rotate":
+        return random_rotate(mask, rng)
+    elif mode == "random_3directions_rotate":
+        return random_3directions_rotate(mask, rng)
+    elif mode == "little_rotate_and_move":
+        return little_rotate_and_move(
+            mask,
+            rng,
+            angles=config.mask_transform_angles,
+            distance=config.mask_transform_distance,
+            transpose=config.mask_transform_transpose,
+        )
+    elif mode == "visa_candle":
+        return visa_candle(mask, rng, shift_pixels=config.visa_candle_shift_pixels, rotate=config.visa_candle_rotate)
+    elif mode == "random_reset":
+        return random_reset(mask, rng)
+    elif mode != "paper":
+        raise ValueError(f"Unknown mask_augmentation mode '{mode}'")
+
+    image = Image.fromarray(np.asarray(mask, dtype=np.uint8))
+    if config.max_mask_rotation_degrees > 0:
+        angle = float(rng.uniform(0.0, config.max_mask_rotation_degrees))
+        image = image.rotate(angle, expand=False, fillcolor=0)
+
+    shifted = np.asarray(image, dtype=np.uint8)
+    max_shift_y = int(round(shifted.shape[0] * config.max_mask_shift_fraction))
+    max_shift_x = int(round(shifted.shape[1] * config.max_mask_shift_fraction))
+    if max(max_shift_y, max_shift_x) > 0:
+        dy = int(rng.integers(-max_shift_y, max_shift_y + 1)) if max_shift_y else 0
+        dx = int(rng.integers(-max_shift_x, max_shift_x + 1)) if max_shift_x else 0
+        shifted = _translate(shifted, dy, dx)
+
+    return _binarize(shifted)
+
+
+def random_rotate(mask: np.ndarray, rng: np.random.Generator) -> np.ndarray:
+    """Whole-mask rotation, uniform in [0, 360] degrees, no shift. Mirrors the release's
+    ``random_rorate``, the sole generation-time transform for metal_nut, screw, hazelnut and fryum.
+    """
+    angle = int(rng.integers(0, 361))
+    return _rotate_mask(mask, angle)
+
+
+def random_3directions_rotate(mask: np.ndarray, rng: np.random.Generator) -> np.ndarray:
+    """One of six equally likely outcomes: rotate 90/180/270 degrees, flip either axis, or leave
+    unchanged. Mirrors ``random_3direcions_rotate``, the authors' sole transform for grid --
+    "unchanged" is a real one-in-six outcome, not a fallback for an unhandled case.
+    """
+    image = Image.fromarray(np.asarray(mask, dtype=np.uint8))
+    choice = int(rng.integers(0, 6))
+    if choice == 0:
+        image = image.rotate(90)
+    elif choice == 1:
+        image = image.rotate(180)
+    elif choice == 2:
+        image = image.rotate(270)
+    elif choice == 3:
+        image = image.transpose(Image.FLIP_LEFT_RIGHT)
+    elif choice == 4:
+        image = image.transpose(Image.FLIP_TOP_BOTTOM)
+    # choice == 5: identity.
+    return _binarize(np.asarray(image, dtype=np.uint8))
+
+
+def little_rotate_and_move(
+    mask: np.ndarray,
+    rng: np.random.Generator,
+    angles: int = 2,
+    distance: float = 0.05,
+    transpose: bool = False,
+) -> np.ndarray:
+    """A small-angle rotation plus a small shift; mirrors ``little_rorate_and_move``.
+
+    The authors' transform for transistor (defaults), cashew (angles=10), chewinggum and
+    pcb1-pcb3 (distance=0.1 or 0.02, transpose=True), and pcb4 (distance=0.02).
+    """
+    image = Image.fromarray(np.asarray(mask, dtype=np.uint8))
+
+    if transpose and int(rng.integers(0, 2)) == 1:
+        image = image.rotate(180)
+
+    angle = int(rng.integers(0, angles + 1))
+    angle = int(rng.choice([angle, 360 - angle]))
+    image = image.rotate(angle, expand=False, fillcolor=0)
+
+    shifted = np.asarray(image, dtype=np.uint8)
+    height, width = shifted.shape[:2]
+    upper_bound = int(width * distance)
+    magnitude = min(int(rng.integers(0, upper_bound + 1)), height // 2, width // 2)
+
+    direction = int(rng.integers(0, 4))
+    if direction == 0:
+        shifted = _translate(shifted, magnitude, 0)
+    elif direction == 1:
+        shifted = _translate(shifted, -magnitude, 0)
+    elif direction == 2:
+        shifted = _translate(shifted, 0, magnitude)
+    else:
+        shifted = _translate(shifted, 0, -magnitude)
+
+    return _binarize(shifted)
+
+
+def visa_candle(
+    mask: np.ndarray,
+    rng: np.random.Generator,
+    shift_pixels: int = 20,
+    rotate: bool = False,
+) -> np.ndarray:
+    """Detach one random connected component, translate it, optionally rotate it, then remerge.
+
+    Mirrors ``visa_candle``; the authors' transform for candle (defaults) and macaroni1
+    (rotate=True). Uses ``scipy.ndimage.label`` (4-connectivity) rather than the original's
+    ``cv2.findContours(RETR_EXTERNAL)`` (8-connectivity, filled contours) -- equivalent for the
+    hole-free, non-diagonally-touching components the affected VisA masks actually have.
+    """
+    array = np.asarray(mask, dtype=np.uint8)
+    labeled, num_features = ndimage.label(array >= 128)
+    if num_features == 0:
+        return _binarize(array)
+
+    chosen = int(rng.integers(1, num_features + 1))
+    component = labeled == chosen
+    remainder = np.where(component, 0, array).astype(np.uint8)
+    piece = np.where(component, 255, 0).astype(np.uint8)
+
+    dy = int(rng.integers(-shift_pixels, shift_pixels + 1))
+    dx = int(rng.integers(-shift_pixels, shift_pixels + 1))
+    piece = _translate(piece, dy, dx)
+
+    if rotate:
+        angle = float(rng.uniform(-10.0, 10.0))
+        piece = _rotate_mask(piece, angle)
+
+    return _binarize(np.maximum(remainder, piece))
+
+
+def random_reset(mask: np.ndarray, rng: np.random.Generator) -> np.ndarray:
+    """Crop each connected component to its bounding box and re-place it at a random,
+    non-overlapping position on an otherwise black canvas. Mirrors ``radomreset``; not reachable
+    by any released class (see ``per_class.py``). A component that exhausts 100 placement
+    attempts is dropped rather than misplaced (see docs/vision.md's divergences list).
+    """
+    array = np.asarray(mask, dtype=np.uint8)
+    height, width = array.shape[:2]
+    labeled, num_features = ndimage.label(array >= 128)
+
+    canvas = np.zeros_like(array)
+    placed_boxes: list[tuple[int, int, int, int]] = []
+
+    for component_id in range(1, num_features + 1):
+        rows, cols = np.nonzero(labeled == component_id)
+        y0, x0, y1, x1 = rows.min(), cols.min(), rows.max(), cols.max()
+        patch = array[y0 : y1 + 1, x0 : x1 + 1]
+        patch_height, patch_width = patch.shape
+
+        for _ in range(100):
+            x = int(rng.integers(0, width - patch_width + 1))
+            y = int(rng.integers(0, height - patch_height + 1))
+            box = (x, y, x + patch_width, y + patch_height)
+            if not any(_boxes_overlap(box, other) for other in placed_boxes):
+                placed_boxes.append(box)
+                canvas[y : y + patch_height, x : x + patch_width] = patch
+                break
+
+    return _binarize(canvas)
+
+
+def _boxes_overlap(a: tuple[int, int, int, int], b: tuple[int, int, int, int]) -> bool:
+    return a[0] < b[2] and a[2] > b[0] and a[1] < b[3] and a[3] > b[1]
+
+
+def _rotate_mask(mask: np.ndarray, angle: float) -> np.ndarray:
+    image = Image.fromarray(np.asarray(mask, dtype=np.uint8))
+    rotated = image.rotate(angle, expand=False, fillcolor=0)
+    return _binarize(np.asarray(rotated, dtype=np.uint8))
+
+
+def _translate(mask: np.ndarray, dy: int, dx: int) -> np.ndarray:
+    """Shift by ``(dy, dx)`` pixels: the vacated edge is filled with black rather than wrapping
+    (``np.roll``'s default), and content pushed past the far edge is discarded.
+    """
+    shifted = np.roll(mask, shift=(dy, dx), axis=(0, 1))
+    if dy > 0:
+        shifted[:dy, :] = 0
+    elif dy < 0:
+        shifted[dy:, :] = 0
+    if dx > 0:
+        shifted[:, :dx] = 0
+    elif dx < 0:
+        shifted[:, dx:] = 0
+    return shifted
+
+
+def _binarize(array: np.ndarray) -> np.ndarray:
+    """Snap back to the {0, 255} contract after an operation (typically rotation) that can leave
+    interpolated, non-binary values.
+    """
+    return np.where(np.asarray(array) >= 128, 255, 0).astype(np.uint8)
+
+
+def _border_mean_colour(image: np.ndarray, strip: int = 20) -> tuple[int, int, int]:
+    """Mean colour of four border strips, used to fill the corners a rotation leaves empty."""
+    height, width = image.shape[0], image.shape[1]
+    strips = [
+        image[max(height - strip, 0) :, :, :],
+        image[:, : min(strip, width), :],
+        image[: min(strip, height), :, :],
+        image[:, max(width - strip, 0) :, :],
+    ]
+    pixels = np.concatenate([piece.reshape(-1, image.shape[2]) for piece in strips], axis=0)
+    return tuple(int(value) for value in pixels.mean(axis=0))
+
+
+def augment_training_pair(
+    image: np.ndarray, mask: np.ndarray, mode: TrainAugmentation, rng: np.random.Generator
+) -> tuple[np.ndarray, np.ndarray]:
+    """Augment one image/mask pair identically during compression (mirrors
+    ``personalized.py:214-280``); independent transforms would leave the mask no longer
+    describing its paired image.
+    """
+    if mode == "none":
+        return image, mask
+
+    image_pil = Image.fromarray(np.asarray(image, dtype=np.uint8))
+    mask_pil = Image.fromarray(np.asarray(mask, dtype=np.uint8))
+
+    if mode == "rotate_180":
+        if int(rng.integers(0, 2)) == 0:
+            image_pil = image_pil.rotate(180)
+            mask_pil = mask_pil.rotate(180)
+    elif mode == "rotate_3_directions":
+        choice = int(rng.integers(0, 6))
+        if choice in (0, 1, 2):
+            angle = (choice + 1) * 90
+            image_pil = image_pil.rotate(angle)
+            mask_pil = mask_pil.rotate(angle)
+        elif choice == 3:
+            image_pil = image_pil.transpose(Image.FLIP_LEFT_RIGHT)
+            mask_pil = mask_pil.transpose(Image.FLIP_LEFT_RIGHT)
+        elif choice == 4:
+            image_pil = image_pil.transpose(Image.FLIP_TOP_BOTTOM)
+            mask_pil = mask_pil.transpose(Image.FLIP_TOP_BOTTOM)
+    elif mode == "rotate_all_directions":
+        angle = int(rng.integers(0, 361))
+        image_pil = image_pil.rotate(angle, expand=False, fillcolor=_border_mean_colour(np.asarray(image)))
+        mask_pil = mask_pil.rotate(angle, expand=False, fillcolor=0)
+    else:
+        raise ValueError(f"Unknown train_augmentation mode '{mode}'")
+
+    return np.asarray(image_pil, dtype=np.uint8), np.asarray(mask_pil, dtype=np.uint8)
+
+
+def select_stored_masks(masks: np.ndarray, count: int, rng: np.random.Generator) -> np.ndarray:
+    """Pick up to ``count`` masks to store in the artifact (the paper's M in [1, 10])."""
+    if len(masks) == 0:
+        return masks
+    take = min(count, len(masks))
+    indices = np.sort(rng.choice(len(masks), size=take, replace=False))
+    return masks[indices]

--- a/src/pyclad/vision/strategies/replaycad/masks.py
+++ b/src/pyclad/vision/strategies/replaycad/masks.py
@@ -1,3 +1,10 @@
+"""Mask providers, and the replay-time transforms reproduced from the release.
+
+Docstrings below cite the authors' code by file and line (``personalized.py:214-280``
+and the like). Those files are not in this repository; they live in the authors' release,
+pinned to a commit under "ReplayCAD" in docs/vision.md.
+"""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -280,7 +287,8 @@ def random_reset(mask: np.ndarray, rng: np.random.Generator) -> np.ndarray:
     """Crop each connected component to its bounding box and re-place it at a random,
     non-overlapping position on an otherwise black canvas. Mirrors ``radomreset``; not reachable
     by any released class (see ``per_class.py``). A component that exhausts 100 placement
-    attempts is dropped rather than misplaced (see docs/vision.md's divergences list).
+    attempts is dropped rather than misplaced -- divergence 7 under "Differences from the
+    original" in docs/vision.md.
     """
     array = np.asarray(mask, dtype=np.uint8)
     height, width = array.shape[:2]

--- a/src/pyclad/vision/strategies/replaycad/memory.py
+++ b/src/pyclad/vision/strategies/replaycad/memory.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+from pyclad.vision.strategies.replaycad.artifacts import (
+    ConceptArtifact,
+    compression_config_hash,
+    load_artifact,
+    save_artifact,
+)
+from pyclad.vision.strategies.replaycad.backend import DiffusionBackend
+from pyclad.vision.strategies.replaycad.config import ReplayCADConfig
+from pyclad.vision.strategies.replaycad.masks import (
+    MaskProvider,
+    build_mask_provider,
+    select_stored_masks,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ReplayCADMemory:
+    """Holds ReplayCAD's compressed conditional features and replays historical concepts.
+
+    Artifacts are cached under ``config.artifact_dir``. The cache key covers only inputs that
+    change the compressed representation, so one compression pass is reused across concept
+    orderings, detectors and evaluation seeds.
+    """
+
+    def __init__(
+        self,
+        config: ReplayCADConfig,
+        backend: DiffusionBackend,
+        benchmark: str = "",
+        mask_provider: Optional[MaskProvider] = None,
+    ):
+        self.config = config
+        self.backend = backend
+        self.benchmark = benchmark
+        self.mask_provider = mask_provider or build_mask_provider(config, benchmark)
+        self._concepts: List[str] = []
+
+    @property
+    def _root(self) -> Path:
+        """Artifact root for this benchmark.
+
+        Concept ids carry no dataset prefix in a single-benchmark run, so without this, two
+        benchmarks sharing one artifact_dir could collide on a common category name -- undetected,
+        since config_hash doesn't cover benchmark identity.
+        """
+        return Path(self.config.artifact_dir) / self.benchmark if self.benchmark else Path(self.config.artifact_dir)
+
+    def known_concepts(self) -> List[str]:
+        return list(self._concepts)
+
+    def release_device_memory(self) -> None:
+        self.backend.release_device_memory()
+
+    def compress(self, concept_id: str, images: np.ndarray) -> None:
+        expected_hash = compression_config_hash(self.config)
+        cached = load_artifact(concept_id, self._root)
+
+        if cached is not None and cached.config_hash == expected_hash:
+            logger.info("ReplayCAD reusing cached artifact for '%s'", concept_id)
+            self._remember(concept_id)
+            return
+
+        if cached is not None:
+            message = (
+                f"Cached ReplayCAD artifact for '{concept_id}' was compressed with a different "
+                f"config_hash ({cached.config_hash} != {expected_hash})."
+            )
+            if self.config.strict_cache:
+                raise ValueError(f"{message} strict_cache=True refuses to recompress.")
+            logger.warning("%s Recompressing.", message)
+
+        if self.config.use_spatial_conditioning:
+            masks = self.mask_provider.masks_for(concept_id, images)
+        else:
+            # Skipped when off: the backend ignores masks entirely, and for mask_backend="sam"
+            # computing them anyway would mean a full vit_h pass over every image, discarded.
+            masks = np.zeros((0, images.shape[1], images.shape[2]), dtype=np.uint8)
+
+        embedding, projection_state = self.backend.compress(concept_id, images, masks)
+
+        rng = np.random.default_rng(self.config.seed)
+        stored_masks = (
+            select_stored_masks(masks, self.config.masks_per_concept, rng)
+            if self.config.use_spatial_conditioning
+            else masks
+        )
+
+        save_artifact(
+            ConceptArtifact(
+                concept_id=concept_id,
+                embedding=embedding,
+                projection_state=projection_state,
+                masks=stored_masks,
+                config_hash=expected_hash,
+                spatial_tokens=self.config.spatial_tokens if self.config.use_spatial_conditioning else 0,
+            ),
+            self._root,
+        )
+        self._remember(concept_id)
+
+    def generate_previous(self) -> np.ndarray:
+        if not self._concepts:
+            return np.zeros((0, 0, 0, 3), dtype=np.uint8)
+
+        batches = []
+        for index, concept_id in enumerate(self._concepts):
+            artifact = load_artifact(concept_id, self._root)
+            if artifact is None:
+                raise RuntimeError(f"ReplayCAD artifact for '{concept_id}' disappeared from the cache")
+            # Distinct per-concept seed: a shared seed would replay identical latent noise for
+            # every concept. Deterministic across runs because it is derived, not drawn.
+            batches.append(
+                self.backend.generate(
+                    artifact, count=self.config.replay_samples_per_concept, seed=self.config.seed + index
+                )
+            )
+        return np.concatenate(batches, axis=0)
+
+    def _remember(self, concept_id: str) -> None:
+        if concept_id not in self._concepts:
+            self._concepts.append(concept_id)
+
+    def info(self) -> Dict[str, Any]:
+        return {
+            "model_id": self.config.model_id,
+            "profile": self.config.profile,
+            "semantic_tokens": self.config.semantic_tokens,
+            "spatial_tokens": self.config.spatial_tokens if self.config.use_spatial_conditioning else 0,
+            "compression_steps": self.config.compression_steps,
+            "spatial_learning_rate": self.config.spatial_learning_rate,
+            "semantic_learning_rate": self.config.semantic_learning_rate,
+            "guidance_scale": self.config.guidance_scale,
+            "inference_steps": self.config.inference_steps,
+            "replay_samples_per_concept": self.config.replay_samples_per_concept,
+            "mask_backend": self.config.mask_backend,
+            "mask_augmentation": self.config.mask_augmentation,
+            "masks_per_concept": self.config.masks_per_concept,
+            "artifact_dir": str(self.config.artifact_dir),
+            "compressed_concepts": self.known_concepts(),
+        }

--- a/src/pyclad/vision/strategies/replaycad/memory.py
+++ b/src/pyclad/vision/strategies/replaycad/memory.py
@@ -35,9 +35,16 @@ class ReplayCADMemory:
         self,
         config: ReplayCADConfig,
         backend: DiffusionBackend,
-        benchmark: str = "",
+        benchmark: str,
         mask_provider: Optional[MaskProvider] = None,
     ):
+        if not benchmark.strip():
+            raise ValueError(
+                "ReplayCADMemory needs a non-empty benchmark name: it separates artifact roots, and "
+                "config_hash does not cover benchmark identity, so two datasets sharing one "
+                "artifact_dir would otherwise collide on a common category name undetected."
+            )
+
         self.config = config
         self.backend = backend
         self.benchmark = benchmark
@@ -48,11 +55,12 @@ class ReplayCADMemory:
     def _root(self) -> Path:
         """Artifact root for this benchmark.
 
-        Concept ids carry no dataset prefix in a single-benchmark run, so without this, two
-        benchmarks sharing one artifact_dir could collide on a common category name -- undetected,
-        since config_hash doesn't cover benchmark identity.
+        Concept ids carry no dataset prefix in a single-benchmark run, so without this level two
+        benchmarks sharing one artifact_dir would collide on a common category name -- undetected,
+        since config_hash doesn't cover benchmark identity. ``__init__`` rejects an empty
+        benchmark, so this separation always holds.
         """
-        return Path(self.config.artifact_dir) / self.benchmark if self.benchmark else Path(self.config.artifact_dir)
+        return Path(self.config.artifact_dir) / self.benchmark
 
     def known_concepts(self) -> List[str]:
         return list(self._concepts)

--- a/src/pyclad/vision/strategies/replaycad/per_class.py
+++ b/src/pyclad/vision/strategies/replaycad/per_class.py
@@ -1,0 +1,270 @@
+"""The ReplayCAD authors' hand-tuned per-class settings, as an opt-in override table.
+
+The paper (section 5.1) describes one uniform configuration per dataset; ``ReplayCADConfig.for_benchmark``
+follows that. The scripts the authors released instead hand-tune each class (backbone, projection
+width, steps, guidance, sample count) and disable spatial conditioning entirely for two of them.
+``apply_per_class`` returns that alternative, re-validated profile for one concept -- a reference
+table, not a runnable mode: ``ReplayCADMemory``/``DiffusersBackend`` each hold a single config for
+the whole stream, while this table varies ``model_id``, ``condition_dim`` and ``resolution`` per
+class, so driving a live run through it would fail on a shape mismatch (VisA alone mixes the
+LDM-256 and SD1.5-512 families).
+
+Values were extracted mechanically from ``tran_mvtec.sh``, ``train_visa.sh``, ``generate_mvtec.sh``,
+``generate_visa.sh`` and the YAML configs they reference. Three source inconsistencies, recorded
+rather than silently resolved:
+
+1. Several generation checkpoints exceed their training config's ``max_steps`` (e.g. cable
+   ``gs-5999`` vs. ``max_steps: 5000``). ``compression_steps`` below uses the checkpoint step, since
+   that is what produced the published samples.
+2. ``train_visa.sh`` passes ``--init_word Process Control Block`` to a single-value argparse option;
+   only the first word is kept, so the effective initializer is ``"Process"``, not the full phrase.
+3. ``capsules`` and ``macaroni2`` are generated through maskless scripts, so ``mask_augmentation``
+   stays ``"none"`` for both -- not either of the two release dispatchers' dead,
+   mutually-contradictory ``macaroni2`` branches (``random_reset`` vs. ``random_rotate``).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, Literal
+
+from pyclad.vision.strategies.replaycad.config import (
+    MaskAugmentation,
+    ReplayCADConfig,
+    TrainAugmentation,
+)
+from pyclad.vision.strategies.replaycad.masks import category_of
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PerClassOverride:
+    """One class's settings as published in the ReplayCAD release scripts."""
+
+    profile: Literal["ldm-256", "sd-512"]
+    compression_steps: int
+    guidance_scale: float
+    replay_samples: int
+    initializer_word: str
+    train_augmentation: TrainAugmentation
+    timestep_sampling: Literal["uniform", "cubic"] = "uniform"
+    use_spatial_conditioning: bool = True
+    wide_projection: bool = False
+    semantic_tokens: int = 20
+    base_learning_rate: float = 5e-5
+    semantic_lr_multiplier: float = 100.0
+    mask_augmentation: MaskAugmentation = "none"
+    mask_transform_angles: int = 2
+    mask_transform_distance: float = 0.05
+    mask_transform_transpose: bool = False
+    visa_candle_shift_pixels: int = 20
+    visa_candle_rotate: bool = False
+
+
+_M = PerClassOverride
+
+MVTEC_OVERRIDES: Dict[str, PerClassOverride] = {
+    "bottle": _M("ldm-256", 2499, 10.0, 200, "screw", "none"),
+    "cable": _M("ldm-256", 5999, 10.0, 400, "screw", "none"),
+    "capsule": _M("ldm-256", 14999, 10.0, 200, "screw", "none"),
+    "carpet": _M("ldm-256", 9999, 1.0, 200, "screw", "none"),
+    "grid": _M(
+        "ldm-256", 24999, 5.0, 800, "screw", "rotate_3_directions", mask_augmentation="random_3directions_rotate"
+    ),
+    "hazelnut": _M("ldm-256", 19999, 10.0, 200, "screw", "rotate_all_directions", mask_augmentation="random_rotate"),
+    "leather": _M("ldm-256", 3499, 1.0, 200, "screw", "none"),
+    "metal_nut": _M("ldm-256", 19999, 10.0, 800, "screw", "rotate_all_directions", mask_augmentation="random_rotate"),
+    "pill": _M("ldm-256", 1499, 10.0, 200, "screw", "none"),
+    "screw": _M("ldm-256", 19999, 10.0, 800, "screw", "rotate_all_directions", mask_augmentation="random_rotate"),
+    "tile": _M("ldm-256", 4999, 10.0, 200, "screw", "none"),
+    "toothbrush": _M("ldm-256", 1499, 10.0, 200, "screw", "none"),
+    "transistor": _M("ldm-256", 4999, 10.0, 800, "screw", "none", mask_augmentation="little_rotate_and_move"),
+    "wood": _M("ldm-256", 5999, 1.0, 200, "screw", "none"),
+}
+
+VISA_OVERRIDES: Dict[str, PerClassOverride] = {
+    "candle": _M("ldm-256", 9999, 10.0, 800, "screw", "none", mask_augmentation="visa_candle"),
+    "capsules": _M(
+        "sd-512",
+        52499,
+        10.0,
+        400,
+        "Process",
+        "rotate_180",
+        use_spatial_conditioning=False,
+        semantic_tokens=40,
+        base_learning_rate=5e-3,
+        semantic_lr_multiplier=1.0,
+    ),
+    "cashew": _M(
+        "sd-512",
+        29999,
+        10.0,
+        400,
+        "Process",
+        "none",
+        mask_augmentation="little_rotate_and_move",
+        mask_transform_angles=10,
+    ),
+    "chewinggum": _M(
+        "sd-512",
+        29999,
+        10.0,
+        400,
+        "Process",
+        "rotate_180",
+        mask_augmentation="little_rotate_and_move",
+        mask_transform_distance=0.1,
+        mask_transform_transpose=True,
+    ),
+    "fryum": _M(
+        "sd-512",
+        31656,
+        10.0,
+        400,
+        "Process",
+        "rotate_180",
+        "cubic",
+        wide_projection=True,
+        mask_augmentation="random_rotate",
+    ),
+    "macaroni1": _M(
+        "ldm-256", 9999, 10.0, 800, "screw", "none", mask_augmentation="visa_candle", visa_candle_rotate=True
+    ),
+    "macaroni2": _M(
+        "ldm-256",
+        14535,
+        10.0,
+        400,
+        "candle",
+        "none",
+        use_spatial_conditioning=False,
+        semantic_tokens=40,
+        base_learning_rate=5e-3,
+        semantic_lr_multiplier=1.0,
+    ),
+    "pcb1": _M(
+        "sd-512",
+        26499,
+        10.0,
+        400,
+        "Process",
+        "rotate_180",
+        "cubic",
+        mask_augmentation="little_rotate_and_move",
+        mask_transform_distance=0.02,
+        mask_transform_transpose=True,
+    ),
+    "pcb2": _M(
+        "sd-512",
+        29999,
+        10.0,
+        400,
+        "Process",
+        "rotate_180",
+        "cubic",
+        mask_augmentation="little_rotate_and_move",
+        mask_transform_distance=0.02,
+        mask_transform_transpose=True,
+    ),
+    "pcb3": _M(
+        "sd-512",
+        29499,
+        10.0,
+        400,
+        "Process",
+        "rotate_180",
+        "cubic",
+        mask_augmentation="little_rotate_and_move",
+        mask_transform_distance=0.02,
+        mask_transform_transpose=True,
+    ),
+    "pcb4": _M(
+        "sd-512",
+        29999,
+        10.0,
+        400,
+        "Process",
+        "none",
+        "cubic",
+        wide_projection=True,
+        mask_augmentation="little_rotate_and_move",
+        mask_transform_distance=0.02,
+    ),
+    # pipe_fryum is absent from both release scripts.
+}
+
+AUTHORS_OVERRIDES: Dict[str, Dict[str, PerClassOverride]] = {
+    "mvtec": MVTEC_OVERRIDES,
+    "visa": VISA_OVERRIDES,
+}
+
+
+def _profile_fields(profile: str, wide_projection: bool) -> dict:
+    if profile == "sd-512":
+        return {
+            "profile": "sd-512",
+            "model_id": "stable-diffusion-v1-5/stable-diffusion-v1-5",
+            "resolution": 512,
+            "condition_dim": 768,
+            "mask_group_width": 512 if wide_projection else 128,
+            "mask_projection_width": 192,
+            "compression_batch_size": 2,
+            "learning_rate_scale": 4,
+            "generation_batch_size": 2,
+        }
+    return {
+        "profile": "ldm-256",
+        "model_id": "CompVis/ldm-text2im-large-256",
+        "resolution": 256,
+        "condition_dim": 1280,
+        "mask_group_width": 256 if wide_projection else 128,
+        "mask_projection_width": 400 if wide_projection else 200,
+        "compression_batch_size": 16,
+        "learning_rate_scale": 32,
+        "generation_batch_size": 8,
+    }
+
+
+def apply_per_class(config: ReplayCADConfig, concept_id: str, benchmark: str) -> ReplayCADConfig:
+    """Return ``config`` with this concept's published settings applied.
+
+    Benchmarks the authors did not publish, and classes missing from their scripts, keep the
+    dataset default and are logged.
+    """
+    table = AUTHORS_OVERRIDES.get(benchmark.lower())
+    if table is None:
+        return config
+
+    override = table.get(category_of(concept_id))
+    if override is None:
+        logger.warning(
+            "ReplayCAD has no published per-class settings for '%s' in %s; using the dataset default profile",
+            concept_id,
+            benchmark,
+        )
+        return config
+
+    updates = _profile_fields(override.profile, override.wide_projection)
+    updates.update(
+        compression_steps=override.compression_steps,
+        guidance_scale=override.guidance_scale,
+        replay_samples_per_concept=override.replay_samples,
+        initializer_word=override.initializer_word,
+        timestep_sampling=override.timestep_sampling,
+        train_augmentation=override.train_augmentation,
+        use_spatial_conditioning=override.use_spatial_conditioning,
+        semantic_tokens=override.semantic_tokens,
+        base_learning_rate=override.base_learning_rate,
+        semantic_lr_multiplier=override.semantic_lr_multiplier,
+        mask_augmentation=override.mask_augmentation,
+        mask_transform_angles=override.mask_transform_angles,
+        mask_transform_distance=override.mask_transform_distance,
+        mask_transform_transpose=override.mask_transform_transpose,
+        visa_candle_shift_pixels=override.visa_candle_shift_pixels,
+        visa_candle_rotate=override.visa_candle_rotate,
+    )
+
+    return type(config).model_validate({**config.model_dump(), **updates})

--- a/src/pyclad/vision/strategies/replaycad/spatial.py
+++ b/src/pyclad/vision/strategies/replaycad/spatial.py
@@ -1,0 +1,37 @@
+import torch
+from torch import nn
+
+
+def spatial_token_count(latent_size: int, group_width: int, projection_width: int, condition_dim: int) -> int:
+    """Number of conditioning tokens the mask projection produces.
+
+    The mask latent is flattened in NCHW order into rows of ``group_width``, each row is projected
+    to ``projection_width``, and the result is reshaped into ``condition_dim``-wide tokens.
+    """
+    if latent_size % group_width:
+        raise ValueError(f"latent size {latent_size} is not divisible by mask_group_width {group_width}")
+    projected = (latent_size // group_width) * projection_width
+    if projected % condition_dim:
+        raise ValueError(f"projected size {projected} is not divisible by condition_dim {condition_dim}")
+    return projected // condition_dim
+
+
+class MaskProjection(nn.Module):
+    """Maps a four-channel mask latent to spatial conditioning tokens.
+
+    Mirrors ReplayCAD's ``mask_linear``: reshape to ``(B, -1, group_width)``, apply
+    ``Linear + ReLU``, reshape to ``(B, -1, condition_dim)``, then concatenate with the text
+    conditioning before cross-attention.
+    """
+
+    def __init__(self, group_width: int, projection_width: int, condition_dim: int):
+        super().__init__()
+        self.group_width = group_width
+        self.condition_dim = condition_dim
+        self.layers = nn.Sequential(nn.Linear(group_width, projection_width), nn.ReLU())
+
+    def forward(self, latents: torch.Tensor) -> torch.Tensor:
+        batch_size = latents.shape[0]
+        grouped = latents.reshape(batch_size, -1, self.group_width)
+        projected = self.layers(grouped)
+        return projected.reshape(batch_size, -1, self.condition_dim)

--- a/src/pyclad/vision/strategies/replaycad/strategy.py
+++ b/src/pyclad/vision/strategies/replaycad/strategy.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import numpy as np
+from PIL import Image
+
+from pyclad.models.model import Model
+from pyclad.strategies.strategy import ConceptAwareStrategy
+from pyclad.vision.prediction_results import VisionPredictionResults
+from pyclad.vision.strategies.replaycad.memory import ReplayCADMemory
+
+
+class ReplayCADStrategy(ConceptAwareStrategy):
+    """Diffusion generative replay for continual anomaly detection (Hu et al., IJCAI 2025).
+
+    Per concept: replay every historical concept from its stored conditional features, refit the
+    detector on replay + new data, then compress the new concept for future replay. The detector is
+    an ordinary pyCLAD vision model -- the paper imposes no restriction on it.
+    """
+
+    def __init__(self, model: Model, memory: ReplayCADMemory):
+        self._model = model
+        self._memory = memory
+
+    def learn(self, data: np.ndarray, concept_id: str) -> None:
+        current = np.asarray(data)
+        if len(current) == 0:
+            raise ValueError(f"ReplayCAD cannot learn empty concept '{concept_id}'")
+
+        try:
+            replay = self._memory.generate_previous()
+            self._memory.release_device_memory()
+
+            train_data = current if len(replay) == 0 else np.concatenate([self._match_shape(replay, current), current])
+            self._model.fit(train_data)
+
+            self._memory.compress(concept_id=concept_id, images=current)
+        finally:
+            self._memory.release_device_memory()
+
+    def predict(self, data: np.ndarray, concept_id: str) -> VisionPredictionResults:
+        del concept_id  # ReplayCAD keeps no per-concept inference state
+        return self._model.predict(data)
+
+    def name(self) -> str:
+        return "ReplayCAD"
+
+    def additional_info(self) -> Dict[str, Any]:
+        return {"model": self._model.name(), "replaycad": self._memory.info()}
+
+    @staticmethod
+    def _match_shape(replay: np.ndarray, current: np.ndarray) -> np.ndarray:
+        """Resize replay images to the current concept's spatial shape and channel count."""
+        if replay.ndim != 4 or current.ndim != 4:
+            raise ValueError(
+                f"ReplayCAD expects (N, H, W, C) arrays; got replay={replay.shape}, current={current.shape}"
+            )
+
+        height, width, channels = current.shape[1:]
+        if channels not in (1, 3):
+            raise ValueError(f"ReplayCAD supports one or three image channels, got {channels}")
+
+        resized = []
+        for image in replay:
+            array = np.asarray(image)
+            if array.ndim == 2:
+                array = np.repeat(array[..., None], 3, axis=-1)
+            pil = Image.fromarray(array[..., :3].astype(np.uint8))
+            pil = pil.convert("L" if channels == 1 else "RGB")
+            pil = pil.resize((width, height), resample=Image.Resampling.BILINEAR)
+            restored = np.asarray(pil)
+            resized.append(restored[..., None] if channels == 1 else restored)
+
+        return np.stack(resized).astype(current.dtype, copy=False)

--- a/tests/vision/models/test_backbones.py
+++ b/tests/vision/models/test_backbones.py
@@ -1,0 +1,50 @@
+import pytest
+import torch
+
+from pyclad.vision.models.utilities.backbones import (
+    TorchvisionFeatureExtractor,
+    create_torchvision_model,
+)
+
+
+def test_named_weights_are_requested_verbatim():
+    import torchvision.models as tv_models
+
+    captured = {}
+
+    def fake_wide_resnet50_2(weights=None):
+        captured["weights"] = weights
+        return torch.nn.Identity()
+
+    original = tv_models.wide_resnet50_2
+    tv_models.wide_resnet50_2 = fake_wide_resnet50_2
+    try:
+        create_torchvision_model("wide_resnet50_2", pretrained=True, weights_name="IMAGENET1K_V1")
+    finally:
+        tv_models.wide_resnet50_2 = original
+
+    assert captured["weights"] is tv_models.Wide_ResNet50_2_Weights.IMAGENET1K_V1
+
+
+def test_unknown_weights_name_lists_available_members():
+    with pytest.raises(ValueError, match="IMAGENET1K_V1"):
+        create_torchvision_model("wide_resnet50_2", pretrained=True, weights_name="NOPE")
+
+
+def test_weights_name_is_ignored_when_not_pretrained():
+    model = create_torchvision_model("resnet18", pretrained=False, weights_name="NOPE")
+    assert isinstance(model, torch.nn.Module)
+
+
+def test_feature_extractor_reports_channels_and_shapes():
+    extractor = TorchvisionFeatureExtractor(
+        backbone_name="resnet18",
+        return_nodes=["layer2", "layer3"],
+        pretrained=False,
+        freeze=True,
+    )
+
+    assert extractor.infer_out_channels((32, 32)) == (128, 256)
+
+    features = extractor(torch.zeros(1, 3, 32, 32))
+    assert [f.shape[1] for f in features] == [128, 256]

--- a/tests/vision/models/test_patchcore.py
+++ b/tests/vision/models/test_patchcore.py
@@ -1,0 +1,150 @@
+import numpy as np
+import pytest
+
+from pyclad.vision.models.patchcore.config import PatchCoreConfig
+from pyclad.vision.models.patchcore.patchcore import PatchCore
+from pyclad.vision.prediction_results import VisionPredictionResults
+
+
+def _config(**overrides) -> PatchCoreConfig:
+    defaults = dict(
+        input_size=(32, 32),
+        backbone_name="resnet18",
+        pretrained_backbone=False,
+        input_range="float01",
+        batch_size=2,
+        coreset_sampling_ratio=0.5,
+        coreset_projection_dimension=8,
+        coreset_starting_points=2,
+        pretrain_embed_dimension=32,
+        target_embed_dimension=32,
+    )
+    defaults.update(overrides)
+    return PatchCoreConfig(**defaults)
+
+
+def test_patchcore_fit_then_predict_shapes():
+    rng = np.random.default_rng(0)
+    train = rng.random((4, 32, 32, 3), dtype=np.float32)
+    test = rng.random((3, 32, 32, 3), dtype=np.float32)
+
+    model = PatchCore(_config())
+    model.fit(train)
+    result = model.predict(test)
+
+    assert isinstance(result, VisionPredictionResults)
+    assert result.y_pred.shape == (3,)
+    assert result.anomaly_scores.shape == (3,)
+    assert result.score_maps.shape == (3, 32, 32)
+
+
+def test_patchcore_predict_handles_empty_input():
+    model = PatchCore(_config(threshold=0.0))
+
+    result = model.predict(np.empty((0, 32, 32, 3), dtype=np.float32))
+
+    assert result.y_pred.shape == (0,)
+    assert result.score_maps.shape == (0,)
+
+
+def test_patchcore_predict_before_fit_raises():
+    model = PatchCore(_config())
+
+    with pytest.raises(RuntimeError, match="fitted"):
+        model.predict(np.zeros((1, 32, 32, 3), dtype=np.float32))
+
+
+def test_image_score_is_max_of_raw_patch_scores_not_of_smoothed_map():
+    rng = np.random.default_rng(3)
+    train = rng.random((4, 32, 32, 3), dtype=np.float32)
+    test = rng.random((2, 32, 32, 3), dtype=np.float32)
+
+    model = PatchCore(_config(smoothing_sigma=8.0))
+    model.fit(train)
+    result = model.predict(test)
+
+    # Heavy smoothing pulls the map maximum well below the raw patch maximum, so an
+    # implementation that aggregated the returned map would report smaller scores.
+    assert np.all(result.anomaly_scores > result.score_maps.reshape(2, -1).max(axis=1))
+
+
+def test_patch_score_is_squared_l2_distance_like_the_reference_faiss_index():
+    # ADer's reference NearestNeighbourScorer is backed by faiss.IndexFlatL2, which returns
+    # SQUARED L2 distances. sklearn's NearestNeighbors.kneighbors returns plain (non-squared)
+    # Euclidean distances, so PatchCore must square them itself to match. Pin this with a fully
+    # deterministic embedding (bypassing the real backbone) rather than only checking shapes: a
+    # memory bank containing the origin and a test patch at distance 3 along one axis must produce
+    # an image score of 3**2 == 9, not 3 -- the value plain sklearn distances would give.
+    model = PatchCore(_config(n_neighbors=1, coreset_sampling_ratio=1.0))
+
+    def fake_train_embed(batch):
+        return np.zeros((1, 4), dtype=np.float32), [[1, 1]]
+
+    model._embed = fake_train_embed
+    model.fit(np.zeros((1, 32, 32, 3), dtype=np.float32))
+
+    def fake_test_embed(batch):
+        return np.array([[3.0, 0.0, 0.0, 0.0]], dtype=np.float32), [[1, 1]]
+
+    model._embed = fake_test_embed
+    result = model.predict(np.zeros((1, 32, 32, 3), dtype=np.float32))
+
+    assert result.anomaly_scores[0] == pytest.approx(9.0)
+    assert result.anomaly_scores[0] != pytest.approx(3.0)  # plain (unsquared) Euclidean distance
+
+
+def test_patchcore_seed_makes_coreset_reproducible():
+    rng = np.random.default_rng(11)
+    train = rng.random((8, 32, 32, 3), dtype=np.float32)
+    test = rng.random((2, 32, 32, 3), dtype=np.float32)
+
+    def scores(seed: int) -> np.ndarray:
+        model = PatchCore(_config(seed=seed, coreset_sampling_ratio=0.3))
+        model.fit(train)
+        return model.predict(test).anomaly_scores
+
+    assert np.array_equal(scores(5), scores(5))
+
+
+def test_patchcore_requests_v1_weights_by_default():
+    captured = {}
+
+    import pyclad.vision.models.patchcore.patchcore as module
+
+    original = module.TorchvisionFeatureExtractor
+
+    class Recording(original):
+        def __init__(self, *args, **kwargs):
+            captured["weights_name"] = kwargs.get("weights_name")
+            super().__init__(*args, **kwargs)
+
+    module.TorchvisionFeatureExtractor = Recording
+    try:
+        PatchCore(_config())
+    finally:
+        module.TorchvisionFeatureExtractor = original
+
+    assert captured["weights_name"] == "IMAGENET1K_V1"
+
+
+def test_unknown_backbone_has_no_default_return_nodes():
+    with pytest.raises(ValueError, match="return nodes"):
+        PatchCore._require_nodes("definitely_not_a_backbone")
+
+
+def test_explicit_return_nodes_win_over_the_defaults():
+    model = PatchCore(_config(backbone_return_nodes=("layer1", "layer2")))
+
+    assert model.module.return_nodes == ("layer1", "layer2")
+
+
+def test_score_maps_match_input_spatial_size():
+    rng = np.random.default_rng(1)
+    train = rng.random((4, 48, 64, 3), dtype=np.float32)
+
+    model = PatchCore(_config(input_size=(32, 32)))
+    model.fit(train)
+    result = model.predict(train[:2])
+
+    # VisionScoringBase resizes maps back to each image's own spatial size.
+    assert result.score_maps.shape == (2, 48, 64)

--- a/tests/vision/strategies/replaycad/conftest.py
+++ b/tests/vision/strategies/replaycad/conftest.py
@@ -1,0 +1,80 @@
+from typing import Optional
+
+import numpy as np
+import pytest
+import torch
+
+from pyclad.vision.strategies.replaycad.artifacts import ConceptArtifact
+from pyclad.vision.strategies.replaycad.config import ReplayCADConfig
+
+
+class StubDiffusionBackend:
+    """In-memory stand-in for the diffusion backend.
+
+    Records every call so tests can assert on the strategy's call order, and returns
+    deterministic tensors and images shaped exactly like the real backend's.
+    """
+
+    def __init__(self, config: ReplayCADConfig):
+        self.config = config
+        self.compress_calls: list[str] = []
+        self.generate_calls: list[tuple[str, int, int]] = []
+        self.release_calls = 0
+
+    def compress(self, concept_id: str, images: np.ndarray, masks: np.ndarray):
+        if len(images) == 0:
+            raise ValueError(f"Cannot compress empty concept '{concept_id}'")
+        # A zero-length mask array means spatial conditioning is off and no masks were computed,
+        # matching the real backend's tolerance (see DiffusersBackend.compress).
+        if len(masks) != 0 and len(images) != len(masks):
+            raise ValueError(f"{len(images)} images but {len(masks)} masks for '{concept_id}'")
+        self.compress_calls.append(concept_id)
+
+        generator = torch.Generator().manual_seed(abs(hash(concept_id)) % (2**31))
+        embedding = torch.randn(self.config.semantic_tokens, self.config.condition_dim, generator=generator)
+        if not self.config.use_spatial_conditioning:
+            return embedding, None
+        projection_state = {
+            "layers.0.weight": torch.zeros(self.config.mask_projection_width, self.config.mask_group_width),
+            "layers.0.bias": torch.zeros(self.config.mask_projection_width),
+        }
+        return embedding, projection_state
+
+    def generate(self, artifact: ConceptArtifact, count: int, seed: int) -> np.ndarray:
+        self.generate_calls.append((artifact.concept_id, count, seed))
+        rng = np.random.default_rng(seed)
+        size = self.config.resolution
+        return rng.integers(0, 256, size=(count, size, size, 3), dtype=np.uint8)
+
+    def release_device_memory(self) -> None:
+        self.release_calls += 1
+
+
+@pytest.fixture
+def replaycad_config(tmp_path):
+    def build(**overrides) -> ReplayCADConfig:
+        defaults = dict(
+            mask_backend="full-frame",
+            resolution=8,
+            condition_dim=4,
+            mask_group_width=2,
+            mask_projection_width=2,
+            semantic_tokens=3,
+            compression_steps=2,
+            compression_batch_size=1,
+            replay_samples_per_concept=2,
+            generation_batch_size=1,
+            masks_per_concept=2,
+        )
+        defaults.update(overrides)
+        return ReplayCADConfig.for_benchmark("mvtec", artifact_dir=tmp_path, **defaults)
+
+    return build
+
+
+@pytest.fixture
+def stub_backend(replaycad_config):
+    def build(config: Optional[ReplayCADConfig] = None) -> StubDiffusionBackend:
+        return StubDiffusionBackend(config or replaycad_config())
+
+    return build

--- a/tests/vision/strategies/replaycad/test_artifacts.py
+++ b/tests/vision/strategies/replaycad/test_artifacts.py
@@ -1,0 +1,190 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from pyclad.vision.strategies.replaycad.artifacts import (
+    ConceptArtifact,
+    compression_config_hash,
+    concept_slug,
+    load_artifact,
+    save_artifact,
+)
+from pyclad.vision.strategies.replaycad.config import ReplayCADConfig
+
+
+def _config(tmp_path: Path, **overrides) -> ReplayCADConfig:
+    return ReplayCADConfig.for_benchmark("mvtec", artifact_dir=tmp_path, mask_backend="full-frame", **overrides)
+
+
+def _artifact(config: ReplayCADConfig, concept_id: str = "mvtec__screw") -> ConceptArtifact:
+    return ConceptArtifact(
+        concept_id=concept_id,
+        embedding=torch.arange(20 * 1280, dtype=torch.float32).reshape(20, 1280),
+        projection_state={"layers.0.weight": torch.ones(200, 128), "layers.0.bias": torch.zeros(200)},
+        masks=np.full((3, 8, 8), 255, dtype=np.uint8),
+        config_hash=compression_config_hash(config),
+        spatial_tokens=5,
+    )
+
+
+def test_artifact_round_trip(tmp_path: Path):
+    config = _config(tmp_path)
+    saved = save_artifact(_artifact(config), tmp_path)
+
+    loaded = load_artifact("mvtec__screw", tmp_path)
+
+    assert saved.is_dir()
+    assert loaded is not None
+    assert loaded.concept_id == "mvtec__screw"
+    assert loaded.embedding.shape == (20, 1280)
+    assert torch.equal(loaded.embedding, _artifact(config).embedding)
+    assert loaded.masks.shape == (3, 8, 8)
+    assert loaded.config_hash == compression_config_hash(config)
+    assert loaded.spatial_tokens == 5
+
+
+def test_projection_state_round_trips_with_its_module_keys(tmp_path: Path):
+    # MaskProjection is nn.Sequential(nn.Linear, nn.ReLU), so these two keys are the contract that
+    # lets a stored artifact be loaded straight back into the module.
+    config = _config(tmp_path)
+    original = _artifact(config)
+    save_artifact(original, tmp_path)
+
+    loaded = load_artifact("mvtec__screw", tmp_path)
+
+    assert set(loaded.projection_state) == {"layers.0.weight", "layers.0.bias"}
+    assert torch.equal(loaded.projection_state["layers.0.weight"], original.projection_state["layers.0.weight"])
+    assert torch.equal(loaded.projection_state["layers.0.bias"], original.projection_state["layers.0.bias"])
+
+
+def test_missing_artifact_returns_none(tmp_path: Path):
+    assert load_artifact("mvtec__nothing", tmp_path) is None
+
+
+def test_interrupted_resave_does_not_load_as_valid(tmp_path: Path, monkeypatch):
+    # The dangerous case is re-saving a concept whose config did not change: the caller's hash check
+    # would still match, so a half-written artifact has to fail to load rather than look like a hit.
+    config = _config(tmp_path)
+    save_artifact(_artifact(config), tmp_path)
+    assert load_artifact("mvtec__screw", tmp_path) is not None
+
+    import pyclad.vision.strategies.replaycad.artifacts as artifacts_module
+
+    def explode(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(artifacts_module.torch, "save", explode)
+
+    with pytest.raises(OSError):
+        save_artifact(_artifact(config), tmp_path)
+
+    assert load_artifact("mvtec__screw", tmp_path) is None
+
+
+def test_meta_write_is_atomic_so_a_crash_mid_write_fails_closed(tmp_path: Path, monkeypatch):
+    """meta.json is itself the crash-safety marker load_artifact checks for. A crash while its own
+    content is being written must not leave a truncated file behind: that would still pass the
+    is_file() gate and then raise JSONDecodeError on every subsequent run, instead of the clean
+    "no artifact" result a failed save is supposed to produce.
+    """
+    config = _config(tmp_path)
+
+    import pyclad.vision.strategies.replaycad.artifacts as artifacts_module
+
+    original_write_text = Path.write_text
+
+    def crash_after_a_partial_write(self, content, *args, **kwargs):
+        # Matches both the fixed code's temp file ("meta.json.tmp") and the pre-fix code's direct
+        # write ("meta.json" itself), so this same test demonstrates the bug against either.
+        if self.name in ("meta.json", "meta.json.tmp"):
+            original_write_text(self, content[: len(content) // 2], *args, **kwargs)
+            raise OSError("simulated crash mid-write")
+        return original_write_text(self, content, *args, **kwargs)
+
+    monkeypatch.setattr(artifacts_module.Path, "write_text", crash_after_a_partial_write)
+
+    with pytest.raises(OSError):
+        save_artifact(_artifact(config), tmp_path)
+
+    # The crash must not leave anything at the real meta.json path -- a partially written file
+    # there would pass load_artifact's existence check and then blow up with JSONDecodeError.
+    assert not (tmp_path / "mvtec__screw" / "meta.json").exists()
+    assert load_artifact("mvtec__screw", tmp_path) is None
+
+
+def test_resave_with_fewer_masks_leaves_none_behind(tmp_path: Path):
+    config = _config(tmp_path)
+    save_artifact(_artifact(config), tmp_path)
+
+    shrunk = _artifact(config)
+    shrunk.masks = np.full((1, 8, 8), 255, dtype=np.uint8)
+    save_artifact(shrunk, tmp_path)
+
+    assert load_artifact("mvtec__screw", tmp_path).masks.shape[0] == 1
+
+
+def test_multidataset_concept_names_are_slugged(tmp_path: Path):
+    config = _config(tmp_path)
+    save_artifact(_artifact(config, concept_id="visa/pcb 1"), tmp_path)
+
+    assert concept_slug("visa/pcb 1") == "visa_pcb-1"
+    assert load_artifact("visa/pcb 1", tmp_path) is not None
+
+
+def test_hash_changes_with_compression_inputs(tmp_path: Path):
+    base = compression_config_hash(_config(tmp_path))
+
+    assert compression_config_hash(_config(tmp_path, compression_steps=1)) != base
+    assert compression_config_hash(_config(tmp_path, semantic_tokens=8)) != base
+    assert compression_config_hash(_config(tmp_path, mask_projection_width=400)) != base
+    assert compression_config_hash(_config(tmp_path, seed=7)) != base
+    assert compression_config_hash(_config(tmp_path, train_augmentation="rotate_180")) != base
+    # weight_decay changes what compress() optimizes (a standalone AdamW-decayed parameter, not
+    # the whole embedding matrix under a zeroed decay -- see backend.py's DiffusersBackend
+    # docstring): an artifact compressed under one weight_decay must not cache-hit for another.
+    assert compression_config_hash(_config(tmp_path, weight_decay=0.05)) != base
+
+
+def test_hash_covers_where_the_masks_come_from(tmp_path: Path):
+    # The mask source feeds the compression loop directly, so changing it must invalidate the cache.
+    base = compression_config_hash(_config(tmp_path))
+
+    assert compression_config_hash(_config(tmp_path, sam_checkpoint=tmp_path / "vit_h.pth")) != base
+    assert compression_config_hash(_config(tmp_path, sam_model_type="vit_b")) != base
+    assert compression_config_hash(_config(tmp_path, precomputed_mask_root=tmp_path / "sam")) != base
+
+
+def test_hash_ignores_inputs_that_do_not_change_the_compressed_representation(tmp_path: Path):
+    base = compression_config_hash(_config(tmp_path))
+
+    # Ordering, detector and replay volume must not invalidate a compression pass.
+    assert compression_config_hash(_config(tmp_path, replay_samples_per_concept=1)) == base
+    assert compression_config_hash(_config(tmp_path, generation_batch_size=1)) == base
+    assert compression_config_hash(_config(tmp_path, guidance_scale=5.0)) == base
+    assert compression_config_hash(_config(tmp_path, strict_cache=True)) == base
+    # Replay-time mask jitter cannot change an already-compressed artifact, so it must not
+    # invalidate one. Hashing it would cost a full recompression per concept for nothing.
+    assert compression_config_hash(_config(tmp_path, mask_augmentation="paper")) == base
+    # Same for the five class-specific transforms and their parameters -- all replay-time.
+    assert compression_config_hash(_config(tmp_path, mask_augmentation="little_rotate_and_move")) == base
+    assert compression_config_hash(_config(tmp_path, mask_transform_angles=10)) == base
+    assert compression_config_hash(_config(tmp_path, mask_transform_distance=0.2)) == base
+    assert compression_config_hash(_config(tmp_path, mask_transform_transpose=True)) == base
+    assert compression_config_hash(_config(tmp_path, visa_candle_shift_pixels=5)) == base
+    assert compression_config_hash(_config(tmp_path, visa_candle_rotate=True)) == base
+
+
+def test_artifact_without_spatial_conditioning_round_trips(tmp_path: Path):
+    config = _config(tmp_path, use_spatial_conditioning=False)
+    artifact = _artifact(config)
+    artifact.projection_state = None
+    artifact.masks = np.zeros((0, 8, 8), dtype=np.uint8)
+    save_artifact(artifact, tmp_path)
+
+    loaded = load_artifact("mvtec__screw", tmp_path)
+
+    assert loaded is not None
+    assert loaded.projection_state is None
+    assert loaded.masks.shape[0] == 0

--- a/tests/vision/strategies/replaycad/test_backend_contract.py
+++ b/tests/vision/strategies/replaycad/test_backend_contract.py
@@ -1,0 +1,790 @@
+import numpy as np
+import pytest
+import torch
+
+from pyclad.vision.strategies.replaycad.artifacts import ConceptArtifact
+from pyclad.vision.strategies.replaycad.backend import DiffusersBackend
+
+
+def test_stub_matches_the_declared_shapes(stub_backend, replaycad_config):
+    config = replaycad_config()
+    backend = stub_backend(config)
+    images = np.zeros((2, 8, 8, 3), dtype=np.uint8)
+    masks = np.full((2, 8, 8), 255, dtype=np.uint8)
+
+    embedding, projection_state = backend.compress("screw", images, masks)
+
+    assert embedding.shape == (config.semantic_tokens, config.condition_dim)
+    assert set(projection_state) == {"layers.0.weight", "layers.0.bias"}
+
+
+def test_stub_generate_returns_uint8_images(stub_backend, replaycad_config):
+    config = replaycad_config()
+    backend = stub_backend(config)
+    artifact = ConceptArtifact(
+        concept_id="screw",
+        embedding=torch.zeros(config.semantic_tokens, config.condition_dim),
+        projection_state=None,
+        masks=np.full((1, 8, 8), 255, dtype=np.uint8),
+        config_hash="deadbeef",
+        spatial_tokens=1,
+    )
+
+    images = backend.generate(artifact, count=3, seed=0)
+
+    assert images.shape == (3, 8, 8, 3)
+    assert images.dtype == np.uint8
+
+
+def test_stub_rejects_misaligned_masks(stub_backend):
+    backend = stub_backend()
+
+    with pytest.raises(ValueError, match="1 masks"):
+        backend.compress("screw", np.zeros((2, 8, 8, 3), dtype=np.uint8), np.zeros((1, 8, 8), dtype=np.uint8))
+
+
+def test_placeholder_installation_is_idempotent(replaycad_config):
+    """A concept is installed again every time it is replayed, so this must not fail or duplicate."""
+    config = replaycad_config()
+    backend = DiffusersBackend(config)
+
+    class FakeTokenizer:
+        def __init__(self):
+            self.vocabulary = {}
+
+        def get_vocab(self):
+            return dict(self.vocabulary)
+
+        def add_tokens(self, tokens):
+            added = 0
+            for token in tokens:
+                if token not in self.vocabulary:
+                    self.vocabulary[token] = len(self.vocabulary)
+                    added += 1
+            return added
+
+        def convert_tokens_to_ids(self, tokens):
+            return [self.vocabulary[token] for token in tokens]
+
+        def __len__(self):
+            return len(self.vocabulary)
+
+    class FakeTextEncoder:
+        def __init__(self, condition_dim):
+            self.embedding = torch.nn.Embedding(64, condition_dim)
+            self.resize_calls = 0
+
+        def resize_token_embeddings(self, size):
+            self.resize_calls += 1
+
+        def get_input_embeddings(self):
+            return self.embedding
+
+    class FakePipeline:
+        def __init__(self, condition_dim):
+            self.tokenizer = FakeTokenizer()
+            self.text_encoder = FakeTextEncoder(condition_dim)
+
+    pipeline = FakePipeline(config.condition_dim)
+
+    first = backend._install_placeholders(pipeline, "screw")
+    second = backend._install_placeholders(pipeline, "screw")
+
+    assert first == second
+    assert len(pipeline.tokenizer.vocabulary) == config.semantic_tokens
+    assert pipeline.text_encoder.resize_calls == 1  # the table grows once, not on every replay
+
+
+def test_install_placeholders_does_not_disturb_the_global_rng(replaycad_config):
+    """torch.manual_seed() here would pin the *global* RNG to config.seed on every call --
+    including every replay in generate() -- so anything downstream that draws from the global RNG
+    without its own generator (e.g. _encode's VAE posterior sample for the mask latent) would get
+    the same "random" draw regardless of the per-concept seed generate() was given. Placeholder
+    init must get its randomness from a local generator instead, leaving global state untouched.
+    """
+    config = replaycad_config()
+    backend = DiffusersBackend(config)
+
+    class FakeTokenizer:
+        def __init__(self):
+            self.vocabulary = {}
+
+        def get_vocab(self):
+            return dict(self.vocabulary)
+
+        def add_tokens(self, tokens):
+            added = 0
+            for token in tokens:
+                if token not in self.vocabulary:
+                    self.vocabulary[token] = len(self.vocabulary)
+                    added += 1
+            return added
+
+        def convert_tokens_to_ids(self, tokens):
+            return [self.vocabulary[token] for token in tokens]
+
+        def __len__(self):
+            return len(self.vocabulary)
+
+    class FakeTextEncoder:
+        def __init__(self, condition_dim):
+            self.embedding = torch.nn.Embedding(64, condition_dim)
+
+        def resize_token_embeddings(self, size):
+            return None
+
+        def get_input_embeddings(self):
+            return self.embedding
+
+    class FakePipeline:
+        def __init__(self, condition_dim):
+            self.tokenizer = FakeTokenizer()
+            self.text_encoder = FakeTextEncoder(condition_dim)
+
+    pipeline = FakePipeline(config.condition_dim)
+
+    torch.manual_seed(123)  # arbitrary unrelated prior global state
+    before = torch.get_rng_state()
+
+    backend._install_placeholders(pipeline, "screw")
+
+    assert torch.equal(before, torch.get_rng_state())
+
+
+def test_unconditional_padding_is_prepended(replaycad_config):
+    config = replaycad_config()
+    uncond = torch.ones(2, 5, config.condition_dim)
+
+    padded = DiffusersBackend._pad_unconditional(uncond, target_tokens=8)
+
+    assert padded.shape == (2, 8, config.condition_dim)
+    # The released sampler puts the zeros first (ddim.py:184), leaving the real text tokens last.
+    assert torch.all(padded[:, :3] == 0)
+    assert torch.all(padded[:, 3:] == 1)
+
+
+def test_unconditional_padding_is_a_no_op_when_lengths_match(replaycad_config):
+    uncond = torch.ones(2, 8, 4)
+
+    assert DiffusersBackend._pad_unconditional(uncond, target_tokens=8) is uncond
+
+
+def test_substitution_hook_is_removed_when_compression_raises(replaycad_config, monkeypatch):
+    """A leaked forward hook would keep substituting this concept's stale placeholder rows into
+    the next concept's forward passes -- the embedding layer is the same module for every concept
+    on a cached pipeline -- silently corrupting that concept's conditioning.
+    """
+    config = replaycad_config(use_spatial_conditioning=False)
+    backend = DiffusersBackend(config)
+
+    class FakeTokenizer:
+        def __init__(self):
+            self.vocabulary = {}
+
+        def get_vocab(self):
+            return dict(self.vocabulary)
+
+        def add_tokens(self, tokens):
+            for token in tokens:
+                self.vocabulary.setdefault(token, len(self.vocabulary))
+            return len(tokens)
+
+        def convert_tokens_to_ids(self, tokens):
+            return [self.vocabulary[token] for token in tokens]
+
+        def __len__(self):
+            return len(self.vocabulary)
+
+    class FakeTextEncoder:
+        def __init__(self, condition_dim):
+            self.embedding = torch.nn.Embedding(64, condition_dim)
+
+        def resize_token_embeddings(self, size):
+            return None
+
+        def get_input_embeddings(self):
+            return self.embedding
+
+    class ExplodingVae:
+        def encode(self, batch):
+            raise RuntimeError("simulated out of memory")
+
+    class FakePipeline:
+        def __init__(self, condition_dim):
+            self.tokenizer = FakeTokenizer()
+            self.text_encoder = FakeTextEncoder(condition_dim)
+            self.vae = ExplodingVae()
+
+    pipeline = FakePipeline(config.condition_dim)
+    monkeypatch.setattr(backend, "_load", lambda: pipeline)
+    embedding_layer = pipeline.text_encoder.embedding
+
+    with pytest.raises(RuntimeError, match="simulated out of memory"):
+        backend.compress(
+            "screw",
+            np.zeros((1, config.resolution, config.resolution, 3), dtype=np.uint8),
+            np.zeros((1, config.resolution, config.resolution), dtype=np.uint8),
+        )
+
+    assert not embedding_layer._forward_hooks
+
+
+def test_substitution_hook_is_removed_when_projection_construction_raises(replaycad_config, monkeypatch):
+    """The `try` guarding `hook.remove()` used to open only around `_run_compression_loop`,
+    leaving the hook registration, `MaskProjection(...).to(device=...)` and the AdamW construction
+    unguarded in between. A CUDA OOM in that gap is realistic -- straight after a full pipeline was
+    just loaded onto the same device -- and would leak the hook exactly like a loop failure does:
+    the leaked closure keeps capturing this call's *aborted* `placeholder`, so every later
+    generate() for this concept would silently substitute mid-training values instead of the
+    artifact's actually-stored embedding. Unlike
+    test_substitution_hook_is_removed_when_compression_raises above, this one fails inside the gap
+    itself (spatial conditioning on, so MaskProjection is actually constructed), not inside the
+    loop, so it would not have caught a `try` that opened too late.
+    """
+    config = replaycad_config(use_spatial_conditioning=True)
+    backend = DiffusersBackend(config)
+
+    class FakeTokenizer:
+        def __init__(self):
+            self.vocabulary = {}
+
+        def get_vocab(self):
+            return dict(self.vocabulary)
+
+        def add_tokens(self, tokens):
+            for token in tokens:
+                self.vocabulary.setdefault(token, len(self.vocabulary))
+            return len(tokens)
+
+        def convert_tokens_to_ids(self, tokens):
+            return [self.vocabulary[token] for token in tokens]
+
+        def __len__(self):
+            return len(self.vocabulary)
+
+    class FakeTextEncoder:
+        def __init__(self, condition_dim):
+            self.embedding = torch.nn.Embedding(64, condition_dim)
+
+        def resize_token_embeddings(self, size):
+            return None
+
+        def get_input_embeddings(self):
+            return self.embedding
+
+    class FakePipeline:
+        def __init__(self, condition_dim):
+            self.tokenizer = FakeTokenizer()
+            self.text_encoder = FakeTextEncoder(condition_dim)
+
+    pipeline = FakePipeline(config.condition_dim)
+    monkeypatch.setattr(backend, "_load", lambda: pipeline)
+    embedding_layer = pipeline.text_encoder.embedding
+
+    import pyclad.vision.strategies.replaycad.backend as backend_module
+
+    def exploding_to(self, *args, **kwargs):
+        raise RuntimeError("simulated CUDA out of memory")
+
+    monkeypatch.setattr(backend_module.MaskProjection, "to", exploding_to)
+
+    with pytest.raises(RuntimeError, match="simulated CUDA out of memory"):
+        backend.compress(
+            "screw",
+            np.zeros((1, config.resolution, config.resolution, 3), dtype=np.uint8),
+            np.zeros((1, config.resolution, config.resolution), dtype=np.uint8),
+        )
+
+    assert not embedding_layer._forward_hooks
+
+
+class _Config:
+    """Dumb attribute bag, standing in for the small pieces of a diffusers config/module this
+    file's fakes need to expose (e.g. ``scheduler.config.num_train_timesteps``)."""
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _fake_loop_pipeline():
+    """Minimal pipeline for _run_compression_loop with _conditioning/_encode stubbed out: only
+    scheduler.config.num_train_timesteps, scheduler.add_noise and unet(...) are still touched."""
+    scheduler = _Config(config=_Config(num_train_timesteps=1000))
+    scheduler.add_noise = lambda latents, noise, timesteps: latents + noise
+    unet = lambda noisy, timesteps, encoder_hidden_states: _Config(  # noqa: E731
+        sample=torch.zeros_like(noisy, requires_grad=True)
+    )
+    return _Config(scheduler=scheduler, unet=unet)
+
+
+def test_compression_draws_an_independent_prompt_per_image(replaycad_config, monkeypatch):
+    """The released dataset draws one caption per __getitem__ call, independently for every image
+    (personalized.py:218). Reusing a single per-step draw across the whole batch would silently
+    cut caption diversity by a factor of compression_batch_size (16x for MVTec's default). This
+    drives _run_compression_loop directly with everything except the prompt draw stubbed out, and
+    checks that a 6-image batch does not all get the same prompt.
+    """
+    config = replaycad_config(compression_steps=1, compression_batch_size=6)
+    backend = DiffusersBackend(config)
+
+    captured_prompts: list[list[str]] = []
+
+    def fake_conditioning(pipeline, *args):
+        # Tolerates both the old call shape (prompt: str, batch_size: int) and the new one
+        # (prompts: list[str]), so this same test can run unmodified against either
+        # _run_compression_loop and let the diversity assertion below be the real signal.
+        if len(args) == 2:
+            prompt, batch_size = args
+            prompts = [prompt] * batch_size
+        else:
+            (prompts,) = args
+        captured_prompts.append(list(prompts))
+        return torch.zeros(len(prompts), 1, config.condition_dim)
+
+    monkeypatch.setattr(backend, "_conditioning", fake_conditioning)
+    monkeypatch.setattr(backend, "_encode", lambda pipeline, batch: torch.zeros(len(batch), 4, 2, 2))
+
+    images = np.zeros((6, config.resolution, config.resolution, 3), dtype=np.uint8)
+    # Non-empty and matching images in length: this test is about prompt diversity alone, kept
+    # independent of the (separately tested) empty-masks tolerance.
+    masks = np.zeros((6, config.resolution, config.resolution), dtype=np.uint8)
+    rng = np.random.default_rng(0)
+    optimizer = torch.optim.AdamW([torch.nn.Parameter(torch.zeros(1))], lr=1e-3)
+
+    backend._run_compression_loop(
+        _fake_loop_pipeline(), None, optimizer, images, masks, rng, torch.device("cpu"), torch.float32, 6, "screw"
+    )
+
+    assert len(captured_prompts) == 1  # one step
+    assert len(captured_prompts[0]) == 6  # one prompt per image
+    assert len(set(captured_prompts[0])) > 1  # not 6 copies of a single per-step draw
+
+
+def test_compression_loop_tolerates_empty_masks_when_spatial_conditioning_is_off(replaycad_config, monkeypatch):
+    """memory.py passes a zero-length mask array when spatial conditioning is off, to skip a full
+    SAM pass whose output the backend would never use. The loop must not index into it:
+    augment_training_pair only ever receives a real mask when projection is not None.
+    """
+    config = replaycad_config(compression_batch_size=3)
+    backend = DiffusersBackend(config)
+
+    monkeypatch.setattr(
+        backend, "_conditioning", lambda pipeline, prompts: torch.zeros(len(prompts), 1, config.condition_dim)
+    )
+    monkeypatch.setattr(backend, "_encode", lambda pipeline, batch: torch.zeros(len(batch), 4, 2, 2))
+
+    images = np.zeros((3, config.resolution, config.resolution, 3), dtype=np.uint8)
+    masks = np.zeros((0, config.resolution, config.resolution), dtype=np.uint8)  # spatial conditioning off
+    rng = np.random.default_rng(0)
+    optimizer = torch.optim.AdamW([torch.nn.Parameter(torch.zeros(1))], lr=1e-3)
+
+    # Must not raise IndexError from masks[index] on the empty array.
+    backend._run_compression_loop(
+        _fake_loop_pipeline(), None, optimizer, images, masks, rng, torch.device("cpu"), torch.float32, 3, "screw"
+    )
+
+
+def test_compress_accepts_a_zero_length_mask_array(replaycad_config, monkeypatch):
+    """The top-level image/mask count check must tolerate a zero-length mask array -- memory.py's
+    way of saying spatial conditioning is off and no masks were computed -- while still catching a
+    genuine misalignment (covered separately by test_stub_rejects_misaligned_masks's real-count
+    case, and by DiffusersBackend sharing the same check).
+    """
+    config = replaycad_config(use_spatial_conditioning=False)
+    backend = DiffusersBackend(config)
+
+    class FakeTokenizer:
+        def get_vocab(self):
+            return {}
+
+        def add_tokens(self, tokens):
+            return len(tokens)
+
+        def convert_tokens_to_ids(self, tokens):
+            return list(range(len(tokens)))
+
+        def __len__(self):
+            return config.semantic_tokens
+
+    class FakeTextEncoder:
+        def __init__(self):
+            self.embedding = torch.nn.Embedding(64, config.condition_dim)
+
+        def resize_token_embeddings(self, size):
+            return None
+
+        def get_input_embeddings(self):
+            return self.embedding
+
+    class FakePipeline:
+        tokenizer = FakeTokenizer()
+        text_encoder = FakeTextEncoder()
+
+    monkeypatch.setattr(backend, "_load", lambda: FakePipeline())
+    monkeypatch.setattr(backend, "_run_compression_loop", lambda *args, **kwargs: None)
+
+    images = np.zeros((2, config.resolution, config.resolution, 3), dtype=np.uint8)
+    masks = np.zeros((0, config.resolution, config.resolution), dtype=np.uint8)
+
+    embedding, projection_state = backend.compress("screw", images, masks)
+
+    assert embedding.shape == (config.semantic_tokens, config.condition_dim)
+    assert projection_state is None
+
+
+# --- placeholder substitution: vocabulary integrity, gradient flow, weight_decay, id->row mapping
+#
+# DiffusersBackend.compress() used to hand embedding_layer.weight straight to AdamW and zero the
+# gradient of every non-placeholder row with a backward hook, which only worked because
+# weight_decay was forced to 0 -- AdamW's decoupled decay ignores the gradient mask and would
+# otherwise corrode the whole vocabulary. It now holds the K learned vectors in their own
+# nn.Parameter (`placeholder`) and substitutes them into the embedding layer's *output* via a
+# forward hook, leaving embedding_layer.weight untouched and requires_grad=False throughout, so a
+# real weight_decay (matching the released implementation's implicit PyTorch AdamW default,
+# ddpm2.py:1563-1573) can no longer touch it. The first three tests below drive that mechanism
+# through a real compress() call: a minimal "text encoder" that is just its own token-embedding
+# lookup, so the loss is a genuine (if physically meaningless) differentiable function of the
+# substituted output -- and therefore of `placeholder` -- with no transformer internals to fake.
+#
+# None of those three checks *which* row lands where, though. Confirmed by mutation: rotating the
+# id->row mapping by one, and making every placeholder id gather row 0 instead of its own, both
+# left every test in this file green except one that removes substitution outright -- because
+# _DifferentiableUnet's original reduction (plain mean over the token axis, then sum) is invariant
+# under permuting *which* row lands at which position, so those mutants produced the exact same
+# loss trajectory as the correct mapping. _DifferentiableUnet below now weights the token axis by
+# position before reducing, so *where* a row lands actually matters to the loss; and
+# test_substitution_hook_maps_each_placeholder_id_to_its_own_row further down asserts the mapping
+# directly, independent of any loss or gradient.
+
+
+class _DifferentiableTokenizer:
+    """Vocabulary starts with one reserved pad entry (id 0), so the padding `_conditioning`
+    relies on can never collide with a newly added placeholder id."""
+
+    def __init__(self):
+        self.vocabulary = {"<pad>": 0}
+        self.model_input_names = ["input_ids"]
+        self.model_max_length = 8
+
+    def get_vocab(self):
+        return dict(self.vocabulary)
+
+    def add_tokens(self, tokens):
+        added = 0
+        for token in tokens:
+            if token not in self.vocabulary:
+                self.vocabulary[token] = len(self.vocabulary)
+                added += 1
+        return added
+
+    def convert_tokens_to_ids(self, tokens):
+        return [self.vocabulary[token] for token in tokens]
+
+    def convert_ids_to_tokens(self, ids):
+        reverse = {index: token for token, index in self.vocabulary.items()}
+        return [reverse[index] for index in ids]
+
+    def __len__(self):
+        return len(self.vocabulary)
+
+    def __call__(self, texts, padding, truncation, max_length, return_tensors):
+        assert padding == "max_length" and truncation and return_tensors == "pt"
+        pad_id = self.vocabulary["<pad>"]
+        rows = []
+        for text in texts:
+            ids = [self.vocabulary[piece] for piece in text.split(" ") if piece]
+            ids = (ids + [pad_id] * max_length)[:max_length]
+            rows.append(ids)
+        return {"input_ids": torch.tensor(rows, dtype=torch.long)}
+
+
+class _DifferentiableTextEncoder:
+    """A "text encoder" that is just its own token embedding lookup: text_encoder(input_ids) ==
+    embedding_layer(input_ids), the exact call the substitution hook attaches to. Standing in for
+    the real CLIP/LDMBert encoders, which do the same lookup internally before further layers that
+    are irrelevant to whether the substitution and its gradient are wired correctly.
+    """
+
+    def __init__(self, condition_dim):
+        self.embedding = torch.nn.Embedding(64, condition_dim)
+        self.config = _Config()
+        self.device = torch.device("cpu")
+
+    def get_input_embeddings(self):
+        return self.embedding
+
+    def resize_token_embeddings(self, size):
+        return None
+
+    def forward(self, input_ids=None):
+        return (self.embedding(input_ids),)
+
+    def __call__(self, **kwargs):
+        return self.forward(**kwargs)
+
+
+class _DifferentiableUnet:
+    """Returns noisy + a bias derived from encoder_hidden_states, so the MSE loss is a real
+    differentiable function of the conditioning tensor -- and, through the substitution hook, of
+    `placeholder` -- without needing an actual denoiser.
+
+    The token axis is weighted by position (1, 2, ..., L) before reducing, rather than a plain
+    mean: a plain mean-then-sum is invariant under permuting which row lands at which position, so
+    it cannot distinguish a correct id->row mapping from a rotated one -- both produce the exact
+    same loss trajectory (see the module comment above this class). Position weighting makes
+    *where* a row lands actually change the loss.
+    """
+
+    def __call__(self, noisy, timesteps, encoder_hidden_states):
+        length = encoder_hidden_states.shape[1]
+        position_weight = torch.arange(
+            1, length + 1, dtype=encoder_hidden_states.dtype, device=encoder_hidden_states.device
+        ).view(1, -1, 1)
+        bias = (encoder_hidden_states * position_weight).mean(dim=1).sum(dim=-1).view(-1, 1, 1, 1)
+        return _Config(sample=noisy + bias)
+
+
+def _build_differentiable_pipeline(config):
+    scheduler = _Config(config=_Config(num_train_timesteps=1000))
+    scheduler.add_noise = lambda latents, noise, timesteps: latents + noise
+    return _Config(
+        tokenizer=_DifferentiableTokenizer(),
+        text_encoder=_DifferentiableTextEncoder(config.condition_dim),
+        unet=_DifferentiableUnet(),
+        scheduler=scheduler,
+    )
+
+
+def _wire_differentiable_backend(config, monkeypatch):
+    """Builds the pipeline above, points a fresh backend at it, and stubs out only image encoding
+    (the VAE round trip is covered separately by test_real_diffusion.py and is irrelevant to the
+    substitution mechanism under test here)."""
+    backend = DiffusersBackend(config)
+    pipeline = _build_differentiable_pipeline(config)
+    monkeypatch.setattr(backend, "_load", lambda: pipeline)
+    monkeypatch.setattr(backend, "_encode", lambda pipeline, batch: torch.zeros(len(batch), 4, 2, 2))
+    return backend, pipeline
+
+
+def test_compression_leaves_the_vocabulary_bit_identical(replaycad_config, monkeypatch):
+    """The property the old gradient-masking backward hook existed to protect. Confirmed
+    load-bearing by temporarily making the substitution write into embedding_layer.weight too and
+    watching this test fail -- see optimizer-fix-report.md for the transcript.
+    """
+    config = replaycad_config(use_spatial_conditioning=False, prompt_templates=("*",), compression_steps=2)
+    backend, pipeline = _wire_differentiable_backend(config, monkeypatch)
+
+    token_ids = backend._install_placeholders(pipeline, "screw")
+    embedding_layer = pipeline.text_encoder.get_input_embeddings()
+    before = embedding_layer.weight.detach().clone()
+
+    images = np.zeros((config.compression_batch_size, config.resolution, config.resolution, 3), dtype=np.uint8)
+    masks = np.zeros((0, config.resolution, config.resolution), dtype=np.uint8)
+    backend.compress("screw", images, masks)
+
+    after = embedding_layer.weight.detach()
+    non_placeholder = torch.ones(after.shape[0], dtype=torch.bool)
+    non_placeholder[token_ids] = False
+
+    assert non_placeholder.sum() > 0  # the fake vocabulary has rows besides the placeholders
+    assert torch.equal(before[non_placeholder], after[non_placeholder])
+
+
+def test_compression_moves_the_placeholder_parameter(replaycad_config, monkeypatch):
+    """Gradients must still reach the learned embedding -- the whole reason to keep optimizing it
+    -- even though it is no longer a slice of embedding_layer.weight.
+    """
+    config = replaycad_config(use_spatial_conditioning=False, prompt_templates=("*",), compression_steps=2)
+    backend, pipeline = _wire_differentiable_backend(config, monkeypatch)
+
+    token_ids = backend._install_placeholders(pipeline, "screw")
+    embedding_layer = pipeline.text_encoder.get_input_embeddings()
+    initial = embedding_layer.weight[token_ids].detach().clone()
+
+    images = np.zeros((config.compression_batch_size, config.resolution, config.resolution, 3), dtype=np.uint8)
+    masks = np.zeros((0, config.resolution, config.resolution), dtype=np.uint8)
+    learned, _ = backend.compress("screw", images, masks)
+
+    assert learned.shape == initial.shape
+    assert not torch.allclose(learned, initial)
+
+
+def test_substitution_hook_maps_each_placeholder_id_to_its_own_row(replaycad_config, monkeypatch):
+    """Direct assertion on the id->row mapping itself, independent of any loss or gradient --
+    install the real hook (DiffusersBackend._install_substitution_hook, the same code compress()
+    uses) with `placeholder` set to K distinguishable rows, call the embedding layer on exactly the
+    placeholder ids, and check each output row against its own placeholder row one at a time.
+
+    Confirmed load-bearing by mutation: rotating the id->row mapping by one, and making every
+    placeholder id gather row 0 instead of its own, both slip past every *other* test in this file
+    (see the module comment above _DifferentiableUnet) -- this test catches both, because it never
+    goes through a loss at all.
+    """
+    config = replaycad_config()
+    backend, pipeline = _wire_differentiable_backend(config, monkeypatch)
+
+    token_ids = backend._install_placeholders(pipeline, "screw")
+    text_encoder = pipeline.text_encoder
+    embedding_layer = text_encoder.get_input_embeddings()
+
+    num_tokens, condition_dim = config.semantic_tokens, config.condition_dim
+    # arange, not random init: guarantees every row is bitwise distinguishable from every other,
+    # so a mismapped row can never accidentally equal the row it should have been compared against.
+    placeholder = torch.arange(num_tokens * condition_dim, dtype=torch.float32).reshape(num_tokens, condition_dim)
+
+    hook = backend._install_substitution_hook(embedding_layer, token_ids, placeholder)
+    try:
+        input_ids = torch.tensor([token_ids], dtype=torch.long)
+        output = text_encoder(input_ids=input_ids)[0]
+    finally:
+        hook.remove()
+
+    assert output.shape == (1, num_tokens, condition_dim)
+    for index in range(num_tokens):
+        assert torch.equal(output[0, index], placeholder[index])
+
+
+def test_compression_optimizer_uses_the_configured_weight_decay(replaycad_config, monkeypatch):
+    """No group-specific override: compress() passes one scalar weight_decay to AdamW's
+    constructor, exactly as ddpm2.py:1563-1573 does (there, by omission -- PyTorch's own default).
+    """
+    config = replaycad_config(use_spatial_conditioning=False, prompt_templates=("*",), compression_steps=1)
+    assert config.weight_decay == pytest.approx(1e-2)
+    backend, pipeline = _wire_differentiable_backend(config, monkeypatch)
+
+    real_adamw = torch.optim.AdamW
+    constructed = []
+
+    def _recording_adamw(*args, **kwargs):
+        optimizer = real_adamw(*args, **kwargs)
+        constructed.append(optimizer)
+        return optimizer
+
+    monkeypatch.setattr(torch.optim, "AdamW", _recording_adamw)
+
+    images = np.zeros((config.compression_batch_size, config.resolution, config.resolution, 3), dtype=np.uint8)
+    masks = np.zeros((0, config.resolution, config.resolution), dtype=np.uint8)
+    backend.compress("screw", images, masks)
+
+    assert len(constructed) == 1
+    weight_decays = [group["weight_decay"] for group in constructed[0].param_groups]
+    assert weight_decays == [pytest.approx(1e-2)]
+
+
+def test_real_backend_reports_a_helpful_error_without_the_extra(replaycad_config, monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def blocked(name, *args, **kwargs):
+        if name.startswith("diffusers"):
+            raise ImportError("no diffusers")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked)
+
+    with pytest.raises(ImportError, match="replaycad"):
+        DiffusersBackend(replaycad_config())._load()
+
+
+# --- C1: the LDM-256 conditioning path (BertTokenizer + LDMBertModel) ------------------------
+#
+# Stable Diffusion's CLIPTokenizer/CLIPTextModel survive _conditioning()'s naive
+# tokenizer(**kwargs) -> text_encoder(**encoded) plumbing by coincidence: CLIPTokenizer never
+# produces token_type_ids, and its checkpoints ship a tokenizer_config.json capping
+# model_max_length at exactly 77. Neither coincidence holds for the LDM-256 profile that MVTec
+# uses by default. Verified against the installed diffusers 0.40 / transformers 5.16 rather than
+# assumed:
+#   - transformers.models.bert.tokenization_bert.BertTokenizer.model_input_names includes
+#     "token_type_ids".
+#   - diffusers.pipelines.latent_diffusion.pipeline_latent_diffusion.LDMBertModel.forward's
+#     signature is (input_ids, attention_mask, position_ids, head_mask, inputs_embeds,
+#     output_attentions, output_hidden_states, return_dict) -- no token_type_ids, and no
+#     **kwargs to swallow one. Calling it with token_type_ids=... raises
+#     "TypeError: forward() got an unexpected keyword argument 'token_type_ids'".
+#   - LDMBertConfig.max_position_embeddings defaults to 77, and LDMBertEncoder.forward looks up
+#     one position row per input token from an nn.Embedding(max_position_embeddings, ...) table
+#     with no bounds check of its own -- feeding it BertTokenizer's own model_max_length (512, or
+#     transformers' VERY_LARGE_INTEGER sentinel when the checkpoint ships no
+#     tokenizer_config.json) raises "IndexError: index out of range in self".
+# The two stubs below mirror both real signatures exactly rather than special-casing the bad
+# inputs, so they reject/error for the same structural reasons the real classes do.
+
+
+class _LDMBertStyleConfig:
+    def __init__(self, max_position_embeddings: int):
+        self.max_position_embeddings = max_position_embeddings
+
+
+class _LDMBertStyleEncoder:
+    """Mirrors LDMBertModel: no token_type_ids parameter, and a position table that only goes up
+    to max_position_embeddings."""
+
+    def __init__(self, max_position_embeddings: int = 77):
+        self.config = _LDMBertStyleConfig(max_position_embeddings)
+        self.device = torch.device("cpu")
+
+    def forward(self, input_ids=None, attention_mask=None, position_ids=None):
+        if input_ids.shape[1] > self.config.max_position_embeddings:
+            raise IndexError("index out of range in self")
+        return (torch.zeros(input_ids.shape[0], input_ids.shape[1], 8),)
+
+    def __call__(self, **kwargs):
+        return self.forward(**kwargs)
+
+
+class _BertStyleTokenizer:
+    """Mirrors BertTokenizer's output contract: model_input_names and the padded shape it
+    produces. ``model_input_names`` defaults to Bert's real list (including token_type_ids);
+    pass a shorter one to mimic a tokenizer that does not produce it."""
+
+    def __init__(self, model_input_names=("input_ids", "token_type_ids", "attention_mask"), model_max_length=512):
+        self.model_input_names = list(model_input_names)
+        self.model_max_length = model_max_length
+
+    def __call__(self, texts, padding, truncation, max_length, return_tensors):
+        assert padding == "max_length" and truncation and return_tensors == "pt"
+        batch = len(texts)
+        values = {
+            "input_ids": torch.ones(batch, max_length, dtype=torch.long),
+            "token_type_ids": torch.zeros(batch, max_length, dtype=torch.long),
+            "attention_mask": torch.ones(batch, max_length, dtype=torch.long),
+        }
+        return {key: values[key] for key in self.model_input_names}
+
+
+class _StubLDMPipeline:
+    def __init__(self, tokenizer, text_encoder):
+        self.tokenizer = tokenizer
+        self.text_encoder = text_encoder
+
+
+def test_conditioning_reproduces_bert_and_ldmbert_defaults(replaycad_config):
+    """The exact combination that crashes the default MVTec/LDM-256 profile deterministically:
+    BertTokenizer's real defaults (token_type_ids in model_input_names, model_max_length=512)
+    against LDMBertModel's real default (max_position_embeddings=77, no token_type_ids
+    parameter). Before the fix this raised TypeError on the first compression/generation step.
+    """
+    backend = DiffusersBackend(replaycad_config())
+    pipeline = _StubLDMPipeline(tokenizer=_BertStyleTokenizer(), text_encoder=_LDMBertStyleEncoder())
+
+    conditioning = backend._conditioning(pipeline, ["a photo of a *", "a rendering of a *"])
+
+    assert conditioning.shape == (2, 77, 8)
+
+
+def test_conditioning_bounds_length_to_the_text_encoders_own_limit(replaycad_config):
+    """Isolates the length bound from the key-filtering fix: this tokenizer produces no
+    token_type_ids at all, so only max_length is under test. Before the fix, max_length came
+    from tokenizer.model_max_length (512) instead of the encoder's own 77-row position table,
+    raising IndexError.
+    """
+    backend = DiffusersBackend(replaycad_config())
+    pipeline = _StubLDMPipeline(
+        tokenizer=_BertStyleTokenizer(model_input_names=["input_ids", "attention_mask"], model_max_length=512),
+        text_encoder=_LDMBertStyleEncoder(max_position_embeddings=77),
+    )
+
+    conditioning = backend._conditioning(pipeline, ["a photo of a *"])
+
+    assert conditioning.shape == (1, 77, 8)

--- a/tests/vision/strategies/replaycad/test_backend_contract.py
+++ b/tests/vision/strategies/replaycad/test_backend_contract.py
@@ -329,15 +329,7 @@ def test_compression_draws_an_independent_prompt_per_image(replaycad_config, mon
 
     captured_prompts: list[list[str]] = []
 
-    def fake_conditioning(pipeline, *args):
-        # Tolerates both the old call shape (prompt: str, batch_size: int) and the new one
-        # (prompts: list[str]), so this same test can run unmodified against either
-        # _run_compression_loop and let the diversity assertion below be the real signal.
-        if len(args) == 2:
-            prompt, batch_size = args
-            prompts = [prompt] * batch_size
-        else:
-            (prompts,) = args
+    def fake_conditioning(pipeline, prompts):
         captured_prompts.append(list(prompts))
         return torch.zeros(len(prompts), 1, config.condition_dim)
 

--- a/tests/vision/strategies/replaycad/test_config.py
+++ b/tests/vision/strategies/replaycad/test_config.py
@@ -1,0 +1,128 @@
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from pyclad.vision.strategies.replaycad.config import (
+    IMAGENET_TEMPLATES_SMALL,
+    ReplayCADConfig,
+)
+
+
+def _config(benchmark: str, **overrides) -> ReplayCADConfig:
+    # mask_backend defaults to "sam", which requires a checkpoint. These tests are about presets
+    # and derived arithmetic, so they pick the backend that needs no external file.
+    defaults = {"mask_backend": "full-frame"}
+    defaults.update(overrides)
+    return ReplayCADConfig.for_benchmark(benchmark, artifact_dir=Path("/tmp/a"), **defaults)
+
+
+def test_sam_backend_requires_a_checkpoint():
+    # Failing loudly is deliberate: silently falling back to full-frame masks would destroy the
+    # spatial conditioning without any signal.
+    with pytest.raises(ValidationError, match="sam_checkpoint"):
+        ReplayCADConfig.for_benchmark("mvtec", artifact_dir=Path("/tmp/a"))
+
+
+def test_mvtec_preset_matches_the_paper():
+    config = _config("mvtec")
+
+    assert config.model_id == "CompVis/ldm-text2im-large-256"
+    assert config.resolution == 256
+    assert config.condition_dim == 1280
+    assert config.semantic_tokens == 20
+    assert (config.mask_group_width, config.mask_projection_width) == (128, 200)
+    assert config.compression_steps == 20_000
+    assert config.spatial_tokens == 5
+
+
+def test_visa_preset_matches_the_released_sd_config():
+    config = _config("visa")
+
+    assert config.resolution == 512
+    assert config.condition_dim == 768
+    # The paper prints (128, 196), which cannot be reshaped into 768-dim tokens.
+    assert (config.mask_group_width, config.mask_projection_width) == (128, 192)
+    assert config.compression_steps == 30_000
+    assert config.spatial_tokens == 32
+
+
+@pytest.mark.parametrize(
+    "benchmark, spatial_lr, semantic_lr",
+    [("mvtec", 1.6e-3, 1.6e-1), ("visa", 2.0e-4, 2.0e-2)],
+)
+def test_learning_rates_reproduce_the_scaled_originals(benchmark, spatial_lr, semantic_lr):
+    # main.py:770 -> lr = accumulate * ngpu * batch_size * base_lr, --scale_lr defaults to True,
+    # every published run used --gpus 0,1. MVTec: 1*2*16*5e-5. VisA: 1*2*2*5e-5.
+    config = _config(benchmark)
+
+    assert config.spatial_learning_rate == pytest.approx(spatial_lr)
+    assert config.semantic_learning_rate == pytest.approx(semantic_lr)
+
+
+def test_unknown_benchmark_falls_back_to_the_ldm_profile():
+    config = _config("btech")
+
+    assert config.profile == "ldm-256"
+    assert config.initializer_word is None
+
+
+def test_non_reshapeable_projection_is_rejected():
+    with pytest.raises(ValidationError, match="conditioning tokens"):
+        _config("visa", mask_projection_width=196)
+
+
+def test_indivisible_group_width_is_rejected():
+    with pytest.raises(ValidationError, match="mask_group_width"):
+        _config("mvtec", mask_group_width=97)
+
+
+def test_masks_per_concept_is_capped_at_ten():
+    # Matching on the field name keeps this from passing on some unrelated validation error.
+    with pytest.raises(ValidationError, match="masks_per_concept"):
+        _config("mvtec", masks_per_concept=11)
+
+
+def test_defaults_follow_the_paper_not_the_released_scripts():
+    config = _config("mvtec")
+
+    assert config.replay_samples_per_concept == 800  # paper section 5.1
+    assert config.guidance_scale == 10.0
+    assert config.inference_steps == 50
+    assert config.ddim_eta == 0.0
+    assert config.mask_augmentation == "none"  # opt in to "paper" or one of the five class transforms
+    assert config.initializer_word is None  # paper: randomly initialized embedding
+    assert config.timestep_sampling == "uniform"  # ddpm2.py average_t defaults to True
+    assert config.train_augmentation == "none"
+    # mask_transfor.py's own defaults for the five class-specific transforms.
+    assert config.mask_transform_angles == 2
+    assert config.mask_transform_distance == 0.05
+    assert config.mask_transform_transpose is False
+    assert config.visa_candle_shift_pixels == 20
+    assert config.visa_candle_rotate is False
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "none",
+        "paper",
+        "random_rotate",
+        "random_3directions_rotate",
+        "little_rotate_and_move",
+        "visa_candle",
+        "random_reset",
+    ],
+)
+def test_mask_augmentation_accepts_the_paper_mode_and_the_five_class_transforms(mode):
+    assert _config("mvtec", mask_augmentation=mode).mask_augmentation == mode
+
+
+def test_mask_augmentation_rejects_unknown_modes():
+    with pytest.raises(ValidationError, match="mask_augmentation"):
+        _config("mvtec", mask_augmentation="rotate_and_shift")
+
+
+def test_prompt_templates_are_the_textual_inversion_list():
+    assert len(IMAGENET_TEMPLATES_SMALL) == 81
+    assert "a photo of a {}" in IMAGENET_TEMPLATES_SMALL

--- a/tests/vision/strategies/replaycad/test_masks.py
+++ b/tests/vision/strategies/replaycad/test_masks.py
@@ -1,0 +1,556 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+from scipy import ndimage
+
+from pyclad.vision.strategies.replaycad.config import ReplayCADConfig
+from pyclad.vision.strategies.replaycad.masks import (
+    FullFrameMaskProvider,
+    PrecomputedMaskProvider,
+    SamMaskProvider,
+    augment_mask,
+    augment_training_pair,
+    build_mask_provider,
+    little_rotate_and_move,
+    random_3directions_rotate,
+    random_reset,
+    random_rotate,
+    select_stored_masks,
+    visa_candle,
+)
+
+
+def _config(tmp_path: Path, **overrides) -> ReplayCADConfig:
+    defaults = dict(mask_backend="full-frame")
+    defaults.update(overrides)
+    return ReplayCADConfig.for_benchmark("mvtec", artifact_dir=tmp_path, **defaults)
+
+
+def test_full_frame_provider_returns_all_ones():
+    images = np.zeros((2, 16, 16, 3), dtype=np.uint8)
+
+    masks = FullFrameMaskProvider().masks_for("screw", images)
+
+    assert masks.shape == (2, 16, 16)
+    assert np.all(masks == 255)
+
+
+def test_precomputed_provider_reads_sorted_files(tmp_path: Path):
+    category_dir = tmp_path / "mvtec" / "screw"
+    category_dir.mkdir(parents=True)
+    for index, value in enumerate([0, 128, 255]):
+        Image.fromarray(np.full((16, 16), value, dtype=np.uint8)).save(category_dir / f"{index:03d}.png")
+
+    provider = PrecomputedMaskProvider(root=tmp_path, benchmark="mvtec")
+    masks = provider.masks_for("mvtec__screw", np.zeros((3, 16, 16, 3), dtype=np.uint8))
+
+    assert masks.shape == (3, 16, 16)
+    assert masks[0].max() == 0 and masks[2].max() == 255
+    # The 128-valued middle file must come back binarized, not passed through.
+    assert set(np.unique(masks)).issubset({0, 255})
+    assert masks[1].max() == 255
+
+
+def test_precomputed_provider_rejects_a_count_mismatch(tmp_path: Path):
+    category_dir = tmp_path / "mvtec" / "screw"
+    category_dir.mkdir(parents=True)
+    Image.fromarray(np.zeros((16, 16), dtype=np.uint8)).save(category_dir / "000.png")
+
+    provider = PrecomputedMaskProvider(root=tmp_path, benchmark="mvtec")
+
+    with pytest.raises(ValueError, match="1 precomputed mask"):
+        provider.masks_for("mvtec__screw", np.zeros((3, 16, 16, 3), dtype=np.uint8))
+
+
+def test_mask_modes_route_listed_concepts_to_full_frame(tmp_path: Path):
+    # carpet is a texture: SAM returns no object mask, so it is pinned to the full frame while
+    # every other concept still goes to the configured backend.
+    config = _config(
+        tmp_path,
+        mask_backend="precomputed",
+        precomputed_mask_root=tmp_path / "sam",
+        mask_modes={"carpet": "full-frame"},
+    )
+    provider = build_mask_provider(config, benchmark="mvtec")
+    images = np.zeros((2, 16, 16, 3), dtype=np.uint8)
+
+    routed = provider.masks_for("mvtec__carpet", images)
+
+    assert np.all(routed == 255)
+    with pytest.raises(ValueError, match="No precomputed masks"):
+        provider.masks_for("mvtec__screw", images)
+
+
+def test_sam_backend_is_selected_without_importing_segment_anything(tmp_path: Path):
+    # Constructing the provider must not need the optional dependency; only masks_for() does.
+    config = _config(tmp_path, mask_backend="sam", sam_checkpoint=tmp_path / "sam_vit_h.pth")
+
+    provider = build_mask_provider(config, benchmark="mvtec")
+
+    assert isinstance(provider, SamMaskProvider)
+
+
+def test_augmentation_is_a_no_op_by_default(tmp_path: Path):
+    config = _config(tmp_path)
+    mask = np.zeros((16, 16), dtype=np.uint8)
+    mask[4:12, 4:12] = 255
+
+    assert np.array_equal(augment_mask(mask, config, np.random.default_rng(0)), mask)
+
+
+def test_paper_augmentation_rotates_and_shifts_deterministically(tmp_path: Path):
+    config = _config(tmp_path, mask_augmentation="paper")
+    mask = np.zeros((32, 32), dtype=np.uint8)
+    mask[8:24, 8:24] = 255
+
+    first = augment_mask(mask, config, np.random.default_rng(0))
+    again = augment_mask(mask, config, np.random.default_rng(0))
+    other = augment_mask(mask, config, np.random.default_rng(1))
+
+    assert np.array_equal(first, again)  # same seed -> same augmentation
+    assert not np.array_equal(first, other)
+    assert not np.array_equal(first, mask)
+    assert first.shape == mask.shape
+    assert set(np.unique(first)).issubset({0, 255})  # stays a binary mask
+
+
+def _two_blob_mask(size: int = 40) -> np.ndarray:
+    mask = np.zeros((size, size), dtype=np.uint8)
+    mask[10:18, 10:18] = 255
+    mask[size - 15 : size - 7, 5:9] = 255
+    return mask
+
+
+class _RecordingRng:
+    """Wraps a real ``Generator``, logging the arguments and result of every ``integers``/
+    ``uniform``/``choice`` call.
+
+    Some of the mask transforms' RNG bounds are off-by-one mutations away from a range whose
+    single missing value renders identically to a neighbour once drawn, rotated and binarized (for
+    example ``random_rotate``'s top-of-range angle 360 looks exactly like angle 0). No amount of
+    output-level comparison can distinguish those cases statistically without an impractical
+    number of samples, so a handful of tests below pin the exact bound passed to the RNG instead.
+    """
+
+    def __init__(self, rng: np.random.Generator):
+        self._rng = rng
+        self.calls: list[tuple] = []  # (method, low_or_a, high_or_None, result)
+
+    def integers(self, low, high=None, *args, **kwargs):
+        result = self._rng.integers(low, high, *args, **kwargs)
+        self.calls.append(("integers", low, high, result))
+        return result
+
+    def uniform(self, low=0.0, high=1.0, *args, **kwargs):
+        result = self._rng.uniform(low, high, *args, **kwargs)
+        self.calls.append(("uniform", low, high, result))
+        return result
+
+    def choice(self, a, *args, **kwargs):
+        result = self._rng.choice(a, *args, **kwargs)
+        self.calls.append(("choice", a, None, result))
+        return result
+
+    def integers_calls(self) -> list[tuple]:
+        return [(low, high) for method, low, high, _result in self.calls if method == "integers"]
+
+
+_CLASS_TRANSFORMS = {
+    "random_rotate": lambda mask, rng: random_rotate(mask, rng),
+    "random_3directions_rotate": lambda mask, rng: random_3directions_rotate(mask, rng),
+    "little_rotate_and_move": lambda mask, rng: little_rotate_and_move(mask, rng),
+    "visa_candle": lambda mask, rng: visa_candle(mask, rng),
+    "random_reset": lambda mask, rng: random_reset(mask, rng),
+}
+
+
+@pytest.mark.parametrize("name", _CLASS_TRANSFORMS)
+def test_class_transform_preserves_shape_dtype_and_binariness(name):
+    mask = _two_blob_mask()
+
+    result = _CLASS_TRANSFORMS[name](mask, np.random.default_rng(7))
+
+    assert result.shape == mask.shape
+    assert result.dtype == np.uint8
+    assert set(np.unique(result)).issubset({0, 255})
+
+
+@pytest.mark.parametrize("name", _CLASS_TRANSFORMS)
+def test_class_transform_is_deterministic_under_a_seed(name):
+    mask = _two_blob_mask()
+    transform = _CLASS_TRANSFORMS[name]
+
+    first = transform(mask, np.random.default_rng(11))
+    again = transform(mask, np.random.default_rng(11))
+
+    assert np.array_equal(first, again)
+
+
+def test_random_rotate_spins_in_place_without_shifting():
+    # The defining difference from little_rotate_and_move: a pure rotation about the mask's centre
+    # leaves an off-centre blob's distance from that centre unchanged, however the angle lands.
+    mask = np.zeros((40, 40), dtype=np.uint8)
+    mask[4:10, 4:10] = 255
+    image_center = np.array([19.5, 19.5])
+    original_radius = np.linalg.norm(np.argwhere(mask == 255).mean(axis=0) - image_center)
+
+    for seed in range(10):
+        rotated = random_rotate(mask, np.random.default_rng(seed))
+        radius = np.linalg.norm(np.argwhere(rotated == 255).mean(axis=0) - image_center)
+        assert radius == pytest.approx(original_radius, abs=2.0)
+
+
+def test_random_rotate_draws_the_angle_from_the_full_closed_degree_range():
+    # rng.integers is high-exclusive, so reaching 360 needs integers(0, 361). A dropped "+1" here
+    # would only ever cost the single value 360 -- which renders identically to a 0-degree
+    # rotation -- so pin the call bound directly instead of trying to observe it statistically.
+    spy = _RecordingRng(np.random.default_rng(0))
+
+    random_rotate(_two_blob_mask(), spy)
+
+    assert spy.integers_calls() == [(0, 361)]
+
+
+def test_random_rotate_produces_far_more_than_six_distinct_outcomes():
+    # Distinguishes it from a random_3directions_rotate body swap, which can only ever produce six
+    # outcomes (rotate 90/180/270, two flips, identity) no matter how many seeds are tried.
+    mask = np.zeros((40, 40), dtype=np.uint8)
+    mask[4:10, 4:14] = 255  # asymmetric blob: rotations by different angles rarely coincide
+
+    results = {tuple(random_rotate(mask, np.random.default_rng(seed)).flatten()) for seed in range(100)}
+
+    assert len(results) > 20
+
+
+def test_three_directions_rotate_returns_one_of_six_outcomes_including_identity():
+    mask = np.zeros((16, 16), dtype=np.uint8)
+    mask[2:6, 9:14] = 255  # asymmetric blob so all six outcomes are distinguishable
+    image = Image.fromarray(mask)
+    possible_outcomes = [
+        mask,
+        np.asarray(image.rotate(90), dtype=np.uint8),
+        np.asarray(image.rotate(180), dtype=np.uint8),
+        np.asarray(image.rotate(270), dtype=np.uint8),
+        np.asarray(image.transpose(Image.FLIP_LEFT_RIGHT), dtype=np.uint8),
+        np.asarray(image.transpose(Image.FLIP_TOP_BOTTOM), dtype=np.uint8),
+    ]
+
+    results = [random_3directions_rotate(mask, np.random.default_rng(seed)) for seed in range(30)]
+
+    for result in results:
+        assert any(np.array_equal(result, outcome) for outcome in possible_outcomes)
+    assert any(np.array_equal(result, mask) for result in results)  # identity does occur
+    assert any(not np.array_equal(result, mask) for result in results)  # but not always
+
+
+def test_little_rotate_and_move_moves_the_mask_only_slightly():
+    # Distinguishes it from visa_candle/random_reset, which can relocate a component anywhere.
+    mask = np.zeros((100, 100), dtype=np.uint8)
+    mask[45:55, 45:55] = 255
+    original_centroid = np.argwhere(mask == 255).mean(axis=0)
+    displacements = []
+
+    for seed in range(15):
+        moved = little_rotate_and_move(mask, np.random.default_rng(seed))
+        assert set(np.unique(moved)).issubset({0, 255})
+        displacements.append(np.linalg.norm(np.argwhere(moved == 255).mean(axis=0) - original_centroid))
+
+    # The default distance=0.05 on a 100px-wide mask caps the shift at int(100*0.05) = 5px.
+    assert max(displacements) <= 6.0
+    assert max(displacements) > 0  # it does actually move, not a no-op
+
+
+def test_little_rotate_and_move_draws_angle_and_magnitude_from_exact_bounds():
+    # A non-square mask, so a magnitude bound accidentally drawn against height rather than width
+    # cannot hide behind height == width, as it would with every other fixture in this file.
+    height, width = 100, 256
+    mask = np.zeros((height, width), dtype=np.uint8)
+    mask[40:60, 118:138] = 255
+    spy = _RecordingRng(np.random.default_rng(0))
+
+    little_rotate_and_move(mask, spy, angles=7, distance=0.05, transpose=False)
+
+    calls = spy.integers_calls()
+    assert (0, 8) in calls  # angle: integers(0, angles + 1), angles=7
+    # magnitude: integers(0, int(width * distance) + 1) = integers(0, int(256 * 0.05) + 1) =
+    # integers(0, 13) -- not round(256 * 0.05) + 1 = 14, and not int(height * distance) + 1 = 6.
+    assert (0, 13) in calls
+    assert (0, 6) not in calls
+    assert (0, 14) not in calls
+
+
+def test_little_rotate_and_move_rotates_both_ways():
+    # Distinguishes rng.choice([angle, 360 - angle]) from a mutant that always keeps `angle`,
+    # which would make every non-zero rotation land on the same side.
+    mask = np.zeros((120, 120), dtype=np.uint8)
+    mask[20:26, 70:90] = 255  # off-centre and elongated, so its centroid vector has a clear swing
+    center = np.array([59.5, 59.5])
+    original_vector = np.argwhere(mask == 255).mean(axis=0) - center
+
+    signs = set()
+    for seed in range(200):
+        # angles>0 with distance=0.0 isolates rotation: magnitude is always drawn from
+        # integers(0, int(width * 0.0) + 1) == integers(0, 1) == 0, so translation never applies.
+        result = little_rotate_and_move(mask, np.random.default_rng(seed), angles=8, distance=0.0, transpose=False)
+        vector = np.argwhere(result == 255).mean(axis=0) - center
+        cross = original_vector[0] * vector[1] - original_vector[1] * vector[0]
+        if abs(cross) > 1.0:  # skip angle in {0, 360}, which carries no rotation-sign information
+            signs.add(cross > 0)
+
+    assert signs == {True, False}
+
+
+def test_little_rotate_and_move_shift_reaches_exactly_int_width_times_distance():
+    # Task's own example: at 256px with distance=0.05, int() gives 12 where round() gives 13.
+    height, width = 100, 256
+    mask = np.zeros((height, width), dtype=np.uint8)
+    mask[45:55, 118:138] = 255  # a small blob near the centre, far from every edge
+    distance = 0.05
+    expected_bound = int(width * distance)
+    center = np.array([(height - 1) / 2, (width - 1) / 2])
+    original_vector = np.argwhere(mask == 255).mean(axis=0) - center
+
+    max_abs_shift = 0.0
+    for seed in range(300):
+        # angles=0 isolates translation: rng.choice([0, 360]) always picks a no-op rotation.
+        result = little_rotate_and_move(mask, np.random.default_rng(seed), angles=0, distance=distance)
+        vector = np.argwhere(result == 255).mean(axis=0) - center
+        displacement = vector - original_vector
+        max_abs_shift = max(max_abs_shift, abs(displacement[0]), abs(displacement[1]))
+
+    # Would read ~5 if the bound were mistakenly drawn against height (int(100 * 0.05) = 5) and
+    # ~13 if drawn with round() instead of int() (round(256 * 0.05) = 13) -- either a mutant this
+    # non-square mask is chosen specifically to expose.
+    assert max_abs_shift == pytest.approx(expected_bound, abs=0.5)
+
+
+def test_little_rotate_and_move_gives_a_180_degree_result_iff_transpose_is_set():
+    mask = _two_blob_mask()
+    rotated_180 = np.asarray(Image.fromarray(mask).rotate(180), dtype=np.uint8)
+
+    # angles=0, distance=0.0 isolate the transpose coin: with no other rotation or shift active,
+    # the only possible outcomes are the original mask or its 180-degree rotation.
+    with_transpose = [
+        little_rotate_and_move(mask, np.random.default_rng(seed), angles=0, distance=0.0, transpose=True)
+        for seed in range(30)
+    ]
+    without_transpose = [
+        little_rotate_and_move(mask, np.random.default_rng(seed), angles=0, distance=0.0, transpose=False)
+        for seed in range(30)
+    ]
+
+    assert any(np.array_equal(result, mask) for result in with_transpose)
+    assert any(np.array_equal(result, rotated_180) for result in with_transpose)
+    assert all(np.array_equal(result, mask) for result in without_transpose)
+    assert not any(np.array_equal(result, rotated_180) for result in without_transpose)
+
+
+def test_visa_candle_moves_exactly_one_component_and_leaves_the_other_untouched():
+    mask = np.zeros((100, 100), dtype=np.uint8)
+    mask[10:20, 10:20] = 255  # component A
+    mask[70:80, 70:80] = 255  # component B
+
+    result = visa_candle(mask, np.random.default_rng(0))
+
+    a_untouched = np.array_equal(result[10:20, 10:20], mask[10:20, 10:20])
+    b_untouched = np.array_equal(result[70:80, 70:80], mask[70:80, 70:80])
+    assert a_untouched != b_untouched  # exactly one component moved, not both or neither
+    # The moved component's own original footprint was erased, not just redrawn in place.
+    moved_original_area = mask[70:80, 70:80].sum() if not b_untouched else mask[10:20, 10:20].sum()
+    moved_remaining_area = result[70:80, 70:80].sum() if not b_untouched else result[10:20, 10:20].sum()
+    assert moved_remaining_area < moved_original_area
+    # Total foreground area is unchanged: the piece was relocated, not duplicated or dropped.
+    assert result.sum() == mask.sum()
+
+
+def test_visa_candle_shift_reaches_the_full_range_on_both_axes():
+    # A single component, well clear of the canvas edges, so a pure translation measurement is not
+    # confounded by clipping or by which of several components got chosen.
+    shift_pixels = 5
+    mask = np.zeros((60, 60), dtype=np.uint8)
+    mask[25:35, 25:35] = 255
+    center_before = np.argwhere(mask == 255).mean(axis=0)
+
+    dys, dxs = [], []
+    for seed in range(250):
+        result = visa_candle(mask, np.random.default_rng(seed), shift_pixels=shift_pixels, rotate=False)
+        center_after = np.argwhere(result == 255).mean(axis=0)
+        dy, dx = center_after - center_before
+        dys.append(dy)
+        dxs.append(dx)
+
+    assert max(dys) == pytest.approx(shift_pixels, abs=0.5)
+    assert min(dys) == pytest.approx(-shift_pixels, abs=0.5)
+    assert max(dxs) == pytest.approx(shift_pixels, abs=0.5)
+    assert min(dxs) == pytest.approx(-shift_pixels, abs=0.5)
+
+
+def test_visa_candle_shift_and_rotation_bounds_are_exact():
+    mask = _two_blob_mask()
+    spy = _RecordingRng(np.random.default_rng(0))
+
+    visa_candle(mask, spy, shift_pixels=5, rotate=True)
+
+    # dy and dx are each drawn from integers(-shift_pixels, shift_pixels + 1); a mutant dropping
+    # the "+1" would cost only the single value +shift_pixels, which the shift-range test above
+    # would need an impractical sample count to catch statistically -- pin the bound directly.
+    assert spy.integers_calls().count((-5, 6)) == 2
+    uniform_calls = [(low, high) for method, low, high, _result in spy.calls if method == "uniform"]
+    assert uniform_calls == [(-10.0, 10.0)]
+
+
+def test_random_reset_preserves_the_number_of_connected_components():
+    mask = np.zeros((64, 64), dtype=np.uint8)
+    mask[4:8, 4:8] = 255
+    mask[4:8, 30:34] = 255
+    mask[40:44, 10:14] = 255
+    _, components_before = ndimage.label(mask >= 128)
+
+    result = random_reset(mask, np.random.default_rng(1))
+
+    _, components_after = ndimage.label(result >= 128)
+    assert components_before == components_after == 3
+    assert result.sum() == mask.sum()  # every component was relocated whole, not clipped
+    assert not np.array_equal(result, mask)  # and actually moved
+
+
+def test_random_reset_relocates_every_component_not_just_one():
+    # Distinguishes it from visa_candle, which moves exactly one component and leaves the rest
+    # untouched (see test_visa_candle_moves_exactly_one_component_and_leaves_the_other_untouched
+    # above) -- the two functions have compatible (mask, rng) signatures, so a body swap between
+    # them would otherwise go undetected.
+    mask = np.zeros((64, 64), dtype=np.uint8)
+    mask[4:8, 4:8] = 255  # component A
+    mask[4:8, 30:34] = 255  # component B
+    mask[40:44, 50:54] = 255  # component C
+    original_boxes = [(4, 4), (4, 30), (40, 50)]
+
+    for seed in range(10):
+        result = random_reset(mask, np.random.default_rng(seed))
+        untouched = sum(
+            np.array_equal(result[y : y + 4, x : x + 4], mask[y : y + 4, x : x + 4]) for y, x in original_boxes
+        )
+        # visa_candle would structurally leave exactly 2 of the 3 components untouched; genuine
+        # random_reset relocates every component (a coincidental round-trip to the same 4x4 spot
+        # on a 64x64 canvas is astronomically unlikely).
+        assert untouched <= 1
+
+
+def test_random_reset_relies_on_the_full_100_placement_attempts():
+    # A canvas tight enough that a single random placement collides with an already-placed
+    # component a substantial fraction of the time, so success is only reliable with the
+    # documented 100 retries per component -- not with one attempt.
+    mask = np.zeros((20, 20), dtype=np.uint8)
+    mask[2:8, 2:8] = 255  # component A: 6x6, placed first, always succeeds into an empty canvas
+    mask[12:18, 12:18] = 255  # component B: 6x6, must avoid A
+    total_area = int(mask.sum())
+
+    drops = sum(1 for seed in range(60) if int(random_reset(mask, np.random.default_rng(seed)).sum()) != total_area)
+
+    assert drops <= 2  # a 1-attempt mutant drops component B roughly a third of the time
+
+
+def test_augment_mask_dispatches_the_five_class_transforms(tmp_path: Path):
+    mask = _two_blob_mask()
+    for mode in _CLASS_TRANSFORMS:
+        config = _config(tmp_path, mask_augmentation=mode)
+
+        direct = _CLASS_TRANSFORMS[mode](mask, np.random.default_rng(3))
+        via_dispatch = augment_mask(mask, config, np.random.default_rng(3))
+
+        assert np.array_equal(direct, via_dispatch)
+
+
+def test_augment_mask_passes_little_rotate_and_move_parameters_through(tmp_path: Path):
+    config = _config(
+        tmp_path,
+        mask_augmentation="little_rotate_and_move",
+        mask_transform_angles=10,
+        mask_transform_distance=0.1,
+        mask_transform_transpose=True,
+    )
+    mask = _two_blob_mask(64)
+
+    direct = little_rotate_and_move(mask, np.random.default_rng(4), angles=10, distance=0.1, transpose=True)
+    via_dispatch = augment_mask(mask, config, np.random.default_rng(4))
+
+    assert np.array_equal(direct, via_dispatch)
+
+
+def test_augment_mask_passes_visa_candle_parameters_through(tmp_path: Path):
+    config = _config(tmp_path, mask_augmentation="visa_candle", visa_candle_shift_pixels=5, visa_candle_rotate=True)
+    mask = _two_blob_mask(64)
+
+    direct = visa_candle(mask, np.random.default_rng(2), shift_pixels=5, rotate=True)
+    via_dispatch = augment_mask(mask, config, np.random.default_rng(2))
+
+    assert np.array_equal(direct, via_dispatch)
+
+
+@pytest.mark.parametrize("mode", ["rotate_180", "rotate_3_directions", "rotate_all_directions"])
+def test_training_augmentation_moves_image_and_mask_together(mode):
+    image = np.zeros((32, 32, 3), dtype=np.uint8)
+    image[4:12, 4:12] = 200
+    mask = np.zeros((32, 32), dtype=np.uint8)
+    mask[4:12, 4:12] = 255
+
+    aug_image, aug_mask = augment_training_pair(image, mask, mode, np.random.default_rng(2))
+
+    assert aug_image.shape == image.shape
+    assert aug_mask.shape == mask.shape
+    # The bright square and the mask square must land in the same place, or the spatial condition
+    # would no longer describe the image it is paired with.
+    assert np.array_equal(aug_image[..., 0] > 100, aug_mask > 128)
+
+
+def test_training_augmentation_is_a_no_op_when_disabled():
+    image = np.full((8, 8, 3), 7, dtype=np.uint8)
+    mask = np.full((8, 8), 255, dtype=np.uint8)
+
+    aug_image, aug_mask = augment_training_pair(image, mask, "none", np.random.default_rng(0))
+
+    assert np.array_equal(aug_image, image)
+    assert np.array_equal(aug_mask, mask)
+
+
+def test_rotate_all_directions_fills_with_the_border_mean_and_black():
+    # personalized.py:255-277 fills the rotated image with the mean colour of four 20px border
+    # strips and the rotated mask with black.
+    image = np.zeros((64, 64, 3), dtype=np.uint8)
+    image[:, :, 0] = 240  # uniform red border and interior -> mean fill is (240, 0, 0)
+    mask = np.full((64, 64), 255, dtype=np.uint8)
+
+    aug_image, aug_mask = augment_training_pair(image, mask, "rotate_all_directions", np.random.default_rng(5))
+
+    corner_image, corner_mask = aug_image[0, 0], aug_mask[0, 0]
+    assert corner_mask == 0 or np.array_equal(aug_mask, mask)  # black fill unless the angle was 0
+    assert corner_image[0] >= 200  # filled from the red border mean, not black
+
+
+def test_training_augmentation_is_reproducible_under_a_seed():
+    image = np.random.default_rng(0).integers(0, 256, (32, 32, 3), dtype=np.uint8)
+    mask = np.zeros((32, 32), dtype=np.uint8)
+    mask[8:20, 8:20] = 255
+
+    first = augment_training_pair(image, mask, "rotate_all_directions", np.random.default_rng(9))
+    again = augment_training_pair(image, mask, "rotate_all_directions", np.random.default_rng(9))
+
+    assert np.array_equal(first[0], again[0]) and np.array_equal(first[1], again[1])
+
+
+def test_stored_mask_selection_is_capped_and_reproducible():
+    masks = np.stack([np.full((8, 8), value, dtype=np.uint8) for value in range(20)])
+
+    first = select_stored_masks(masks, count=10, rng=np.random.default_rng(3))
+    again = select_stored_masks(masks, count=10, rng=np.random.default_rng(3))
+
+    assert first.shape == (10, 8, 8)
+    assert np.array_equal(first, again)
+
+
+def test_stored_mask_selection_handles_fewer_masks_than_requested():
+    masks = np.stack([np.zeros((8, 8), dtype=np.uint8) for _ in range(3)])
+
+    assert select_stored_masks(masks, count=10, rng=np.random.default_rng(0)).shape == (3, 8, 8)

--- a/tests/vision/strategies/replaycad/test_memory.py
+++ b/tests/vision/strategies/replaycad/test_memory.py
@@ -1,0 +1,149 @@
+import numpy as np
+import pytest
+
+from pyclad.vision.strategies.replaycad.artifacts import load_artifact
+from pyclad.vision.strategies.replaycad.memory import ReplayCADMemory
+
+
+def _images(count: int = 4) -> np.ndarray:
+    return np.random.default_rng(0).integers(0, 256, size=(count, 8, 8, 3), dtype=np.uint8)
+
+
+class _ExplodingMaskProvider:
+    """A mask provider that fails loudly if it is ever asked for masks."""
+
+    def masks_for(self, concept_id, images):
+        raise AssertionError(f"masks_for('{concept_id}') should not be called when spatial conditioning is off")
+
+
+def test_compress_writes_an_artifact(replaycad_config, stub_backend):
+    config = replaycad_config()
+    memory = ReplayCADMemory(config=config, backend=stub_backend(config), benchmark="mvtec")
+
+    memory.compress("mvtec__screw", _images())
+
+    artifact = load_artifact("mvtec__screw", config.artifact_dir / "mvtec")
+    assert artifact is not None
+    assert artifact.embedding.shape == (config.semantic_tokens, config.condition_dim)
+    assert len(artifact.masks) == config.masks_per_concept
+    assert memory.known_concepts() == ["mvtec__screw"]
+
+
+def test_second_run_reuses_the_cached_artifact(replaycad_config, stub_backend):
+    config = replaycad_config()
+    backend = stub_backend(config)
+    ReplayCADMemory(config=config, backend=backend, benchmark="mvtec").compress("mvtec__screw", _images())
+
+    fresh_backend = stub_backend(config)
+    ReplayCADMemory(config=config, backend=fresh_backend, benchmark="mvtec").compress("mvtec__screw", _images())
+
+    assert fresh_backend.compress_calls == []  # cache hit: stage 1 not re-run
+
+
+def test_changed_compression_config_recompresses(replaycad_config, stub_backend, caplog):
+    first = replaycad_config()
+    ReplayCADMemory(config=first, backend=stub_backend(first), benchmark="mvtec").compress("mvtec__screw", _images())
+
+    second = replaycad_config(compression_steps=3)
+    backend = stub_backend(second)
+    with caplog.at_level("WARNING"):
+        ReplayCADMemory(config=second, backend=backend, benchmark="mvtec").compress("mvtec__screw", _images())
+
+    assert backend.compress_calls == ["mvtec__screw"]
+    assert "config_hash" in caplog.text
+
+
+def test_strict_cache_raises_on_a_hash_mismatch(replaycad_config, stub_backend):
+    first = replaycad_config()
+    ReplayCADMemory(config=first, backend=stub_backend(first), benchmark="mvtec").compress("mvtec__screw", _images())
+
+    second = replaycad_config(compression_steps=3, strict_cache=True)
+    memory = ReplayCADMemory(config=second, backend=stub_backend(second), benchmark="mvtec")
+
+    with pytest.raises(ValueError, match="strict_cache"):
+        memory.compress("mvtec__screw", _images())
+
+
+def test_generate_previous_covers_every_known_concept(replaycad_config, stub_backend):
+    config = replaycad_config(replay_samples_per_concept=3)
+    backend = stub_backend(config)
+    memory = ReplayCADMemory(config=config, backend=backend, benchmark="mvtec")
+    memory.compress("mvtec__screw", _images())
+    memory.compress("mvtec__pill", _images())
+
+    replay = memory.generate_previous()
+
+    assert replay.shape == (6, config.resolution, config.resolution, 3)
+    assert [call[0] for call in backend.generate_calls] == ["mvtec__screw", "mvtec__pill"]
+    assert all(call[1] == 3 for call in backend.generate_calls)
+
+
+def test_artifacts_are_stored_under_their_benchmark(replaycad_config, stub_backend):
+    # Two benchmarks sharing one artifact_dir must not collide on a common category name.
+    config = replaycad_config()
+    ReplayCADMemory(config=config, backend=stub_backend(config), benchmark="mvtec").compress("screw", _images())
+    ReplayCADMemory(config=config, backend=stub_backend(config), benchmark="btech").compress("screw", _images())
+
+    assert (config.artifact_dir / "mvtec" / "screw" / "meta.json").is_file()
+    assert (config.artifact_dir / "btech" / "screw" / "meta.json").is_file()
+
+
+def test_a_benchmark_gets_its_own_cache(replaycad_config, stub_backend):
+    config = replaycad_config()
+    ReplayCADMemory(config=config, backend=stub_backend(config), benchmark="mvtec").compress("screw", _images())
+
+    other = stub_backend(config)
+    ReplayCADMemory(config=config, backend=other, benchmark="btech").compress("screw", _images())
+
+    # Same concept name, same config, different benchmark: this must be a miss, not a hit.
+    assert other.compress_calls == ["screw"]
+
+
+def test_generate_previous_is_empty_before_any_compression(replaycad_config, stub_backend):
+    config = replaycad_config()
+    memory = ReplayCADMemory(config=config, backend=stub_backend(config), benchmark="mvtec")
+
+    assert len(memory.generate_previous()) == 0
+
+
+def test_generation_seed_differs_per_concept_but_is_reproducible(replaycad_config, stub_backend):
+    config = replaycad_config()
+    backend = stub_backend(config)
+    memory = ReplayCADMemory(config=config, backend=backend, benchmark="mvtec")
+    memory.compress("mvtec__screw", _images())
+    memory.compress("mvtec__pill", _images())
+
+    first = memory.generate_previous()
+    seeds = [call[2] for call in backend.generate_calls]
+    second = memory.generate_previous()
+
+    assert seeds[0] != seeds[1]  # otherwise both concepts replay identical noise
+    assert np.array_equal(first, second)
+
+
+def test_masks_are_not_computed_when_spatial_conditioning_is_off(replaycad_config, stub_backend):
+    """For semantic-only classes with mask_backend='sam', computing masks at all would be a full
+    vit_h pass over every training image whose output the backend then ignores. The mask provider
+    must not even be called, and compression must still succeed with the zero-length array that
+    replaces it.
+    """
+    config = replaycad_config(use_spatial_conditioning=False)
+    memory = ReplayCADMemory(
+        config=config, backend=stub_backend(config), benchmark="mvtec", mask_provider=_ExplodingMaskProvider()
+    )
+
+    memory.compress("mvtec__capsules", _images())  # must not raise
+
+    artifact = load_artifact("mvtec__capsules", config.artifact_dir / "mvtec")
+    assert artifact is not None
+    assert artifact.masks.shape[0] == 0
+    assert memory.known_concepts() == ["mvtec__capsules"]
+
+
+def test_release_is_forwarded_to_the_backend(replaycad_config, stub_backend):
+    config = replaycad_config()
+    backend = stub_backend(config)
+
+    ReplayCADMemory(config=config, backend=backend, benchmark="mvtec").release_device_memory()
+
+    assert backend.release_calls == 1

--- a/tests/vision/strategies/replaycad/test_memory.py
+++ b/tests/vision/strategies/replaycad/test_memory.py
@@ -147,3 +147,12 @@ def test_release_is_forwarded_to_the_backend(replaycad_config, stub_backend):
     ReplayCADMemory(config=config, backend=backend, benchmark="mvtec").release_device_memory()
 
     assert backend.release_calls == 1
+
+
+@pytest.mark.parametrize("benchmark", ["", "   "])
+def test_an_empty_benchmark_is_rejected(replaycad_config, stub_backend, benchmark):
+    """The artifact root is the only thing separating two datasets under one artifact_dir."""
+    config = replaycad_config()
+
+    with pytest.raises(ValueError, match="non-empty benchmark"):
+        ReplayCADMemory(config=config, backend=stub_backend(config), benchmark=benchmark)

--- a/tests/vision/strategies/replaycad/test_per_class.py
+++ b/tests/vision/strategies/replaycad/test_per_class.py
@@ -1,0 +1,195 @@
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from pyclad.vision.strategies.replaycad.config import ReplayCADConfig
+from pyclad.vision.strategies.replaycad.per_class import (
+    AUTHORS_OVERRIDES,
+    apply_per_class,
+)
+
+
+def _base(benchmark: str) -> ReplayCADConfig:
+    return ReplayCADConfig.for_benchmark(benchmark, artifact_dir=Path("/tmp/a"), mask_backend="full-frame")
+
+
+def test_every_released_class_is_covered():
+    assert len(AUTHORS_OVERRIDES["mvtec"]) == 14
+    assert len(AUTHORS_OVERRIDES["visa"]) == 11
+
+
+def test_mvtec_texture_classes_use_low_guidance():
+    config = apply_per_class(_base("mvtec"), "mvtec__carpet", benchmark="mvtec")
+
+    assert config.guidance_scale == 1.0
+    assert config.compression_steps == 9999
+    assert config.replay_samples_per_concept == 200
+    assert config.initializer_word == "screw"
+
+
+def test_grid_uses_the_three_direction_augmentation_and_scale_five():
+    config = apply_per_class(_base("mvtec"), "grid", benchmark="mvtec")
+
+    assert config.guidance_scale == 5.0
+    assert config.replay_samples_per_concept == 800
+    assert config.train_augmentation == "rotate_3_directions"
+
+
+def test_applying_an_override_still_validates_the_shapes(monkeypatch):
+    """The published table is self-consistent, so this injects an override that genuinely breaks."""
+    from pyclad.vision.strategies.replaycad import per_class as module
+
+    original_profile_fields = module._profile_fields
+
+    def broken_profile(profile, wide_projection):
+        fields = original_profile_fields(profile, wide_projection)
+        fields["mask_projection_width"] = 196  # 196 does not divide into 768-wide tokens
+        return fields
+
+    monkeypatch.setattr(module, "_profile_fields", broken_profile)
+
+    # model_copy() would let this through silently; model_validate() must not.
+    with pytest.raises(ValidationError, match="conditioning tokens"):
+        apply_per_class(_base("visa"), "visa__pcb1", benchmark="visa")
+
+
+def test_the_two_unmasked_visa_classes_keep_their_own_training_recipe():
+    # capsules and macaroni2 used the stock textual-inversion configs: 40 vectors, base lr 5e-3,
+    # and a single-group optimizer with no multiplier on the embedding.
+    for concept in ("visa__capsules", "visa__macaroni2"):
+        config = apply_per_class(_base("visa"), concept, benchmark="visa")
+
+        assert config.semantic_tokens == 40
+        assert config.base_learning_rate == pytest.approx(5e-3)
+        assert config.semantic_lr_multiplier == pytest.approx(1.0)
+        assert config.semantic_learning_rate == pytest.approx(config.spatial_learning_rate)
+
+    # Everything else keeps the mask-conditioned recipe.
+    pcb1 = apply_per_class(_base("visa"), "visa__pcb1", benchmark="visa")
+    assert (pcb1.semantic_tokens, pcb1.semantic_lr_multiplier) == (20, 100.0)
+
+
+def test_capsules_training_augmentation_matches_its_config():
+    # v1-finetune.yaml sets rotate_180: true; macaroni2's config has no such key.
+    assert AUTHORS_OVERRIDES["visa"]["capsules"].train_augmentation == "rotate_180"
+    assert AUTHORS_OVERRIDES["visa"]["macaroni2"].train_augmentation == "none"
+
+
+def test_visa_mixes_diffusion_families():
+    sd = apply_per_class(_base("visa"), "visa__pcb1", benchmark="visa")
+    ldm = apply_per_class(_base("visa"), "visa__candle", benchmark="visa")
+
+    assert sd.profile == "sd-512" and sd.resolution == 512 and sd.condition_dim == 768
+    assert ldm.profile == "ldm-256" and ldm.resolution == 256 and ldm.condition_dim == 1280
+
+
+def test_wide_projection_classes():
+    pcb4 = apply_per_class(_base("visa"), "visa__pcb4", benchmark="visa")
+
+    assert (pcb4.mask_group_width, pcb4.mask_projection_width) == (512, 192)
+    assert pcb4.spatial_tokens == 8
+
+
+def test_cubic_timestep_sampling_only_for_the_lifang_configs():
+    assert apply_per_class(_base("visa"), "pcb1", benchmark="visa").timestep_sampling == "cubic"
+    assert apply_per_class(_base("visa"), "fryum", benchmark="visa").timestep_sampling == "cubic"
+    # chewinggum omits average_t and cashew sets it to true, so both stay uniform.
+    assert apply_per_class(_base("visa"), "chewinggum", benchmark="visa").timestep_sampling == "uniform"
+    assert apply_per_class(_base("visa"), "cashew", benchmark="visa").timestep_sampling == "uniform"
+    assert apply_per_class(_base("mvtec"), "screw", benchmark="mvtec").timestep_sampling == "uniform"
+
+
+def test_semantic_only_classes_disable_spatial_conditioning():
+    for concept in ("visa__macaroni2", "visa__capsules"):
+        config = apply_per_class(_base("visa"), concept, benchmark="visa")
+        assert config.use_spatial_conditioning is False
+
+
+def test_classes_missing_from_the_scripts_fall_back_with_a_warning(caplog):
+    with caplog.at_level("WARNING"):
+        mvtec = apply_per_class(_base("mvtec"), "mvtec__zipper", benchmark="mvtec")
+        visa = apply_per_class(_base("visa"), "visa__pipe_fryum", benchmark="visa")
+
+    assert mvtec.compression_steps == 20_000  # dataset default
+    assert visa.compression_steps == 30_000
+    assert "zipper" in caplog.text and "pipe_fryum" in caplog.text
+
+
+def test_unknown_benchmark_returns_the_config_unchanged():
+    base = _base("mvtec")
+
+    assert apply_per_class(base, "btech__01", benchmark="btech") is base
+
+
+def test_multidataset_names_resolve_on_the_category():
+    prefixed = apply_per_class(_base("mvtec"), "mvtec-ad__screw", benchmark="mvtec")
+    bare = apply_per_class(_base("mvtec"), "screw", benchmark="mvtec")
+
+    assert prefixed.compression_steps == bare.compression_steps == 19999
+
+
+def test_mask_augmentation_matches_the_generation_dispatch_scripts():
+    # txt2img_with_mask.py: class_name in ["metal_nut","screw","fryum","hazelnut"] -> random_rorate
+    for concept in ("metal_nut", "screw", "hazelnut"):
+        assert apply_per_class(_base("mvtec"), concept, benchmark="mvtec").mask_augmentation == "random_rotate"
+    assert apply_per_class(_base("visa"), "fryum", benchmark="visa").mask_augmentation == "random_rotate"
+
+    # class_name in ["grid"] -> random_3direcions_rotate
+    assert apply_per_class(_base("mvtec"), "grid", benchmark="mvtec").mask_augmentation == "random_3directions_rotate"
+
+    # transistor -> little_rorate_and_move() with every default
+    transistor = apply_per_class(_base("mvtec"), "transistor", benchmark="mvtec")
+    assert transistor.mask_augmentation == "little_rotate_and_move"
+    assert (
+        transistor.mask_transform_angles,
+        transistor.mask_transform_distance,
+        transistor.mask_transform_transpose,
+    ) == (
+        2,
+        0.05,
+        False,
+    )
+
+    # cashew -> little_rorate_and_move(angles=10)
+    cashew = apply_per_class(_base("visa"), "cashew", benchmark="visa")
+    assert (cashew.mask_augmentation, cashew.mask_transform_angles) == ("little_rotate_and_move", 10)
+
+    # chewinggum -> little_rorate_and_move(distance=0.1, tranpose=True)
+    chewinggum = apply_per_class(_base("visa"), "chewinggum", benchmark="visa")
+    assert chewinggum.mask_augmentation == "little_rotate_and_move"
+    assert (chewinggum.mask_transform_distance, chewinggum.mask_transform_transpose) == (0.1, True)
+
+    # pcb1/pcb2/pcb3 -> little_rorate_and_move(distance=0.02, tranpose=True); pcb4 without tranpose
+    for concept in ("pcb1", "pcb2", "pcb3"):
+        pcb = apply_per_class(_base("visa"), concept, benchmark="visa")
+        assert pcb.mask_augmentation == "little_rotate_and_move"
+        assert (pcb.mask_transform_distance, pcb.mask_transform_transpose) == (0.02, True)
+    pcb4 = apply_per_class(_base("visa"), "pcb4", benchmark="visa")
+    assert pcb4.mask_augmentation == "little_rotate_and_move"
+    assert (pcb4.mask_transform_distance, pcb4.mask_transform_transpose) == (0.02, False)
+
+    # candle -> visa_candle(); macaroni1 -> visa_candle(rotate=True)
+    candle = apply_per_class(_base("visa"), "candle", benchmark="visa")
+    assert (candle.mask_augmentation, candle.visa_candle_shift_pixels, candle.visa_candle_rotate) == (
+        "visa_candle",
+        20,
+        False,
+    )
+    macaroni1 = apply_per_class(_base("visa"), "macaroni1", benchmark="visa")
+    assert (macaroni1.mask_augmentation, macaroni1.visa_candle_rotate) == ("visa_candle", True)
+
+    # class_name in [...] -> pass (no transform at all)
+    for concept in ("bottle", "cable", "capsule", "carpet", "leather", "pill", "toothbrush", "wood", "tile"):
+        assert apply_per_class(_base("mvtec"), concept, benchmark="mvtec").mask_augmentation == "none"
+
+
+def test_capsules_and_macaroni2_never_receive_a_mask_transform():
+    # Both generate through the plain, maskless scripts (stable_txt2img.py / txt2img.py, per
+    # generate_visa.sh), so neither ever reaches txt2img_with_mask.py / stable_txt2img_with_mask.py
+    # and no generation-time mask transform is ever applied -- matching their
+    # use_spatial_conditioning=False above. This holds regardless of the two release dispatchers'
+    # own dead, mutually-contradictory macaroni2 branches (random_reset vs. random_rotate).
+    for concept in ("visa__capsules", "visa__macaroni2"):
+        config = apply_per_class(_base("visa"), concept, benchmark="visa")
+        assert config.mask_augmentation == "none"

--- a/tests/vision/strategies/replaycad/test_real_diffusion.py
+++ b/tests/vision/strategies/replaycad/test_real_diffusion.py
@@ -1,0 +1,153 @@
+"""End-to-end smoke test for ReplayCADStrategy against a real ``diffusers`` pipeline.
+
+Every other test in this suite drives :class:`DiffusersBackend` through the in-memory
+``StubDiffusionBackend`` (see ``conftest.py``). That stub returns tensors and images shaped
+exactly like the real backend's, but it never calls into ``diffusers``/``transformers`` -- it
+cannot catch a wrong component attribute name, an unsupported ``resize_token_embeddings`` call, a
+renamed scheduler keyword argument, or a VAE that reshapes differently than assumed. This test
+runs the real backend against a genuine, few-MB Stable-Diffusion-shaped pipeline instead, so those
+assumptions get checked at least once.
+
+It downloads that pipeline from the Hugging Face Hub on first run (cached afterwards), so it is
+marked ``longrun`` and stays out of the default suite -- run it with ``pytest --longrun``.
+
+A green result verifies the API contract, not the quality of the method: the pipeline is
+Stable-Diffusion-shaped, so the LDM-256 path is exercised only by the unit-level stubs in
+``test_backend_contract.py``, and no number from the paper is reproduced here.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyclad.vision.models.patchcore.config import PatchCoreConfig
+from pyclad.vision.models.patchcore.patchcore import PatchCore
+from pyclad.vision.strategies.replaycad.artifacts import load_artifact
+from pyclad.vision.strategies.replaycad.backend import DiffusersBackend
+from pyclad.vision.strategies.replaycad.config import ReplayCADConfig
+from pyclad.vision.strategies.replaycad.memory import ReplayCADMemory
+from pyclad.vision.strategies.replaycad.strategy import ReplayCADStrategy
+
+# hf-internal-testing/tiny-stable-diffusion-pipe -- the brief's suggested first choice -- publishes
+# only Flax weights (FlaxCLIPTextModel, FlaxUNet2DConditionModel, FlaxAutoencoderKL) under a
+# `_class_name` of "StableDiffusionPipeline". Loading it through installed diffusers 0.40 fails
+# before any pyCLAD code runs: `AttributeError: module diffusers.pipelines.stable_diffusion has no
+# attribute FlaxStableDiffusionSafetyChecker`. diffusers/tiny-stable-diffusion-torch is diffusers'
+# own torch-native counterpart in the same "tiny-*" test-fixture family (published under the
+# `diffusers` org itself, for this exact purpose) and loads cleanly, so it is used instead.
+MODEL_ID = "diffusers/tiny-stable-diffusion-torch"
+
+# True dimensions read from the loaded pipeline (`pipe = DiffusionPipeline.from_pretrained(MODEL_ID,
+# safety_checker=None)`), not assumed -- see task-12-report.md Step 2 for the full transcript:
+#   pipe.unet.config.cross_attention_dim -> 32
+#   pipe.unet.config.sample_size         -> 64 (StableDiffusionPipeline.__init__ floors any
+#                                          checkpoint's sample_size to 64; the raw unet/config.json
+#                                          on the Hub says 32, but 64 is what the loaded pipeline
+#                                          object -- what backend.py actually sees -- reports)
+#   pipe.unet.config.in_channels         -> 4
+#   sorted(pipe.components)              -> feature_extractor, image_encoder, safety_checker,
+#                                            scheduler, text_encoder, tokenizer, unet, vae
+CONDITION_DIM = 32
+RESOLUTION = 64
+
+# mask_group_width=64, mask_projection_width=32 divide the *configured* latent arithmetic exactly,
+# matching the brief's own worked example: latent_size = (64 // 8) ** 2 * 4 = 256; 256 / 64 = 4
+# rows; 4 * 32 = 128; 128 / 32 = 4 spatial tokens. Nothing at runtime depends on that token count
+# being accurate (MaskProjection reshapes whatever it is actually given), which is fortunate: this
+# tiny VAE only has two down-sampling blocks and empirically halves resolution instead of the
+# standard LDM/SD eighth, so the *real* per-mask latent has 4x the elements this arithmetic assumes.
+# See "What remains unverified" in task-12-report.md.
+MASK_GROUP_WIDTH = 64
+MASK_PROJECTION_WIDTH = 32
+
+
+class RecordingPatchCore(PatchCore):
+    """Records how many images each ``fit`` call receives, without instrumenting production code."""
+
+    def __init__(self, config: PatchCoreConfig):
+        super().__init__(config)
+        self.fit_sizes: list[int] = []
+
+    def fit(self, data: np.ndarray) -> None:
+        self.fit_sizes.append(len(data))
+        super().fit(data)
+
+
+def _images(count: int, seed: int) -> np.ndarray:
+    return np.random.default_rng(seed).integers(0, 256, size=(count, RESOLUTION, RESOLUTION, 3), dtype=np.uint8)
+
+
+def _replaycad_config(tmp_path) -> ReplayCADConfig:
+    return ReplayCADConfig(
+        profile="ldm-256",
+        model_id=MODEL_ID,
+        resolution=RESOLUTION,
+        condition_dim=CONDITION_DIM,
+        semantic_tokens=2,
+        mask_group_width=MASK_GROUP_WIDTH,
+        mask_projection_width=MASK_PROJECTION_WIDTH,
+        compression_steps=2,
+        compression_batch_size=2,
+        learning_rate_scale=1,
+        inference_steps=2,
+        replay_samples_per_concept=2,
+        generation_batch_size=2,
+        masks_per_concept=1,
+        mask_backend="full-frame",
+        artifact_dir=tmp_path,
+        device="cpu",
+        torch_dtype="float32",
+    )
+
+
+def _detector() -> RecordingPatchCore:
+    # Small and untrained, matching tests/vision/models/test_patchcore.py's own pattern: this test
+    # is about ReplayCAD's diffusion plumbing, not PatchCore's detection quality, and an untrained
+    # resnet18 needs no download of its own.
+    config = PatchCoreConfig(
+        input_size=(32, 32),
+        batch_size=4,
+        backbone_name="resnet18",
+        pretrained_backbone=False,
+        coreset_sampling_ratio=1.0,
+        pretrain_embed_dimension=32,
+        target_embed_dimension=32,
+        device="cpu",
+        seed=0,
+    )
+    return RecordingPatchCore(config)
+
+
+@pytest.mark.longrun
+def test_replaycad_trains_generates_and_detects_on_a_real_diffusion_pipeline(tmp_path):
+    config = _replaycad_config(tmp_path)
+    memory = ReplayCADMemory(config=config, backend=DiffusersBackend(config))
+    detector = _detector()
+    strategy = ReplayCADStrategy(detector, memory)
+
+    first_images = _images(2, seed=1)
+    strategy.learn(first_images, concept_id="screw")
+
+    second_images = _images(2, seed=2)
+    strategy.learn(second_images, concept_id="pill")
+
+    # The first concept has nothing to replay; the second trains on screw's replay plus pill's own
+    # images -- the whole reason ReplayCAD exists.
+    assert detector.fit_sizes[0] == 2
+    assert detector.fit_sizes[1] == config.replay_samples_per_concept + 2
+
+    for concept_id in ("screw", "pill"):
+        concept_dir = tmp_path / concept_id
+        assert (concept_dir / "embedding.pt").is_file()
+        assert (concept_dir / "projection.pt").is_file()
+
+    artifact = load_artifact("pill", tmp_path)
+    assert artifact is not None
+    assert artifact.embedding.shape == (config.semantic_tokens, config.condition_dim)
+
+    result = strategy.predict(second_images, concept_id="pill")
+    assert result.anomaly_scores.shape == (2,)
+    assert np.all(np.isfinite(result.anomaly_scores))
+    assert result.score_maps.shape == (2, RESOLUTION, RESOLUTION)
+    assert np.all(np.isfinite(result.score_maps))

--- a/tests/vision/strategies/replaycad/test_real_diffusion.py
+++ b/tests/vision/strategies/replaycad/test_real_diffusion.py
@@ -122,7 +122,7 @@ def _detector() -> RecordingPatchCore:
 @pytest.mark.longrun
 def test_replaycad_trains_generates_and_detects_on_a_real_diffusion_pipeline(tmp_path):
     config = _replaycad_config(tmp_path)
-    memory = ReplayCADMemory(config=config, backend=DiffusersBackend(config))
+    memory = ReplayCADMemory(config=config, backend=DiffusersBackend(config), benchmark="mvtec")
     detector = _detector()
     strategy = ReplayCADStrategy(detector, memory)
 

--- a/tests/vision/strategies/replaycad/test_spatial.py
+++ b/tests/vision/strategies/replaycad/test_spatial.py
@@ -1,0 +1,56 @@
+import pytest
+import torch
+
+from pyclad.vision.strategies.replaycad.spatial import (
+    MaskProjection,
+    spatial_token_count,
+)
+
+
+@pytest.mark.parametrize(
+    "latent_size, group, projection, condition_dim, expected",
+    [
+        (32 * 32 * 4, 128, 200, 1280, 5),  # MVTec / LDM-256
+        (64 * 64 * 4, 128, 192, 768, 32),  # VisA / SD-512
+        (64 * 64 * 4, 512, 192, 768, 8),  # released pcb4 / fryum wide projection
+    ],
+)
+def test_token_counts_match_the_reference_shapes(latent_size, group, projection, condition_dim, expected):
+    assert spatial_token_count(latent_size, group, projection, condition_dim) == expected
+
+
+def test_projection_maps_latents_to_condition_tokens():
+    projection = MaskProjection(group_width=128, projection_width=200, condition_dim=1280)
+
+    tokens = projection(torch.zeros(3, 4, 32, 32))
+
+    assert tokens.shape == (3, 5, 1280)
+
+
+def test_projection_is_a_linear_relu_stack():
+    projection = MaskProjection(group_width=128, projection_width=200, condition_dim=1280)
+
+    keys = list(projection.state_dict().keys())
+
+    assert keys == ["layers.0.weight", "layers.0.bias"]
+
+
+def test_projection_output_is_non_negative():
+    projection = MaskProjection(group_width=128, projection_width=200, condition_dim=1280)
+
+    tokens = projection(torch.randn(2, 4, 32, 32))
+
+    assert torch.all(tokens >= 0)  # ReLU is the last op, as in ddpm2.py:528
+
+
+def test_reshape_error_names_the_adjustable_fields():
+    from pathlib import Path
+
+    from pydantic import ValidationError
+
+    from pyclad.vision.strategies.replaycad.config import ReplayCADConfig
+
+    with pytest.raises(ValidationError, match="mask_projection_width"):
+        ReplayCADConfig.for_benchmark(
+            "visa", artifact_dir=Path("/tmp/a"), mask_backend="full-frame", mask_projection_width=196
+        )

--- a/tests/vision/strategies/replaycad/test_strategy.py
+++ b/tests/vision/strategies/replaycad/test_strategy.py
@@ -1,0 +1,186 @@
+import numpy as np
+import pytest
+
+from pyclad.vision.prediction_results import VisionPredictionResults
+from pyclad.vision.strategies.replaycad.memory import ReplayCADMemory
+from pyclad.vision.strategies.replaycad.strategy import ReplayCADStrategy
+
+
+class RecordingModel:
+    def __init__(self, input_size=(8, 8)):
+        self.fit_calls: list[np.ndarray] = []
+        self.input_size = input_size
+
+    def fit(self, data: np.ndarray):
+        self.fit_calls.append(np.asarray(data))
+
+    def predict(self, data: np.ndarray) -> VisionPredictionResults:
+        count = len(data)
+        return VisionPredictionResults(
+            y_pred=np.zeros(count, dtype=np.int64),
+            anomaly_scores=np.zeros(count, dtype=np.float32),
+            score_maps=np.zeros((count, *self.input_size), dtype=np.float32),
+        )
+
+    def name(self) -> str:
+        return "RecordingModel"
+
+    def additional_info(self) -> dict:
+        return {}
+
+
+def _images(count: int = 4, size: int = 8) -> np.ndarray:
+    return np.random.default_rng(1).integers(0, 256, size=(count, size, size, 3), dtype=np.uint8)
+
+
+def _strategy(config, backend, model=None):
+    memory = ReplayCADMemory(config=config, backend=backend, benchmark="mvtec")
+    return ReplayCADStrategy(model or RecordingModel(), memory), memory
+
+
+def test_first_concept_trains_on_real_data_only(replaycad_config, stub_backend):
+    config = replaycad_config()
+    model = RecordingModel()
+    strategy, _ = _strategy(config, stub_backend(config), model)
+    data = _images(4)
+
+    strategy.learn(data, concept_id="mvtec__screw")
+
+    assert len(model.fit_calls) == 1
+    assert np.array_equal(model.fit_calls[0], data)
+
+
+def test_second_concept_trains_on_replay_then_new_data(replaycad_config, stub_backend):
+    config = replaycad_config(replay_samples_per_concept=3)
+    model = RecordingModel()
+    strategy, _ = _strategy(config, stub_backend(config), model)
+
+    strategy.learn(_images(4), concept_id="mvtec__screw")
+    new_data = _images(2)
+    strategy.learn(new_data, concept_id="mvtec__pill")
+
+    combined = model.fit_calls[1]
+    assert len(combined) == 3 + 2  # replay for screw, then pill's own images
+    assert np.array_equal(combined[3:], new_data)
+
+
+def test_replay_is_resized_to_the_new_concept_shape(replaycad_config, stub_backend):
+    # The diffusion model generates at its own resolution; the detector needs one array.
+    config = replaycad_config(resolution=8, replay_samples_per_concept=2)
+    model = RecordingModel()
+    strategy, _ = _strategy(config, stub_backend(config), model)
+
+    strategy.learn(_images(2, size=8), concept_id="mvtec__screw")
+    strategy.learn(_images(2, size=16), concept_id="mvtec__pill")
+
+    assert model.fit_calls[1].shape == (4, 16, 16, 3)
+
+
+def test_compression_runs_after_fitting(replaycad_config, stub_backend):
+    config = replaycad_config()
+    backend = stub_backend(config)
+    order: list[str] = []
+
+    class OrderingModel(RecordingModel):
+        def fit(self, data):
+            order.append("fit")
+            super().fit(data)
+
+    original_compress = backend.compress
+
+    def tracking_compress(*args, **kwargs):
+        order.append("compress")
+        return original_compress(*args, **kwargs)
+
+    backend.compress = tracking_compress
+    strategy, _ = _strategy(config, backend, OrderingModel())
+
+    strategy.learn(_images(4), concept_id="mvtec__screw")
+
+    assert order == ["fit", "compress"]
+
+
+def test_learn_follows_the_generate_release_fit_compress_release_order(replaycad_config, stub_backend):
+    """Pins the position of each step, not just how many times each happened."""
+    config = replaycad_config()
+    backend = stub_backend(config)
+    order: list[str] = []
+
+    class OrderingModel(RecordingModel):
+        def fit(self, data):
+            order.append("fit")
+            super().fit(data)
+
+    for attribute, label in (("generate", "generate"), ("compress", "compress"), ("release_device_memory", "release")):
+        original = getattr(backend, attribute)
+
+        def record(*args, _original=original, _label=label, **kwargs):
+            order.append(_label)
+            return _original(*args, **kwargs)
+
+        setattr(backend, attribute, record)
+
+    strategy, _ = _strategy(config, backend, OrderingModel())
+    strategy.learn(_images(4), concept_id="mvtec__screw")
+    strategy.learn(_images(4), concept_id="mvtec__pill")
+
+    assert order == [
+        # First concept: nothing to replay, so the backend is never asked to generate.
+        "release",
+        "fit",
+        "compress",
+        "release",
+        # Second concept: screw is replayed before the detector sees anything.
+        "generate",
+        "release",
+        "fit",
+        "compress",
+        "release",
+    ]
+
+
+def test_device_memory_is_released_even_when_fitting_fails(replaycad_config, stub_backend):
+    config = replaycad_config()
+    backend = stub_backend(config)
+
+    class FailingModel(RecordingModel):
+        def fit(self, data):
+            raise RuntimeError("simulated cuda out of memory")
+
+    strategy, _ = _strategy(config, backend, FailingModel())
+
+    with pytest.raises(RuntimeError, match="simulated cuda out of memory"):
+        strategy.learn(_images(4), concept_id="mvtec__screw")
+
+    # One release always happens before fit; a second is only possible via the finally running
+    # despite fit's exception. ">= 1" would pass even without a finally, so this pins the count.
+    assert backend.release_calls == 2
+
+
+def test_empty_concept_is_rejected(replaycad_config, stub_backend):
+    config = replaycad_config()
+    strategy, _ = _strategy(config, stub_backend(config))
+
+    with pytest.raises(ValueError, match="empty concept"):
+        strategy.learn(np.zeros((0, 8, 8, 3), dtype=np.uint8), concept_id="mvtec__screw")
+
+
+def test_predict_delegates_to_the_detector(replaycad_config, stub_backend):
+    config = replaycad_config()
+    strategy, _ = _strategy(config, stub_backend(config))
+
+    result = strategy.predict(_images(3), concept_id="mvtec__screw")
+
+    assert isinstance(result, VisionPredictionResults)
+    assert result.y_pred.shape == (3,)
+
+
+def test_info_reports_the_mechanism(replaycad_config, stub_backend):
+    config = replaycad_config()
+    strategy, _ = _strategy(config, stub_backend(config))
+
+    info = strategy.info()["strategy"]
+
+    assert info["name"] == "ReplayCAD"
+    assert info["model"] == "RecordingModel"
+    assert info["replaycad"]["semantic_tokens"] == config.semantic_tokens

--- a/tests/vision/test_docs_references.py
+++ b/tests/vision/test_docs_references.py
@@ -1,0 +1,79 @@
+"""Every ``docs/*.md`` pointer in the source must name a section, and that section must exist.
+
+Docstrings that promise documentation ("recorded in ``docs/vision.md``") outlive the paragraph
+they were written against: the doc gets restructured, the promised list is never written, and
+nothing fails. So a pointer has to name its target -- ``"Data leakage" in docs/vision.md`` --
+and this test resolves that name against the file's actual headings.
+"""
+
+import pathlib
+import re
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCANNED_TREES = ("src/pyclad", "examples")
+
+# A pointer that names its section: `"Some heading" in docs/whatever.md`, with optional
+# reST/Markdown backticks around the path. Whitespace is normalised first, so the phrase is
+# still matched when a docstring wraps it across lines.
+NAMED_REFERENCE = re.compile(
+    r"[\"'`]{1,2}(?P<section>[^\"'`\n]+?)[\"'`]{1,2}\s+in\s+`{0,2}(?P<doc>docs/[\w./-]+\.md)`{0,2}"
+)
+ANY_REFERENCE = re.compile(r"docs/[\w./-]+\.md")
+MARKDOWN_HEADING = re.compile(r"^#{1,6}\s+(?P<title>.+?)\s*$", re.MULTILINE)
+# Headings carry inline markup (`**bold**`, `` `code` ``) that a prose pointer will not repeat.
+HEADING_MARKUP = re.compile(r"[*_`]")
+
+
+def _python_sources():
+    for tree in SCANNED_TREES:
+        for path in sorted((REPO_ROOT / tree).rglob("*.py")):
+            yield path
+
+
+def _normalised(text: str) -> str:
+    return re.sub(r"\s+", " ", text)
+
+
+def _headings_of(doc: pathlib.Path) -> set:
+    return {
+        HEADING_MARKUP.sub("", m.group("title")).strip().casefold()
+        for m in MARKDOWN_HEADING.finditer(doc.read_text(encoding="utf-8"))
+    }
+
+
+def test_every_docs_pointer_names_a_section():
+    unnamed = []
+    for path in _python_sources():
+        text = _normalised(path.read_text(encoding="utf-8"))
+        named_spans = [m.span("doc") for m in NAMED_REFERENCE.finditer(text)]
+        for match in ANY_REFERENCE.finditer(text):
+            if not any(start <= match.start() and match.end() <= end for start, end in named_spans):
+                unnamed.append(f"{path.relative_to(REPO_ROOT)}: {match.group()}")
+
+    assert not unnamed, (
+        "These pointers name a doc file but no section inside it, so nothing can verify the "
+        "promised content exists. Write them as '\"Section heading\" in docs/<file>.md':\n  " + "\n  ".join(unnamed)
+    )
+
+
+def test_every_referenced_section_exists():
+    missing = []
+    for path in _python_sources():
+        for match in NAMED_REFERENCE.finditer(_normalised(path.read_text(encoding="utf-8"))):
+            doc = REPO_ROOT / match.group("doc")
+            section = match.group("section").strip()
+            if not doc.is_file():
+                missing.append(f"{path.relative_to(REPO_ROOT)}: {match.group('doc')} does not exist")
+            elif section.casefold() not in _headings_of(doc):
+                missing.append(f"{path.relative_to(REPO_ROOT)}: {match.group('doc')} has no heading {section!r}")
+
+    assert not missing, "Referenced documentation sections are missing:\n  " + "\n  ".join(missing)
+
+
+def test_the_check_would_catch_a_broken_pointer(tmp_path):
+    """Guard against the regexes silently matching nothing and the tests above passing vacuously."""
+    text = _normalised('promised under "Nonexistent Heading" in ``docs/vision.md``.')
+    match = NAMED_REFERENCE.search(text)
+    assert match is not None and match.group("doc") == "docs/vision.md"
+    assert match.group("section") == "Nonexistent Heading"
+    assert match.group("section").casefold() not in _headings_of(REPO_ROOT / "docs/vision.md")


### PR DESCRIPTION
Implements ReplayCAD as a detector-agnostic pyCLAD strategy, plus PatchCore as a vision model.

Compression costs 20-30k diffusion steps per concept and does not depend on concept ordering, the detector, or replay volume, so artifacts are cached on disk under a key covering only the inputs that change the compressed representation.

`src/pyclad/vision/strategies/replaycad/` — config and presets, spatial conditioning, artifact cache, mask providers and transforms, diffusers backend, memory, strategy, and the authors' per-class settings as a reference table. `src/pyclad/vision/models/patchcore/` — PatchCore on the shared vision interfaces.

## Worth reviewing closely

- **`per_class.py` values.** 25 classes transcribed from the authors' shell scripts and YAMLs. A wrong number here is invisible at runtime. It produces a plausible run with the wrong config.
- **The compression cache key** (`artifacts.py::_HASHED_FIELDS`). It must cover exactly what changes a stored artifact. Too narrow silently serves a stale artifact, too broad wastes hours of GPU. Both failure modes were hit during development.
- **The embedding substitution** (`backend.py`). The K learned vectors are a standalone parameter substituted into the embedding layer's output by a forward hook, so the frozen vocabulary is never written to. If the id-to-row mapping were wrong, the wrong vectors would train and nothing would fail.
- **PatchCore's image-level score** is the max over raw patch scores (as in the PatchCore paper), not over the smoothed map (as in ADer, which produced the 93.7/54.7 row).

Model weights come from the Hugging Face Hub on first run. Datasets other than MVTec and VisA also need a SAM checkpoint, since the authors' precomputed masks only cover those two.

Adds a `replaycad` optional extra (diffusers, transformers, accelerate, safetensors, segment-anything) - pip install -e ".[replaycad]"

## Open questions

1. `per_class.py` is a reference table, not a runnable mode — memory and backend hold one config per stream while the table varies model, resolution and projection width per class. Wire it
   properly, or leave it as documentation?
2. PatchCore first, InvAD (the paper's own baseline) in a follow-up — or the other way round?
3. The artifact cache is on by default. Reasonable, or should it be opt-in?
4. The authors' `SAM.zip` has no masks for MVTec `zipper` or VisA `pipe_fryum`. The example routes `zipper` to a full-frame mask. Better to require the `sam` backend for those?

## Divergences from the original

Hyperparameters follow the released implementation. These do not:

1. `diffusers` rather than the authors' vendored `ldm/` — numerics will not match bit for bit.
2. Default is the paper's uniform per-dataset profile, not the authors' per-class tuning.
3. 800 replay samples per class (the paper), the released scripts generate 200-800 per class.
4. Random embedding initializer (the paper), not the authors' `--init_word`.
5. Detector is PatchCore, not InvAD, so Table 1 is not directly comparable.
6. PatchCore image score aggregation differs from ADer's, as above.
7. Replay is resized in memory - the authors wrote images to disk and let the detector's transform resize them, so the resampling filter differs.
8. `random_reset` implements the algorithm as described, not the original code's index-misalignment bug when a component fails placement.
9. The two generation dispatchers disagree on `macaroni2`'s mask transform and neither runs. Recorded, not resolved.
10. Stored masks are sampled at random, not the authors' curated per-class selection.
11. Training augmentation runs after resize, the original augments at source resolution.