### PR TITLE
Add UCAD model and strategy with example

### DIFF
--- a/docs/vision.md
+++ b/docs/vision.md
@@ -10,16 +10,58 @@ Every model ships with a ready-to-run example under `examples/models/vision/`.
 |---|---|--|
 | **PaSTe** | Student–teacher distillation | `paste_torch_example.py` |
 | **FastFlow** | Normalizing flow on features | `fastflow_torch_example.py` |
+| **UCAD** | Continual key-prompt-knowledge memory over a frozen ViT | `ucad_torch_example.py` |
+
+### UCAD
+
+Liu et al., *Unsupervised Continual Anomaly Detection with Contrastively-learned Prompt*,
+AAAI 2024 ([reference code](https://github.com/shirowalker/UCAD)). Unlike the other two
+models, UCAD is itself the continual mechanism: each concept appends one entry to a memory
+that is never reset — a **key** coreset of frozen-ViT patch features, a **prompt** of learned
+attention prefixes, and a **knowledge** coreset scored against by nearest neighbour. At
+inference each image is routed to a task by its nearest key, so task identity is inferred
+from the data and never supplied by the caller. Use `UCADStrategy`, not a replay wrapper, and
+a `ConceptAwareScenario` — `learn()` needs the concept name to find its SAM structure masks,
+while `predict()` discards it.
+
+`structure_mode` defaults to `"none"`, which skips the contrastive prompt training (the
+paper's CPM-only ablation) and needs no extra data. For the full method, point
+`structure_mask_root` at the authors' precomputed SAM maps, laid out as
+`<root>/<category>/train/good/*.png`.
+
+#### Data leakage
+
+**In this port: none.** `fit()` accepts only the training array, the decision threshold comes
+from a quantile of training scores, and routing reads only the learned keys.
+`tests/vision/models/test_ucad_no_leakage.py` pins that as executable assertions — scores must
+not change when the evaluated batch is regrouped or reordered, `predict()` must not mutate
+learned state, and the strategy must ignore the concept id it is handed.
+
+Which is why these numbers are *not* comparable to the paper's Tables 1–4, and are expected to be lower. In `run_ucad.py`, every
+epoch is evaluated on the test set and the prompt and knowledge bank are kept from the epoch
+with the best test AUROC (lines 262–264, with an early break at AUROC = 1); the reported score
+is a running ensemble accumulated across epochs (line 128 vs 149); scores are min-max
+normalised over the whole test set (lines 190–211); the continual evaluation loop is commented
+out entirely (lines 410–509), so the published per-task numbers are measured right after each
+task is trained and cannot show forgetting; and the reported "FM" is the gap between two memory
+budgets, not forgetting in the sense of Chaudhry et al. There is no validation split
+(`train_val_split=1`), so honest epoch selection is impossible in that codebase — this port
+therefore trains a fixed 25 epochs and keeps the last one, with no selection criterion at all.
 
 ## Setup — extra libraries required
 
-Beyond a normal pyCLAD install, the vision models need **exactly three additional packages** (the deep-learning stack):
+Beyond a normal pyCLAD install, the vision models need the deep-learning stack below. PaSTe and
+FastFlow need only the first three packages; UCAD additionally needs `timm`, and
+`segment-anything` if you use `structure_mode="sam"`. Install everything UCAD needs at once
+with `pip install -e '.[ucad]'`.
 
 | Package | Used for |
 |---|---|
 | `torch` | networks, tensors, training |
 | `torchvision` | pretrained backbones (ResNet / MobileNet / EfficientNet) + feature extraction |
 | `pytorch-lightning` | training loop (`pl.Trainer`, `LightningModule`) |
+| `timm` | UCAD's ViT backbone |
+| `segment-anything` | UCAD's `structure_mode="sam"` only |
 
 ## Datasets
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -37,7 +37,8 @@ from a quantile of training scores, and routing reads only the learned keys.
 not change when the evaluated batch is regrouped or reordered, `predict()` must not mutate
 learned state, and the strategy must ignore the concept id it is handed.
 
-Which is why these numbers are *not* comparable to the paper's Tables 1–4, and are expected to be lower. In `run_ucad.py`, every
+These numbers are *not* comparable to the paper's Tables 1–4 and
+are expected to be lower, because the reference evaluation is not leak-free. In `run_ucad.py`, every
 epoch is evaluated on the test set and the prompt and knowledge bank are kept from the epoch
 with the best test AUROC (lines 262–264, with an early break at AUROC = 1); the reported score
 is a running ensemble accumulated across epochs (line 128 vs 149); scores are min-max
@@ -47,6 +48,26 @@ task is trained and cannot show forgetting; and the reported "FM" is the gap bet
 budgets, not forgetting in the sense of Chaudhry et al. There is no validation split
 (`train_val_split=1`), so honest epoch selection is impossible in that codebase — this port
 therefore trains a fixed 25 epochs and keeps the last one, with no selection criterion at all.
+
+#### Divergences from the reference
+
+`UCADConfig`'s defaults follow the [reference code](https://github.com/shirowalker/UCAD) rather
+than the paper prose wherever the two disagree. Every place this port departs from either is
+listed here.
+
+| What | Reference / paper | This port | Why |
+|---|---|---|---|
+| Epoch selection | Keeps the epoch with the best **test** AUROC (`run_ucad.py` lines 262–264) | Trains a fixed `epochs=25` and keeps the last | No test data may reach `fit()` — see [Data leakage](#data-leakage) above |
+| Score post-processing | Min-max normalises over the whole test set and ensembles scores across epochs | Raw nearest-neighbour distances from the final epoch | Same reason |
+| Backbone weights | The paper's text says ImageNet-21k; the code's `vit_base_patch16_224` + `pretrained=True` resolved (timm 0.6.7) to ImageNet-21k **finetuned on ImageNet-1k** | `backbone_name="vit_base_patch16_224.augreg_in21k_ft_in1k"` — the weights the reference actually loaded | Newer timm requires the tag to be explicit; pinning it keeps the port reproducible. Set `"vit_base_patch16_224.augreg_in21k"` for the paper's stated variant |
+| `prompt_depth` | Prompts all 12 blocks while reading features out after block index 5 | Defaults to `6`, matching `feature_layer` | Prompt slices past the read-out block receive no gradient and only cost storage. Larger values are still accepted and merely log an info message |
+| Coreset size | Samples a *percentage* of the feature pool | Samples an exact count (`key_size` / `knowledge_size`, both `196`) | A percentage of a varying pool can round down by one; UCAD specifies the banks as absolute sizes |
+
+Reproduced deliberately, quirks included: the SCL loss keeps the reference's diagonal self-pairs
+(a constant offset that does not change the gradient direction); patch-label downsampling
+reproduces `cv2.resize`'s bilinear-then-round behaviour (`mask_interpolation="bilinear"`);
+routing distances are squared to match the reference's faiss index; and the prompt is
+initialised `uniform(-1, 1)` as in EPrompt.
 
 ## Setup — extra libraries required
 

--- a/examples/models/vision/ucad_torch_example.py
+++ b/examples/models/vision/ucad_torch_example.py
@@ -1,0 +1,76 @@
+import logging
+import pathlib
+
+from pyclad.callbacks.evaluation.concept_metric_evaluation import ConceptMetricCallback
+from pyclad.callbacks.evaluation.time_evaluation import TimeEvaluationCallback
+from pyclad.metrics.base.average_precision import AveragePrecision
+from pyclad.metrics.base.f1_score import F1Score
+from pyclad.metrics.base.roc_auc import RocAuc
+from pyclad.metrics.continual.average_continual import ContinualAverage
+from pyclad.metrics.continual.backward_transfer import BackwardTransfer
+from pyclad.metrics.continual.forward_transfer import ForwardTransfer
+from pyclad.output.json_writer import JsonOutputWriter
+from pyclad.scenarios.concept_aware import ConceptAwareScenario
+from pyclad.vision.callbacks.vision_pixel_concept_metric_callback import (
+    VisionPixelConceptMetricCallback,
+)
+from pyclad.vision.data.readers.vision_reader import read_vision_dataset
+from pyclad.vision.metrics.pixel_aupro import PixelAUPRO
+from pyclad.vision.metrics.pixel_average_precision import PixelAveragePrecision
+from pyclad.vision.metrics.pixel_roc_auc import PixelRocAuc
+from pyclad.vision.models.ucad.config import UCADConfig
+from pyclad.vision.models.ucad.ucad import UCAD
+from pyclad.vision.strategies.ucad.strategy import UCADStrategy
+
+logging.basicConfig(level=logging.INFO)
+
+if __name__ == "__main__":
+    """
+    UCAD (Liu et al., AAAI 2024) for continual visual anomaly detection.
+
+    NOTE: results from this port are NOT comparable to the paper's Tables 1-4. The reference
+    implementation selects the prompt and knowledge bank by the best test-set AUROC over 25
+    epochs and never runs its continual evaluation loop. See docs/vision.md.
+    """
+    dataset = read_vision_dataset(
+        root=pathlib.Path("../../resources/vision/BTech_Dataset_transformed"),
+        benchmark="btech",
+        resize_to=(224, 224),
+        data_mode="numpy",
+        color_mode="rgb",
+    )
+
+    model_config = UCADConfig(
+        input_size=(224, 224),
+        batch_size=8,
+        epochs=25,
+        # CPM-only by default. For the full CPM+SCL method, point these at the authors'
+        # precomputed SAM maps (the mvtec2d-sam-b archive):
+        #   structure_mode="precomputed",
+        #   structure_mask_root="/data/mvtec2d-sam-b",
+        structure_mode="none",
+        seed=42,
+    )
+    model = UCAD(model_config)
+
+    # No replay wrapper: UCAD's continual mechanism is its own key-prompt-knowledge memory.
+    strategy = UCADStrategy(model)
+
+    summarized_metrics = [ContinualAverage(), BackwardTransfer(), ForwardTransfer()]
+
+    callbacks = [
+        # Image-level
+        ConceptMetricCallback(base_metric=RocAuc(), summarized_metrics=summarized_metrics),
+        ConceptMetricCallback(base_metric=F1Score(), summarized_metrics=summarized_metrics),
+        ConceptMetricCallback(base_metric=AveragePrecision(), summarized_metrics=summarized_metrics),
+        VisionPixelConceptMetricCallback(base_metric=PixelRocAuc(), summarized_metrics=summarized_metrics),
+        VisionPixelConceptMetricCallback(base_metric=PixelAveragePrecision(), summarized_metrics=summarized_metrics),
+        VisionPixelConceptMetricCallback(base_metric=PixelAUPRO(), summarized_metrics=summarized_metrics),
+        TimeEvaluationCallback(),
+    ]
+
+    scenario = ConceptAwareScenario(dataset=dataset, strategy=strategy, callbacks=callbacks)
+    scenario.run()
+
+    output_writer = JsonOutputWriter(pathlib.Path("output.json"))
+    output_writer.write([model, dataset, strategy, *callbacks])

--- a/examples/models/vision/ucad_torch_example.py
+++ b/examples/models/vision/ucad_torch_example.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
 
     NOTE: results from this port are NOT comparable to the paper's Tables 1-4. The reference
     implementation selects the prompt and knowledge bank by the best test-set AUROC over 25
-    epochs and never runs its continual evaluation loop. See docs/vision.md.
+    epochs and never runs its continual evaluation loop. See "Data leakage" in docs/vision.md.
     """
     dataset = read_vision_dataset(
         root=pathlib.Path("../../resources/vision/BTech_Dataset_transformed"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,10 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = ["black>=24.4", "flake8>=7.1.0", "isort>=5.13.0", "pytest>=8.2.2"]
+ucad = [
+    "timm>=1.0",
+    "segment-anything>=1.0",
+]
 
 [tool.black]
 line-length = 120

--- a/src/pyclad/vision/models/ucad/__init__.py
+++ b/src/pyclad/vision/models/ucad/__init__.py
@@ -1,0 +1,10 @@
+"""UCAD: task-agnostic continual visual anomaly detection (Liu et al., AAAI 2024)."""
+
+from pyclad.vision.models.ucad.config import UCADConfig
+from pyclad.vision.models.ucad.ucad import (
+    UCAD,
+    UCADTaskMemory,
+    structure_contrastive_loss,
+)
+
+__all__ = ["UCAD", "UCADConfig", "UCADTaskMemory", "structure_contrastive_loss"]

--- a/src/pyclad/vision/models/ucad/config.py
+++ b/src/pyclad/vision/models/ucad/config.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+from typing import Literal, Optional
+
+from pydantic import Field, model_validator
+
+from pyclad.vision.models.utilities.config import ImageSize, VisionConfig
+
+
+class UCADConfig(VisionConfig):
+    """Configuration for UCAD.
+
+    Defaults follow the reference implementation (https://github.com/shirowalker/UCAD),
+    not the paper prose, wherever the two disagree. Each divergence is recorded in
+    ``docs/vision.md``. Training fields live here rather than in ``LightningVisionConfig``
+    because UCAD optimises a single prompt tensor for a fixed number of epochs with no
+    validation split and no early stopping, so that base class's fields would be inert.
+    """
+
+    input_size: ImageSize = (224, 224)
+    batch_size: int = Field(default=8, gt=0)
+
+    # timm 0.6.7 resolved `vit_base_patch16_224` + `pretrained=True` to these weights
+    # (ImageNet-21k pretrained, ImageNet-1k finetuned). The paper's text claims plain
+    # ImageNet-21k; `vit_base_patch16_224.augreg_in21k` selects that as an ablation.
+    backbone_name: str = "vit_base_patch16_224.augreg_in21k_ft_in1k"
+    pretrained_backbone: bool = True
+
+    feature_layer: int = Field(default=6, gt=0)
+    prompt_depth: int = Field(default=6, gt=0)
+    prompt_length: int = Field(default=1, gt=0)
+    prompt_init: Literal["zero", "uniform"] = "uniform"
+
+    target_embed_dimension: int = Field(default=1024, gt=0)
+    key_size: int = Field(default=196, gt=0)
+    knowledge_size: int = Field(default=196, gt=0)
+    coreset_projection_dimension: int = Field(default=128, gt=0)
+    coreset_starting_points: int = Field(default=10, gt=0)
+    n_neighbors: int = Field(default=1, gt=0)
+
+    epochs: int = Field(default=25, ge=0)
+    learning_rate: float = Field(default=5e-4, gt=0.0)
+    weight_decay: float = Field(default=0.0, ge=0.0)
+    gradient_clip_norm: float = Field(default=1.0, gt=0.0)
+    contrastive_temperature: float = Field(default=0.5, gt=0.0)
+    show_training_progress: bool = False
+
+    structure_mode: Literal["none", "precomputed", "sam"] = "none"
+    structure_mask_root: Optional[str] = None
+    mask_interpolation: Literal["bilinear", "nearest"] = "bilinear"
+    sam_checkpoint: Optional[str] = None
+    sam_model_type: str = "vit_b"
+
+    routing_statistic: Literal["mean", "max"] = "mean"
+    smoothing_sigma: float = Field(default=4.0, ge=0.0)
+
+    @model_validator(mode="after")
+    def _validate_ucad_configuration(self):
+        if self.structure_mode == "precomputed":
+            if not self.structure_mask_root:
+                raise ValueError("structure_mask_root is required when structure_mode='precomputed'")
+            if not Path(self.structure_mask_root).expanduser().exists():
+                raise ValueError(f"structure_mask_root does not exist: {self.structure_mask_root}")
+        if self.structure_mode == "sam":
+            if not self.sam_checkpoint:
+                raise ValueError("sam_checkpoint is required when structure_mode='sam'")
+            if not Path(self.sam_checkpoint).expanduser().is_file():
+                raise ValueError(f"sam_checkpoint does not exist: {self.sam_checkpoint}")
+        return self

--- a/src/pyclad/vision/models/ucad/config.py
+++ b/src/pyclad/vision/models/ucad/config.py
@@ -10,10 +10,11 @@ class UCADConfig(VisionConfig):
     """Configuration for UCAD.
 
     Defaults follow the reference implementation (https://github.com/shirowalker/UCAD),
-    not the paper prose, wherever the two disagree. Each divergence is recorded in
-    ``docs/vision.md``. Training fields live here rather than in ``LightningVisionConfig``
-    because UCAD optimises a single prompt tensor for a fixed number of epochs with no
-    validation split and no early stopping, so that base class's fields would be inert.
+    not the paper prose, wherever the two disagree. Each divergence is recorded under
+    "Divergences from the reference" in ``docs/vision.md``. Training fields live here rather
+    than in ``LightningVisionConfig`` because UCAD optimises a single prompt tensor for a fixed
+    number of epochs with no validation split and no early stopping, so that base class's
+    fields would be inert.
     """
 
     input_size: ImageSize = (224, 224)

--- a/src/pyclad/vision/models/ucad/coreset.py
+++ b/src/pyclad/vision/models/ucad/coreset.py
@@ -1,0 +1,131 @@
+"""UCAD's own copies of two PatchCore utilities.
+
+``RescaleSegmentor`` and ``ApproximateGreedyCoresetSampler`` originate in PatchCore
+(``pyclad.vision.models.patchcore.patchcore``), which is not yet on ``main`` -- it lives on
+another, still-unmerged feature branch. UCAD needs exactly these two helpers, so this module
+carries its own copies (trimmed to only what UCAD calls: ``convert_to_segmentation`` and
+``run_with_target_size``) instead of depending on that branch.
+
+When the PatchCore model lands on ``main``, this module should be reduced to imports from
+``pyclad.vision.models.patchcore.patchcore`` rather than carrying duplicate implementations.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from scipy import ndimage
+from torch import nn
+
+
+class RescaleSegmentor:
+    def __init__(self, device: torch.device, target_size: tuple[int, int], smoothing: float):
+        self.device = device
+        self.target_size = target_size
+        self.smoothing = smoothing
+
+    def convert_to_segmentation(self, patch_scores: np.ndarray) -> np.ndarray:
+        with torch.no_grad():
+            if isinstance(patch_scores, np.ndarray):
+                patch_scores = torch.from_numpy(patch_scores)
+
+            scores = patch_scores.to(self.device).unsqueeze(1)
+            scores = F.interpolate(scores, size=self.target_size, mode="bilinear", align_corners=False)
+            scores = scores.squeeze(1).cpu().numpy()
+
+        if self.smoothing <= 0:
+            return scores.astype(np.float32, copy=False)
+        return np.asarray(
+            [ndimage.gaussian_filter(score, sigma=self.smoothing) for score in scores],
+            dtype=np.float32,
+        )
+
+
+class ApproximateGreedyCoresetSampler:
+    """Greedy coreset subsampling, restricted to the exact-count entry point UCAD uses.
+
+    The original PatchCore utility also offers a percentage-based ``run()`` (and the
+    ``percentage`` constructor parameter that only it needs) plus a weighted-selection
+    variant of the private helper below, for the other model's needs. Neither is reachable
+    from UCAD, which only ever asks for an exact-size coreset, so both are left out here.
+    """
+
+    def __init__(
+        self,
+        device: torch.device,
+        number_of_starting_points: int = 10,
+        dimension_to_project_features_to: int = 128,
+        random_seed: int = 0,
+    ):
+        self.device = device
+        self.number_of_starting_points = number_of_starting_points
+        self.dimension_to_project_features_to = dimension_to_project_features_to
+        self.random_seed = random_seed
+
+    def _reduce_features(self, features: torch.Tensor) -> torch.Tensor:
+        if features.shape[1] == self.dimension_to_project_features_to:
+            return features.to(self.device)
+
+        with torch.random.fork_rng():
+            torch.manual_seed(self.random_seed)
+            mapper = nn.Linear(features.shape[1], self.dimension_to_project_features_to, bias=False).to(self.device)
+        return mapper(features.to(self.device))
+
+    @staticmethod
+    def _compute_batchwise_differences(matrix_a: torch.Tensor, matrix_b: torch.Tensor) -> torch.Tensor:
+        a_times_a = matrix_a.unsqueeze(1).bmm(matrix_a.unsqueeze(2)).reshape(-1, 1)
+        b_times_b = matrix_b.unsqueeze(1).bmm(matrix_b.unsqueeze(2)).reshape(1, -1)
+        a_times_b = matrix_a.mm(matrix_b.T)
+        return (-2 * a_times_b + a_times_a + b_times_b).clamp(0, None).sqrt()
+
+    def _compute_greedy_coreset_indices(self, features: torch.Tensor, num_samples: int) -> np.ndarray:
+        """Greedy coreset selection: repeatedly pick the point farthest from the selected set.
+
+        "Farthest" is approximated via mean distance to a random subset of starting points,
+        updated incrementally as each new point is selected.
+        """
+        number_of_starting_points = min(self.number_of_starting_points, len(features))
+        rng = np.random.default_rng(self.random_seed)
+        start_points = rng.choice(len(features), number_of_starting_points, replace=False).tolist()
+
+        approximate_distance_matrix = self._compute_batchwise_differences(features, features[start_points])
+        approximate_coreset_anchor_distances = torch.mean(approximate_distance_matrix, axis=-1).reshape(-1, 1)
+
+        coreset_indices = []
+
+        with torch.no_grad():
+            for _ in range(num_samples):
+                scores = approximate_coreset_anchor_distances.squeeze(-1)
+                select_idx = torch.argmax(scores).item()
+                coreset_indices.append(select_idx)
+
+                coreset_select_distance = self._compute_batchwise_differences(
+                    features, features[select_idx : select_idx + 1]
+                )
+                approximate_coreset_anchor_distances = torch.cat(
+                    [approximate_coreset_anchor_distances, coreset_select_distance],
+                    dim=-1,
+                )
+                approximate_coreset_anchor_distances = torch.min(
+                    approximate_coreset_anchor_distances, dim=1
+                ).values.reshape(-1, 1)
+
+        return np.array(coreset_indices)
+
+    def run_with_target_size(self, features: np.ndarray, target_size: int) -> np.ndarray:
+        """Select exactly ``target_size`` coreset points, or all of them when there are fewer.
+
+        UCAD specifies its key and knowledge banks as an absolute number of vectors (196);
+        expressing that as a percentage of a varying pool size could round down by one, so
+        this samples an exact count directly instead.
+        """
+        if target_size <= 0:
+            raise ValueError("target_size must be positive")
+        if len(features) <= target_size:
+            return features.astype(np.float32, copy=False)
+
+        feature_tensor = torch.from_numpy(features.astype(np.float32, copy=False))
+        reduced_features = self._reduce_features(feature_tensor)
+        sample_indices = self._compute_greedy_coreset_indices(reduced_features, num_samples=target_size)
+        return feature_tensor[sample_indices].cpu().numpy().astype(np.float32, copy=False)

--- a/src/pyclad/vision/models/ucad/structure.py
+++ b/src/pyclad/vision/models/ucad/structure.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import abc
+from pathlib import Path
+from typing import Optional, Union
+
+import numpy as np
+from PIL import Image
+
+from pyclad.vision.models.ucad.config import UCADConfig
+
+_IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".bmp", ".tif", ".tiff"})
+_MULTIDATASET_SEPARATOR = "__"
+
+
+def category_of(concept_id: str) -> str:
+    """Category part of a concept id, dropping a multidataset ``<alias>__`` prefix.
+
+    Deliberately duplicated from ReplayCAD's helper rather than imported: a model must not
+    depend on a strategy package.
+    """
+    return str(concept_id).rsplit(_MULTIDATASET_SEPARATOR, 1)[-1]
+
+
+class StructureMaskProvider(abc.ABC):
+    """Supplies SAM region-id maps for one task's training images."""
+
+    @abc.abstractmethod
+    def masks_for(self, concept_id: Optional[str], images: np.ndarray) -> Optional[np.ndarray]:
+        """Return ``(N, H, W)`` int64 region labels aligned with ``images``, or ``None``."""
+
+
+class NoStructureMaskProvider(StructureMaskProvider):
+    """CPM-only ablation: no masks, therefore no SCL and an untrained prompt."""
+
+    def masks_for(self, concept_id: Optional[str], images: np.ndarray) -> None:
+        return None
+
+
+class PrecomputedStructureMaskProvider(StructureMaskProvider):
+    """Loads the authors' precomputed SAM maps (the ``mvtec2d-sam-b`` archive).
+
+    Region ids live in channel 0 of the PNG, read the same way as the reference
+    implementation's ``cv2.imread(path)[:, :, 0]`` (see ``_load_label_map``). Masks are paired
+    with images by sorted filename order — the same order the vision readers index a category
+    in — and a count mismatch raises rather than silently shifting the pairing by one.
+    """
+
+    def __init__(self, root: Union[str, Path], interpolation: str = "bilinear"):
+        if interpolation not in ("bilinear", "nearest"):
+            raise ValueError(f"interpolation must be 'bilinear' or 'nearest', got {interpolation!r}")
+        self.root = Path(root).expanduser()
+        self.interpolation = interpolation
+
+    def masks_for(self, concept_id: Optional[str], images: np.ndarray) -> np.ndarray:
+        directory = self._resolve_directory(concept_id)
+        paths = sorted(p for p in directory.iterdir() if p.is_file() and p.suffix.lower() in _IMAGE_SUFFIXES)
+        if len(paths) != len(images):
+            raise ValueError(
+                f"Concept '{concept_id}' has {len(images)} training image(s) but "
+                f"{len(paths)} structure mask(s) in {directory}. Masks are paired by sorted "
+                "filename order, so the counts must match exactly."
+            )
+
+        height, width = int(images.shape[1]), int(images.shape[2])
+        return np.stack([self._load_label_map(path, height, width) for path in paths]).astype(np.int64, copy=False)
+
+    def _resolve_directory(self, concept_id: Optional[str]) -> Path:
+        if not concept_id:
+            raise ValueError(
+                "UCAD structure_mode='precomputed' needs a concept id to locate that concept's "
+                f"structure masks, but none was supplied (concept_id={concept_id!r}). This means "
+                "fit() ran without a concept-aware scenario: use a scenario such as "
+                "ConceptAwareScenario, whose strategy calls UCAD.set_current_concept() before "
+                "fit(), so precomputed masks can be paired with the right task."
+            )
+        candidates: list[Path] = []
+        names = [str(concept_id)]
+        category = category_of(concept_id)
+        if category != str(concept_id):
+            names.append(category)
+        for name in names:
+            candidates += [self.root / name / "train" / "good", self.root / name / "train", self.root / name]
+        for candidate in candidates:
+            if candidate.is_dir():
+                return candidate
+        raise FileNotFoundError(
+            "Could not locate precomputed UCAD structure masks. Checked: " + ", ".join(str(path) for path in candidates)
+        )
+
+    def _load_label_map(self, path: Path, height: int, width: int) -> np.ndarray:
+        with Image.open(path) as image:
+            label_map = image.getchannel(0)
+            if label_map.size != (width, height):
+                resample = Image.Resampling.BILINEAR if self.interpolation == "bilinear" else Image.Resampling.NEAREST
+                label_map = label_map.resize((width, height), resample=resample)
+            return np.asarray(label_map, dtype=np.int64)
+
+
+class SamStructureMaskProvider(StructureMaskProvider):
+    """Generates multi-region SAM maps at run time.
+
+    Regions are painted largest-first so that smaller regions overwrite larger ones and every
+    region ends up with a distinct id, matching the authors' preprocessing script.
+    """
+
+    def __init__(self, checkpoint: Union[str, Path], model_type: str, device: str):
+        self.checkpoint = Path(checkpoint).expanduser()
+        self.model_type = model_type
+        self.device = device
+        self._generator = None
+
+    def _load(self):
+        if self._generator is not None:
+            return self._generator
+        try:
+            from segment_anything import SamAutomaticMaskGenerator, sam_model_registry
+        except ImportError as exc:
+            raise ImportError(
+                "UCAD's online SAM structure masks require segment-anything. " "Install pyclad with the 'ucad' extra."
+            ) from exc
+        sam = sam_model_registry[self.model_type](checkpoint=str(self.checkpoint))
+        sam.to(device=self.device)
+        sam.eval()
+        self._generator = SamAutomaticMaskGenerator(sam)
+        return self._generator
+
+    def masks_for(self, concept_id: Optional[str], images: np.ndarray) -> np.ndarray:
+        generator = self._load()
+        return np.stack([self._one(generator, image) for image in images]).astype(np.int64, copy=False)
+
+    @staticmethod
+    def _one(generator, image: np.ndarray) -> np.ndarray:
+        rgb = np.asarray(image)
+        if rgb.ndim == 2:
+            rgb = np.repeat(rgb[..., None], 3, axis=-1)
+        if rgb.dtype != np.uint8:
+            scale = 255.0 if rgb.size and float(rgb.max()) <= 1.0 else 1.0
+            rgb = np.clip(rgb * scale, 0, 255).astype(np.uint8)
+        rgb = np.ascontiguousarray(rgb[..., :3])
+
+        labels = np.zeros(rgb.shape[:2], dtype=np.int64)
+        for region_id, region in enumerate(sorted(generator.generate(rgb), key=lambda r: r["area"], reverse=True), 1):
+            labels[np.asarray(region["segmentation"], dtype=bool)] = region_id
+        return labels
+
+
+def build_structure_mask_provider(config: UCADConfig, device: str) -> StructureMaskProvider:
+    if config.structure_mode == "none":
+        return NoStructureMaskProvider()
+    if config.structure_mode == "precomputed":
+        return PrecomputedStructureMaskProvider(config.structure_mask_root, config.mask_interpolation)
+    if config.structure_mode == "sam":
+        return SamStructureMaskProvider(config.sam_checkpoint, config.sam_model_type, device)
+    raise ValueError(f"Unknown UCAD structure mode: {config.structure_mode}")

--- a/src/pyclad/vision/models/ucad/ucad.py
+++ b/src/pyclad/vision/models/ucad/ucad.py
@@ -1,0 +1,491 @@
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from sklearn.neighbors import NearestNeighbors
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from pyclad.vision.models.ucad.config import UCADConfig
+from pyclad.vision.models.ucad.coreset import (
+    ApproximateGreedyCoresetSampler,
+    RescaleSegmentor,
+)
+from pyclad.vision.models.ucad.structure import build_structure_mask_provider
+from pyclad.vision.models.utilities.base_model import VisionScoringBase
+
+logger = logging.getLogger(__name__)
+
+
+def structure_contrastive_loss(
+    patch_features: torch.Tensor,
+    region_labels: torch.Tensor,
+    temperature: float = 0.5,
+) -> torch.Tensor:
+    """UCAD's Structure-based Contrastive Learning objective (paper Eq. 3).
+
+    Patch features assigned to the same SAM region are pulled together and features from
+    different regions are pushed apart, over all pairs within an image. This reproduces the
+    reference ``VisionTransformer.contrastive_loss`` exactly, including the self-pairs it
+    keeps on the diagonal (which contribute a constant ``-1/T`` per patch and therefore do
+    not change the gradient direction, but do change the reported loss value).
+    """
+    if patch_features.ndim != 3:
+        raise ValueError(f"patch_features must have shape (B, P, D), got {tuple(patch_features.shape)}")
+    if region_labels.shape != patch_features.shape[:2]:
+        raise ValueError(
+            f"region_labels must have shape {tuple(patch_features.shape[:2])}, " f"got {tuple(region_labels.shape)}"
+        )
+    if temperature <= 0:
+        raise ValueError("temperature must be positive")
+
+    normalized = F.normalize(patch_features, dim=-1)
+    similarity = torch.bmm(normalized, normalized.transpose(1, 2)) / temperature
+    same_region = (region_labels.unsqueeze(1) == region_labels.unsqueeze(2)).to(similarity.dtype)
+    return (-similarity * same_region + torch.exp(similarity) * (1.0 - same_region)).mean()
+
+
+@dataclass(frozen=True)
+class UCADTaskMemory:
+    """One entry of UCAD's key-prompt-knowledge memory (paper's CPM)."""
+
+    key: np.ndarray
+    prompt: torch.Tensor
+    knowledge: np.ndarray
+    concept_id: Optional[str] = None
+    final_scl_loss: Optional[float] = None
+
+
+class UCAD(VisionScoringBase):
+    """Unsupervised Continual Anomaly Detection with contrastively-learned prompts.
+
+    Each ``fit()`` appends one task memory and never resets, so a plain concept-incremental
+    stream builds the whole key-prompt-knowledge space. Inference is task-agnostic: the task
+    is chosen per image from the learned keys, never from the concept id.
+
+    No method accepts test data, test labels, or any statistic derived from them. The
+    reference implementation selects its prompt and knowledge bank by test AUROC; this port
+    trains for a fixed number of epochs and keeps the last one, so its scores are lower than
+    the paper's by construction. See ``docs/vision.md``.
+    """
+
+    config: UCADConfig
+
+    def __init__(self, config: Optional[UCADConfig] = None):
+        super().__init__(config or UCADConfig())
+
+        self._apply_seed()  # before backbone construction: init is random when not pretrained
+        self.module = self._build_backbone().to(self._device).eval()
+        self._validate_backbone()
+        for parameter in self.module.parameters():
+            parameter.requires_grad_(False)
+
+        self._embed_dim = int(self.module.embed_dim)
+        self._num_heads = int(self.module.blocks[0].attn.num_heads)
+        if self._embed_dim % self._num_heads != 0:
+            raise ValueError(
+                f"UCAD embedding dimension {self._embed_dim} is not divisible by "
+                f"the attention head count {self._num_heads}"
+            )
+        self._head_dim = self._embed_dim // self._num_heads
+        if self.config.prompt_depth > self.config.feature_layer:
+            logger.info(
+                "UCAD prompt_depth=%d exceeds feature_layer=%d; prompt slices past the read-out "
+                "block receive no gradient and only cost storage. This matches the reference, "
+                "which prompts all 12 blocks while reading features after block index 5.",
+                self.config.prompt_depth,
+                self.config.feature_layer,
+            )
+
+        self._segmentor = RescaleSegmentor(
+            device=self._device,
+            target_size=self.config.input_size,
+            smoothing=self.config.smoothing_sigma,
+        )
+        self._mask_provider = build_structure_mask_provider(self.config, str(self._device))
+        self._task_memories: list[UCADTaskMemory] = []
+        self._key_indices: list[NearestNeighbors] = []
+        self._knowledge_indices: list[NearestNeighbors] = []
+        self._grid_size: Optional[tuple[int, int]] = None
+        self._current_concept_id: Optional[str] = None
+        self._cached_image_scores: Optional[torch.Tensor] = None
+
+    # --- construction --------------------------------------------------------
+    def _build_backbone(self) -> nn.Module:
+        try:
+            import timm
+        except ImportError as exc:
+            raise ImportError("UCAD requires timm. Install pyclad with the 'ucad' extra.") from exc
+
+        try:
+            return timm.create_model(
+                self.config.backbone_name,
+                pretrained=self.config.pretrained_backbone,
+                num_classes=0,
+                img_size=self.config.input_size,
+            )
+        except TypeError as exc:
+            # Only ViT-family models accept `img_size`; a CNN backbone rejects it here rather
+            # than failing later in _validate_backbone with a more confusing message.
+            raise TypeError(
+                f"UCAD backbone '{self.config.backbone_name}' is not a compatible timm ViT: "
+                "it does not accept an img_size argument"
+            ) from exc
+
+    def _validate_backbone(self) -> None:
+        required = ("patch_embed", "_pos_embed", "patch_drop", "norm_pre", "blocks", "embed_dim")
+        missing = [name for name in required if not hasattr(self.module, name)]
+        if missing:
+            raise TypeError(
+                f"UCAD backbone '{self.config.backbone_name}' is not a compatible timm ViT; missing {missing}"
+            )
+        if self.config.feature_layer > len(self.module.blocks):
+            raise ValueError(
+                f"feature_layer={self.config.feature_layer} exceeds backbone depth={len(self.module.blocks)}"
+            )
+        if self.config.prompt_depth > len(self.module.blocks):
+            raise ValueError(
+                f"prompt_depth={self.config.prompt_depth} exceeds backbone depth={len(self.module.blocks)}"
+            )
+
+    def _initial_prompt(self) -> torch.Tensor:
+        shape = (self.config.prompt_depth, 2, self.config.prompt_length, self._num_heads, self._head_dim)
+        if self.config.prompt_init == "zero":
+            return torch.zeros(shape, dtype=torch.float32, device=self._device)
+        # uniform(-1, 1), matching EPrompt's `nn.init.uniform_(self.prompt, -1, 1)`. Drawn from
+        # the global RNG, which _apply_seed() has just fixed, so tasks start from the same
+        # initialisation the reference gives them (it re-seeds per task with the same seed).
+        return torch.empty(shape, dtype=torch.float32, device=self._device).uniform_(-1.0, 1.0)
+
+    def _forward_block_with_prefix_prompt(
+        self, block: nn.Module, tokens: torch.Tensor, layer_prompt: torch.Tensor
+    ) -> torch.Tensor:
+        """Run one timm ViT block with learned key/value prefixes (DualPrompt-style)."""
+        attention = block.attn
+        normalized = block.norm1(tokens)
+        batch_size, token_count, embed_dim = normalized.shape
+
+        qkv = (
+            attention.qkv(normalized)
+            .reshape(batch_size, token_count, 3, attention.num_heads, embed_dim // attention.num_heads)
+            .permute(2, 0, 3, 1, 4)
+        )
+        query, key, value = qkv.unbind(0)
+        query, key = attention.q_norm(query), attention.k_norm(key)
+
+        key_prefix = layer_prompt[0].permute(1, 0, 2).unsqueeze(0).expand(batch_size, -1, -1, -1)
+        value_prefix = layer_prompt[1].permute(1, 0, 2).unsqueeze(0).expand(batch_size, -1, -1, -1)
+        key = torch.cat([key_prefix.to(key.dtype), key], dim=2)
+        value = torch.cat([value_prefix.to(value.dtype), value], dim=2)
+
+        weights = attention.attn_drop(torch.matmul(query * attention.scale, key.transpose(-2, -1)).softmax(dim=-1))
+        attended = torch.matmul(weights, value).transpose(1, 2).reshape(batch_size, token_count, embed_dim)
+        attended = attention.proj_drop(attention.proj(attended))
+
+        tokens = tokens + block.drop_path1(block.ls1(attended))
+        return tokens + block.drop_path2(block.ls2(block.mlp(block.norm2(tokens))))
+
+    def _forward_patch_tokens(self, images: torch.Tensor, prompt: Optional[torch.Tensor]) -> torch.Tensor:
+        """Patch tokens after ``feature_layer`` blocks, prefix tokens dropped."""
+        x = self.module.patch_embed(images)
+        x = self.module._pos_embed(x)
+        x = self.module.patch_drop(x)
+        x = self.module.norm_pre(x)
+
+        for block_index, block in enumerate(self.module.blocks[: self.config.feature_layer]):
+            if prompt is not None and block_index < self.config.prompt_depth:
+                x = self._forward_block_with_prefix_prompt(block, x, prompt[block_index])
+            else:
+                x = block(x)
+        return x[:, int(getattr(self.module, "num_prefix_tokens", 1)) :]
+
+    # --- features ------------------------------------------------------------
+    def _map_dimension(self, features: torch.Tensor) -> torch.Tensor:
+        """768 -> target_embed_dimension, matching the reference MeanMapper + Aggregator."""
+        if features.shape[-1] == self.config.target_embed_dimension:
+            return features
+        flattened = features.reshape(-1, 1, features.shape[-1])
+        mapped = F.adaptive_avg_pool1d(flattened, self.config.target_embed_dimension)
+        return mapped.reshape(*features.shape[:-1], self.config.target_embed_dimension)
+
+    @staticmethod
+    def _infer_grid_size(patch_count: int) -> tuple[int, int]:
+        side = int(round(math.sqrt(patch_count)))
+        if side * side != patch_count:
+            raise ValueError(f"UCAD requires a square ViT patch grid, got {patch_count} patch tokens")
+        return side, side
+
+    def _patch_features(
+        self, images: torch.Tensor, prompt: Optional[torch.Tensor]
+    ) -> tuple[np.ndarray, tuple[int, int]]:
+        """Mapped patch embeddings ``(B*P, D)`` for a preprocessed batch, plus the patch grid."""
+        self.module.eval()
+        with torch.no_grad():
+            tokens = self._forward_patch_tokens(
+                images.to(self._device, dtype=torch.float32),
+                None if prompt is None else prompt.to(self._device),
+            )
+            grid = self._infer_grid_size(tokens.shape[1])
+            mapped = self._map_dimension(tokens)
+        return mapped.reshape(-1, mapped.shape[-1]).cpu().numpy().astype(np.float32, copy=False), grid
+
+    def _extract_patch_embeddings(
+        self, data: np.ndarray, prompt: Optional[torch.Tensor]
+    ) -> tuple[np.ndarray, tuple[int, int]]:
+        batches: list[np.ndarray] = []
+        grid: Optional[tuple[int, int]] = None
+        for (batch_x,) in self._prepare_batches(data, shuffle=False):
+            features, grid = self._patch_features(batch_x, prompt)
+            batches.append(features)
+        return np.concatenate(batches, axis=0), grid
+
+    @property
+    def task_memories(self) -> tuple[UCADTaskMemory, ...]:
+        return tuple(self._task_memories)
+
+    def set_current_concept(self, concept_id: Optional[str]) -> None:
+        """Record which concept the next ``fit()`` learns.
+
+        Used only to locate that concept's structure masks. It never reaches inference:
+        ``_inference_maps`` routes from the learned keys alone.
+        """
+        self._current_concept_id = concept_id
+
+    def _select_coreset(self, features: np.ndarray, target_size: int) -> np.ndarray:
+        sampler = ApproximateGreedyCoresetSampler(
+            device=self._device,
+            number_of_starting_points=self.config.coreset_starting_points,
+            dimension_to_project_features_to=self.config.coreset_projection_dimension,
+            random_seed=self.config.seed if self.config.seed is not None else 0,
+        )
+        return sampler.run_with_target_size(features, target_size)
+
+    def _downsample_region_labels(self, masks: torch.Tensor, grid: tuple[int, int]) -> torch.Tensor:
+        """Region-id maps -> one integer label per patch.
+
+        The reference uses ``cv2.resize`` (bilinear, then uint8 rounding) to reach the 14x14
+        grid, so the default reproduces that including the rounding.
+        """
+        if self.config.mask_interpolation == "nearest":
+            resized = F.interpolate(masks, size=grid, mode="nearest")
+        elif self.config.mask_interpolation == "bilinear":
+            resized = F.interpolate(masks, size=grid, mode="bilinear", align_corners=False).round()
+        else:
+            raise ValueError(f"Unknown UCAD mask interpolation: {self.config.mask_interpolation!r}")
+        return resized[:, 0].reshape(masks.shape[0], -1).to(torch.long)
+
+    def _train_prompt(
+        self, data: np.ndarray, structure_masks: Optional[np.ndarray]
+    ) -> tuple[torch.Tensor, Optional[float]]:
+        initial_prompt = self._initial_prompt()
+        if structure_masks is None or self.config.epochs == 0:
+            return initial_prompt.detach(), None
+        if len(structure_masks) != len(data):
+            raise ValueError(f"UCAD received {len(structure_masks)} structure masks for {len(data)} images")
+
+        mask_array = np.asarray(structure_masks)
+        expected_spatial_size = self._preprocessor.spatial_size(data)
+        if tuple(mask_array.shape[1:3]) != expected_spatial_size:
+            raise ValueError(
+                f"UCAD structure masks have spatial shape {tuple(mask_array.shape[1:3])} but the "
+                f"input images have spatial shape {expected_spatial_size}. Structure mask "
+                "providers assume NHWC images; check config.input_layout if the images are NCHW."
+            )
+
+        images = self._preprocessor.transform(data)
+        masks = torch.as_tensor(mask_array, dtype=torch.float32).unsqueeze(1)
+
+        prompt = nn.Parameter(initial_prompt.detach().clone())
+        optimizer = torch.optim.Adam(
+            [prompt],
+            lr=self.config.learning_rate,
+            betas=(0.9, 0.999),
+            eps=1e-8,
+            weight_decay=self.config.weight_decay,
+        )
+        generator = torch.Generator().manual_seed(self.config.seed) if self.config.seed is not None else None
+        loader = DataLoader(
+            TensorDataset(images, masks),
+            batch_size=self.config.batch_size,
+            shuffle=True,
+            num_workers=0,
+            generator=generator,
+        )
+
+        self.module.eval()
+        final_loss: Optional[float] = None
+        for epoch in range(self.config.epochs):
+            epoch_losses: list[float] = []
+            for image_batch, mask_batch in loader:
+                image_batch = image_batch.to(self._device, dtype=torch.float32)
+                mask_batch = mask_batch.to(self._device)
+
+                tokens = self._forward_patch_tokens(image_batch, prompt)
+                labels = self._downsample_region_labels(mask_batch, self._infer_grid_size(tokens.shape[1]))
+                loss = structure_contrastive_loss(tokens, labels, temperature=self.config.contrastive_temperature)
+
+                optimizer.zero_grad(set_to_none=True)
+                loss.backward()
+                torch.nn.utils.clip_grad_norm_([prompt], self.config.gradient_clip_norm)
+                optimizer.step()
+                epoch_losses.append(float(loss.detach().cpu()))
+
+            final_loss = float(np.mean(epoch_losses)) if epoch_losses else final_loss
+            if self.config.show_training_progress:
+                logger.info(
+                    "UCAD task %d SCL epoch %d/%d loss=%s",
+                    len(self._task_memories),
+                    epoch + 1,
+                    self.config.epochs,
+                    "nan" if final_loss is None else f"{final_loss:.6f}",
+                )
+        return prompt.detach(), final_loss
+
+    def fit(self, data: np.ndarray) -> None:
+        if len(data) == 0:
+            raise ValueError("UCAD cannot learn an empty task")
+        self._apply_seed()
+
+        key_features, grid = self._extract_patch_embeddings(data, prompt=None)
+        if self._grid_size is None:
+            self._grid_size = grid
+        elif self._grid_size != grid:
+            raise ValueError(f"All UCAD tasks must share the same feature grid; expected {self._grid_size}, got {grid}")
+        key = self._select_coreset(key_features, self.config.key_size)
+
+        structure_masks = self._mask_provider.masks_for(self._current_concept_id, np.asarray(data))
+        if structure_masks is None and self.config.epochs > 0:
+            logger.info(
+                "UCAD task %d runs the CPM-only ablation (structure_mode='none'): no SCL performed.",
+                len(self._task_memories),
+            )
+        prompt, final_scl_loss = self._train_prompt(data, structure_masks)
+        self._last_loss = final_scl_loss
+
+        knowledge_features, _ = self._extract_patch_embeddings(data, prompt=prompt)
+        knowledge = self._select_coreset(knowledge_features, self.config.knowledge_size)
+
+        self._task_memories.append(
+            UCADTaskMemory(
+                key=key,
+                prompt=prompt.detach().cpu(),
+                knowledge=knowledge,
+                concept_id=self._current_concept_id,
+                final_scl_loss=final_scl_loss,
+            )
+        )
+        self._key_indices.append(NearestNeighbors(n_neighbors=1, n_jobs=1).fit(key))
+        self._knowledge_indices.append(
+            NearestNeighbors(n_neighbors=min(self.config.n_neighbors, len(knowledge)), n_jobs=1).fit(knowledge)
+        )
+        self._calibrate_threshold(data)
+
+    def _require_fitted(self) -> None:
+        if not self._task_memories or self._grid_size is None:
+            raise RuntimeError("UCAD must learn at least one task before scoring or predicting")
+
+    def _route(self, batch: torch.Tensor) -> np.ndarray:
+        """Task index per image, from the learned keys alone (paper Eq. 4).
+
+        The concept id of the evaluated data is never consulted, which is what makes the
+        evaluation task-agnostic. Distances are squared to match the reference's faiss index;
+        this matters here because the statistic is a mean, which squaring does not commute with.
+        """
+        batch_size = batch.shape[0]
+        if len(self._task_memories) == 1:
+            return np.zeros(batch_size, dtype=np.int64)
+
+        features, grid = self._patch_features(batch, prompt=None)
+        queries = features.reshape(batch_size, grid[0] * grid[1], -1)
+
+        statistics = np.empty((len(self._task_memories), batch_size), dtype=np.float32)
+        for task_index, index in enumerate(self._key_indices):
+            for image_index, query in enumerate(queries):
+                distances, _ = index.kneighbors(query)
+                squared = np.square(distances[:, 0])
+                statistics[task_index, image_index] = (
+                    squared.max() if self.config.routing_statistic == "max" else squared.mean()
+                )
+        return np.argmin(statistics, axis=0).astype(np.int64)
+
+    def _inference_maps(self, batch: torch.Tensor) -> torch.Tensor:
+        self._require_fitted()
+
+        batch_size = batch.shape[0]
+        grid_height, grid_width = self._grid_size
+        patch_scores = np.empty((batch_size, grid_height * grid_width), dtype=np.float32)
+
+        selected = self._route(batch)
+        for task_index in np.unique(selected):
+            positions = np.flatnonzero(selected == task_index)
+            memory = self._task_memories[int(task_index)]
+            features, _ = self._patch_features(batch[positions], memory.prompt)
+            distances, _ = self._knowledge_indices[int(task_index)].kneighbors(features)
+            scores = np.square(distances).mean(axis=1).astype(np.float32, copy=False)
+            patch_scores[positions] = scores.reshape(len(positions), -1)
+
+        self._cached_image_scores = torch.from_numpy(patch_scores.max(axis=1)).to(batch.device)
+        maps = self._segmentor.convert_to_segmentation(patch_scores.reshape(batch_size, grid_height, grid_width))
+        return torch.from_numpy(np.asarray(maps, dtype=np.float32)).to(batch.device)
+
+    def _aggregate_scores(self, score_maps: torch.Tensor) -> torch.Tensor:
+        cached, self._cached_image_scores = self._cached_image_scores, None
+        if cached is not None and cached.shape[0] == score_maps.shape[0]:
+            return cached
+        return super()._aggregate_scores(score_maps)
+
+    def selected_task_indices(self, data: np.ndarray) -> np.ndarray:
+        """Task chosen per image, for routing-accuracy diagnostics."""
+        self._require_fitted()
+        selected: list[np.ndarray] = []
+        for (batch_x,) in self._prepare_batches(data, shuffle=False):
+            selected.append(self._route(batch_x.to(self._device, dtype=torch.float32)))
+        return np.concatenate(selected) if selected else np.asarray([], dtype=np.int64)
+
+    def _variant_label(self) -> str:
+        """Report what actually ran, not what was configured.
+
+        ``config.structure_mode`` is intent: ``_train_prompt`` silently falls back to an
+        untrained prompt (no SCL) whenever structure masks are unavailable for a concept, or
+        whenever ``config.epochs == 0``, regardless of ``structure_mode``. Since this label
+        lands in benchmark result JSON, it must be derived from what happened, not from
+        config. ``UCADTaskMemory.final_scl_loss`` is ``None`` exactly when no SCL ran for that
+        task, so it is the honest signal to key off.
+        """
+        if not self._task_memories:
+            return "no tasks fitted yet"
+        trained = [memory.final_scl_loss is not None for memory in self._task_memories]
+        if all(trained):
+            return "CPM+SCL"
+        if not any(trained):
+            return "CPM-only"
+        return "mixed CPM-only/CPM+SCL"
+
+    def _extra_info(self) -> dict:
+        memory_bytes = sum(
+            memory.key.nbytes + memory.knowledge.nbytes + memory.prompt.numel() * memory.prompt.element_size()
+            for memory in self._task_memories
+        )
+        return {
+            "method": "UCAD",
+            "paper": "Unsupervised Continual Anomaly Detection with Contrastively-learned Prompt (AAAI 2024)",
+            "variant": self._variant_label(),
+            "device": str(self._device),
+            "tasks_seen": len(self._task_memories),
+            "task_concepts": [memory.concept_id for memory in self._task_memories],
+            "key_sizes": [int(len(memory.key)) for memory in self._task_memories],
+            "knowledge_sizes": [int(len(memory.knowledge)) for memory in self._task_memories],
+            "prompt_shapes": [list(memory.prompt.shape) for memory in self._task_memories],
+            "final_scl_losses": [memory.final_scl_loss for memory in self._task_memories],
+            "key_prompt_knowledge_bytes": int(memory_bytes),
+            "epoch_selection": "last",
+        }
+
+    def name(self) -> str:
+        return "UCAD"

--- a/src/pyclad/vision/models/ucad/ucad.py
+++ b/src/pyclad/vision/models/ucad/ucad.py
@@ -13,12 +13,12 @@ from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
 
 from pyclad.vision.models.ucad.config import UCADConfig
-from pyclad.vision.models.ucad.coreset import (
+from pyclad.vision.models.ucad.structure import build_structure_mask_provider
+from pyclad.vision.models.utilities.base_model import VisionScoringBase
+from pyclad.vision.models.utilities.coreset import (
     ApproximateGreedyCoresetSampler,
     RescaleSegmentor,
 )
-from pyclad.vision.models.ucad.structure import build_structure_mask_provider
-from pyclad.vision.models.utilities.base_model import VisionScoringBase
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +72,7 @@ class UCAD(VisionScoringBase):
     No method accepts test data, test labels, or any statistic derived from them. The
     reference implementation selects its prompt and knowledge bank by test AUROC; this port
     trains for a fixed number of epochs and keeps the last one, so its scores are lower than
-    the paper's by construction. See ``docs/vision.md``.
+    the paper's by construction. See "Data leakage" in ``docs/vision.md``.
     """
 
     config: UCADConfig

--- a/src/pyclad/vision/models/utilities/coreset.py
+++ b/src/pyclad/vision/models/utilities/coreset.py
@@ -1,16 +1,18 @@
-"""UCAD's own copies of two PatchCore utilities.
+"""Coreset sampling and anomaly-map rescaling, shared by the patch-memory models.
 
-``RescaleSegmentor`` and ``ApproximateGreedyCoresetSampler`` originate in PatchCore
-(``pyclad.vision.models.patchcore.patchcore``), which is not yet on ``main`` -- it lives on
-another, still-unmerged feature branch. UCAD needs exactly these two helpers, so this module
-carries its own copies (trimmed to only what UCAD calls: ``convert_to_segmentation`` and
-``run_with_target_size``) instead of depending on that branch.
+These two helpers originate in PatchCore and are needed verbatim by every model that scores
+patches against a subsampled memory bank. They live here, in ``utilities``, rather than inside
+one model's package so that no model has to import from another -- the same layering rule that
+keeps models from importing strategy packages.
 
-When the PatchCore model lands on ``main``, this module should be reduced to imports from
-``pyclad.vision.models.patchcore.patchcore`` rather than carrying duplicate implementations.
+Two sizings are offered because the callers ask for different things: PatchCore keeps a
+fraction of its feature pool (``run``), UCAD keeps an exact count (``run_with_target_size``).
+Both go through the same greedy selection.
 """
 
 from __future__ import annotations
+
+from typing import Optional
 
 import numpy as np
 import torch
@@ -43,22 +45,25 @@ class RescaleSegmentor:
 
 
 class ApproximateGreedyCoresetSampler:
-    """Greedy coreset subsampling, restricted to the exact-count entry point UCAD uses.
+    """Greedy coreset subsampling: repeatedly keep the point farthest from what is already kept.
 
-    The original PatchCore utility also offers a percentage-based ``run()`` (and the
-    ``percentage`` constructor parameter that only it needs) plus a weighted-selection
-    variant of the private helper below, for the other model's needs. Neither is reachable
-    from UCAD, which only ever asks for an exact-size coreset, so both are left out here.
+    ``percentage`` is only read by ``run``; a caller that sizes its coreset absolutely uses
+    ``run_with_target_size`` and leaves it unset.
     """
 
     def __init__(
         self,
         device: torch.device,
+        percentage: Optional[float] = None,
         number_of_starting_points: int = 10,
         dimension_to_project_features_to: int = 128,
         random_seed: int = 0,
     ):
+        if percentage is not None and not 0.0 < percentage <= 1.0:
+            raise ValueError("percentage must be in (0, 1]")
+
         self.device = device
+        self.percentage = percentage
         self.number_of_starting_points = number_of_starting_points
         self.dimension_to_project_features_to = dimension_to_project_features_to
         self.random_seed = random_seed
@@ -112,6 +117,19 @@ class ApproximateGreedyCoresetSampler:
                 ).values.reshape(-1, 1)
 
         return np.array(coreset_indices)
+
+    def run(self, features: np.ndarray) -> np.ndarray:
+        """Keep ``percentage`` of ``features``, at least one point."""
+        if self.percentage is None:
+            raise ValueError("run() needs a percentage; pass one to the constructor or call run_with_target_size()")
+        if self.percentage == 1.0:
+            return features
+
+        feature_tensor = torch.from_numpy(features.astype(np.float32, copy=False))
+        reduced_features = self._reduce_features(feature_tensor)
+        num_samples = max(1, int(len(features) * self.percentage))
+        sample_indices = self._compute_greedy_coreset_indices(reduced_features, num_samples=num_samples)
+        return feature_tensor[sample_indices].cpu().numpy().astype(np.float32, copy=False)
 
     def run_with_target_size(self, features: np.ndarray, target_size: int) -> np.ndarray:
         """Select exactly ``target_size`` coreset points, or all of them when there are fewer.

--- a/src/pyclad/vision/strategies/ucad/__init__.py
+++ b/src/pyclad/vision/strategies/ucad/__init__.py
@@ -1,0 +1,5 @@
+"""UCAD's continual strategy: task-agnostic inference over a key-prompt-knowledge memory."""
+
+from pyclad.vision.strategies.ucad.strategy import UCADStrategy
+
+__all__ = ["UCADStrategy"]

--- a/src/pyclad/vision/strategies/ucad/strategy.py
+++ b/src/pyclad/vision/strategies/ucad/strategy.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import numpy as np
+
+from pyclad.strategies.strategy import ConceptAwareStrategy, ConceptIncrementalStrategy
+from pyclad.vision.models.ucad.ucad import UCAD
+from pyclad.vision.prediction_results import VisionPredictionResults
+
+
+class UCADStrategy(ConceptIncrementalStrategy, ConceptAwareStrategy):
+    """Continual strategy for UCAD's key-prompt-knowledge memory (Liu et al., AAAI 2024).
+
+    The continual mechanism lives in the model, which appends one memory entry per concept and
+    never resets. This adapter exists for one reason on each side: ``learn`` passes the concept
+    id down so the model can find that concept's SAM structure masks, and ``predict``
+    **discards** the concept id it is handed so that task identity can only come from the
+    learned keys.
+    """
+
+    def __init__(self, model: UCAD):
+        self._model = model
+        self._tasks_seen = 0
+
+    def learn(self, data: np.ndarray, concept_id: Optional[str] = None, **kwargs) -> None:
+        del kwargs
+        self._model.set_current_concept(concept_id)
+        self._model.fit(data)
+        self._tasks_seen += 1
+
+    def predict(self, data: np.ndarray, concept_id: Optional[str] = None, **kwargs) -> VisionPredictionResults:
+        # concept_id is deliberately discarded: revealing the evaluated concept would turn a
+        # task-agnostic method into a task-aware one and inflate every reported metric.
+        del concept_id, kwargs
+        return self._model.predict(data)
+
+    def name(self) -> str:
+        return "UCAD"
+
+    def additional_info(self) -> Dict:
+        return {
+            "continual_mechanism": "key_prompt_knowledge",
+            "task_agnostic_inference": True,
+            "tasks_seen": self._tasks_seen,
+        }

--- a/tests/vision/models/test_coreset.py
+++ b/tests/vision/models/test_coreset.py
@@ -1,0 +1,82 @@
+"""Shared greedy-coreset sampler: both sizings, and the invariant that ties them together."""
+
+import numpy as np
+import pytest
+import torch
+
+from pyclad.vision.models.utilities.coreset import ApproximateGreedyCoresetSampler
+
+DEVICE = torch.device("cpu")
+SAMPLER_KWARGS = dict(number_of_starting_points=3, dimension_to_project_features_to=8, random_seed=7)
+
+
+def _features(rows: int, dim: int = 16) -> np.ndarray:
+    return np.random.RandomState(rows + dim).rand(rows, dim).astype(np.float32)
+
+
+def _sampler(**overrides):
+    return ApproximateGreedyCoresetSampler(device=DEVICE, **{**SAMPLER_KWARGS, **overrides})
+
+
+def test_target_size_returns_exactly_that_many_points():
+    coreset = _sampler().run_with_target_size(_features(60), target_size=17)
+    assert coreset.shape == (17, 16)
+
+
+def test_target_size_keeps_everything_when_the_pool_is_smaller():
+    features = _features(5)
+    np.testing.assert_array_equal(_sampler().run_with_target_size(features, target_size=196), features)
+
+
+@pytest.mark.parametrize("target_size", [0, -1])
+def test_target_size_must_be_positive(target_size):
+    with pytest.raises(ValueError, match="target_size must be positive"):
+        _sampler().run_with_target_size(_features(20), target_size=target_size)
+
+
+def test_percentage_keeps_that_fraction_of_the_pool():
+    assert _sampler(percentage=0.3).run(_features(100)).shape == (30, 16)
+
+
+def test_percentage_keeps_at_least_one_point():
+    assert _sampler(percentage=0.01).run(_features(7)).shape == (1, 16)
+
+
+def test_a_full_percentage_returns_the_pool_untouched():
+    features = _features(40)
+    assert _sampler(percentage=1.0).run(features) is features
+
+
+def test_run_without_a_percentage_is_rejected():
+    with pytest.raises(ValueError, match="needs a percentage"):
+        _sampler().run(_features(20))
+
+
+@pytest.mark.parametrize("percentage", [0.0, -0.2, 1.5])
+def test_percentage_outside_the_unit_interval_is_rejected(percentage):
+    with pytest.raises(ValueError, match=r"percentage must be in \(0, 1\]"):
+        _sampler(percentage=percentage)
+
+
+def test_the_two_entry_points_agree_when_they_ask_for_the_same_count():
+    """`run(0.25)` on 80 points and `run_with_target_size(20)` must select the same 20."""
+    features = _features(80)
+    np.testing.assert_array_equal(
+        _sampler(percentage=0.25).run(features),
+        _sampler().run_with_target_size(features, target_size=20),
+    )
+
+
+def test_the_same_seed_selects_the_same_coreset():
+    features = _features(50)
+    first = _sampler(random_seed=3).run_with_target_size(features, target_size=11)
+    second = _sampler(random_seed=3).run_with_target_size(features, target_size=11)
+    np.testing.assert_array_equal(first, second)
+
+
+def test_a_different_seed_selects_a_different_coreset():
+    features = _features(50)
+    assert not np.array_equal(
+        _sampler(random_seed=3).run_with_target_size(features, target_size=11),
+        _sampler(random_seed=99).run_with_target_size(features, target_size=11),
+    )

--- a/tests/vision/models/test_ucad.py
+++ b/tests/vision/models/test_ucad.py
@@ -1,0 +1,372 @@
+import numpy as np
+import pytest
+import torch
+from sklearn.neighbors import NearestNeighbors
+
+from pyclad.vision.models.ucad.config import UCADConfig
+from pyclad.vision.models.ucad.ucad import (
+    UCAD,
+    UCADTaskMemory,
+    structure_contrastive_loss,
+)
+from pyclad.vision.models.utilities.base_model import VisionScoringBase
+from pyclad.vision.prediction_results import VisionPredictionResults
+
+
+def test_loss_matches_the_reference_formula_on_a_hand_computed_case():
+    # Two orthogonal unit features in different regions. Normalised cosine similarities are
+    # [[1, 0], [0, 1]]; divided by T=0.5 that is [[2, 0], [0, 2]]. The reference computes
+    # (-sim * same_region + exp(sim) * (1 - same_region)).mean(), keeping the self-pairs:
+    #   same-region diagonal: -2 and -2;  cross-region off-diagonal: exp(0) and exp(0)
+    #   mean = (-2 + 1 + 1 - 2) / 4 = -0.5
+    features = torch.tensor([[[1.0, 0.0], [0.0, 1.0]]])
+    labels = torch.tensor([[0, 1]])
+
+    assert structure_contrastive_loss(features, labels, temperature=0.5).item() == pytest.approx(-0.5)
+
+
+def test_identical_regions_give_a_purely_attractive_loss():
+    features = torch.tensor([[[1.0, 0.0], [0.0, 1.0]]])
+    labels = torch.tensor([[0, 0]])
+
+    # every pair is same-region: mean(-sim) = -(2 + 0 + 0 + 2) / 4 = -1.0
+    assert structure_contrastive_loss(features, labels, temperature=0.5).item() == pytest.approx(-1.0)
+
+
+def test_loss_is_invariant_to_feature_magnitude():
+    features = torch.tensor([[[3.0, 0.0], [0.0, 7.0]]])
+    labels = torch.tensor([[0, 1]])
+
+    assert structure_contrastive_loss(features, labels, temperature=0.5).item() == pytest.approx(-0.5)
+
+
+def test_loss_rejects_mismatched_shapes():
+    with pytest.raises(ValueError, match="region_labels must have shape"):
+        structure_contrastive_loss(torch.zeros(1, 2, 2), torch.zeros(1, 3, dtype=torch.long))
+
+    with pytest.raises(ValueError, match=r"patch_features must have shape"):
+        structure_contrastive_loss(torch.zeros(2, 2), torch.zeros(2, dtype=torch.long))
+
+    with pytest.raises(ValueError, match="temperature must be positive"):
+        structure_contrastive_loss(torch.zeros(1, 2, 2), torch.zeros(1, 2, dtype=torch.long), temperature=0.0)
+
+
+timm = pytest.importorskip("timm")
+
+
+def _config(**overrides) -> UCADConfig:
+    """A ViT-Tiny at 32x32: a 2x2 patch grid, 4 patches per image. CPU-fast."""
+    defaults = dict(
+        backbone_name="vit_tiny_patch16_224",
+        pretrained_backbone=False,
+        input_size=(32, 32),
+        input_range="float01",
+        batch_size=2,
+        feature_layer=3,
+        prompt_depth=3,
+        target_embed_dimension=16,
+        key_size=3,
+        knowledge_size=3,
+        coreset_projection_dimension=4,
+        coreset_starting_points=2,
+        epochs=1,
+        seed=0,
+    )
+    defaults.update(overrides)
+    return UCADConfig(**defaults)
+
+
+def _images(count: int, fill: float, seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return (rng.random((count, 32, 32, 3), dtype=np.float32) * 0.1 + fill).astype(np.float32)
+
+
+def test_backbone_is_frozen_and_the_prompt_is_the_only_trainable_tensor():
+    model = UCAD(_config())
+
+    assert all(not p.requires_grad for p in model.module.parameters())
+
+
+def test_patch_features_have_the_mapped_dimension_and_a_square_grid():
+    model = UCAD(_config())
+    batch = model._preprocessor.transform(_images(2, 0.3)).to(model._device)
+
+    features, grid = model._patch_features(batch, prompt=None)
+
+    assert grid == (2, 2)
+    assert features.shape == (2 * 4, 16)
+    assert features.dtype == np.float32
+
+
+def test_the_prompt_changes_the_features_and_receives_the_only_gradient():
+    model = UCAD(_config())
+    batch = model._preprocessor.transform(_images(2, 0.3)).to(model._device)
+
+    unprompted = model._forward_patch_tokens(batch, None)
+    prompt = torch.nn.Parameter(model._initial_prompt())
+    prompted = model._forward_patch_tokens(batch, prompt)
+
+    assert not torch.allclose(unprompted, prompted)
+
+    prompted.sum().backward()
+    assert prompt.grad is not None
+    assert torch.isfinite(prompt.grad).all()
+    assert all(p.grad is None for p in model.module.parameters())
+
+
+def test_initial_prompt_has_the_prefix_key_value_shape():
+    model = UCAD(_config(prompt_depth=3, prompt_length=1))
+    heads = model.module.blocks[0].attn.num_heads
+
+    assert tuple(model._initial_prompt().shape) == (3, 2, 1, heads, model.module.embed_dim // heads)
+
+
+def test_zero_prompt_init_leaves_a_zero_tensor():
+    model = UCAD(_config(prompt_init="zero"))
+
+    assert torch.count_nonzero(model._initial_prompt()) == 0
+
+
+def test_a_non_vit_backbone_is_rejected_with_a_clear_message():
+    with pytest.raises(TypeError, match="compatible timm ViT"):
+        UCAD(_config(backbone_name="resnet18"))
+
+
+def test_feature_layer_beyond_the_backbone_depth_is_rejected():
+    with pytest.raises(ValueError, match="exceeds backbone depth"):
+        UCAD(_config(feature_layer=99, prompt_depth=1))
+
+
+def test_fit_appends_one_task_memory_per_call_and_never_resets():
+    model = UCAD(_config())
+
+    model.set_current_concept("a")
+    model.fit(_images(4, 0.2, seed=1))
+    model.set_current_concept("b")
+    model.fit(_images(4, 0.7, seed=2))
+
+    assert len(model.task_memories) == 2
+    assert [memory.concept_id for memory in model.task_memories] == ["a", "b"]
+
+
+def test_key_and_knowledge_are_capped_at_the_configured_sizes():
+    model = UCAD(_config(key_size=3, knowledge_size=2))
+    model.fit(_images(4, 0.2))  # 4 images * 4 patches = 16 candidate vectors
+
+    memory = model.task_memories[0]
+    assert memory.key.shape == (3, 16)
+    assert memory.knowledge.shape == (2, 16)
+
+
+def test_all_patches_are_kept_when_there_are_fewer_than_the_target():
+    model = UCAD(_config(key_size=999, knowledge_size=999))
+    model.fit(_images(2, 0.2))  # 2 images * 4 patches = 8 vectors
+
+    assert model.task_memories[0].key.shape == (8, 16)
+
+
+def test_cpm_only_ablation_does_not_train_the_prompt():
+    # prompt_init="zero" makes this deterministic without reasoning about RNG ordering: an
+    # untrained zero prompt must still be all zeros after fit.
+    model = UCAD(_config(structure_mode="none", epochs=5, prompt_init="zero"))
+
+    model.fit(_images(4, 0.2))
+
+    memory = model.task_memories[0]
+    assert memory.final_scl_loss is None
+    assert torch.count_nonzero(memory.prompt) == 0
+
+
+def test_scl_training_moves_the_prompt_and_records_a_loss(tmp_path):
+    from PIL import Image
+
+    directory = tmp_path / "bottle"
+    directory.mkdir(parents=True)
+    rng = np.random.default_rng(3)
+    for index in range(4):
+        regions = rng.integers(0, 3, size=(32, 32)).astype(np.uint8)
+        Image.fromarray(regions, mode="L").save(directory / f"{index:03d}.png")
+
+    model = UCAD(
+        _config(
+            structure_mode="precomputed",
+            structure_mask_root=str(tmp_path),
+            epochs=2,
+            prompt_init="zero",
+        )
+    )
+
+    model.set_current_concept("bottle")
+    model.fit(_images(4, 0.2))
+
+    memory = model.task_memories[0]
+    assert memory.final_scl_loss is not None
+    assert np.isfinite(memory.final_scl_loss)
+    assert torch.count_nonzero(memory.prompt) > 0  # a zero prompt that trained is no longer zero
+    assert model.additional_info()["variant"] == "CPM+SCL"
+    assert model.additional_info()["last_loss"] == memory.final_scl_loss
+
+
+def test_train_prompt_rejects_structure_masks_with_the_wrong_spatial_shape():
+    # A mask array shaped like NCHW-misread dimensions (e.g. (channels, height) instead of
+    # (height, width)) must raise rather than silently train on garbage region labels.
+    model = UCAD(_config())
+    data = _images(2, 0.2)
+    wrong_shape_masks = np.zeros((2, 3, 32), dtype=np.int64)
+
+    with pytest.raises(ValueError, match=r"\(3, 32\).*\(32, 32\)"):
+        model._train_prompt(data, wrong_shape_masks)
+
+
+def test_fit_rejects_an_empty_task():
+    model = UCAD(_config())
+
+    with pytest.raises(ValueError, match="cannot learn an empty task"):
+        model.fit(np.empty((0, 32, 32, 3), dtype=np.float32))
+
+
+def test_tasks_must_share_a_patch_grid():
+    # Mutating config.input_size would not work: the preprocessor captured its size at
+    # construction. Set the recorded grid directly to stand in for an earlier task that had one.
+    model = UCAD(_config())
+    model.fit(_images(2, 0.2))
+    model._grid_size = (7, 7)
+
+    with pytest.raises(ValueError, match="must share the same feature grid"):
+        model.fit(_images(2, 0.5))
+
+
+def _two_task_model(**overrides) -> UCAD:
+    model = UCAD(_config(**overrides))
+    model.set_current_concept("dark")
+    model.fit(_images(4, 0.05, seed=11))
+    model.set_current_concept("bright")
+    model.fit(_images(4, 0.85, seed=12))
+    return model
+
+
+def test_predict_returns_the_vision_contract():
+    model = _two_task_model()
+
+    result = model.predict(_images(3, 0.05, seed=21))
+
+    assert isinstance(result, VisionPredictionResults)
+    assert result.y_pred.shape == (3,)
+    assert result.anomaly_scores.shape == (3,)
+    assert result.score_maps.shape == (3, 32, 32)
+
+
+def test_routing_is_per_image_within_a_single_batch():
+    model = _two_task_model(batch_size=8)
+    mixed = np.concatenate([_images(3, 0.05, seed=31), _images(3, 0.85, seed=32)])
+
+    selected = model.selected_task_indices(mixed)
+
+    assert selected.shape == (6,)
+    assert set(selected[:3]) == {0}
+    assert set(selected[3:]) == {1}
+
+
+def test_a_single_task_routes_everything_to_itself():
+    model = UCAD(_config())
+    model.fit(_images(4, 0.2))
+
+    np.testing.assert_array_equal(model.selected_task_indices(_images(3, 0.9)), np.zeros(3, dtype=np.int64))
+
+
+def test_reported_score_is_the_cached_raw_patch_maximum_and_the_cache_is_cleared_after_predict():
+    # Smoothing with sigma=4 flattens a 2x2 map towards its mean, so the raw per-patch maximum
+    # UCAD caches and reports must differ from what generic max-pooling over the (already
+    # smoothed, already resized) returned maps would give -- that gap is real but only ~5e-4 on
+    # this grid, far too thin a margin to rest a regression guard on. So pin the handshake
+    # itself rather than a magnitude comparison: the reported score must not equal what
+    # VisionScoringBase._aggregate_scores computes from the same maps, and the cache the
+    # override consumes must not survive past predict() to leak into a later batch.
+    model = UCAD(_config(smoothing_sigma=4.0))
+    model.fit(_images(4, 0.2))
+
+    result = model.predict(_images(2, 0.9, seed=41))
+
+    generic_scores = VisionScoringBase._aggregate_scores(model, torch.from_numpy(result.score_maps))
+    assert not np.array_equal(result.anomaly_scores, generic_scores.numpy())
+    assert model._cached_image_scores is None
+
+
+def test_patch_scores_are_squared_l2_like_the_reference_faiss_index():
+    # The reference NearestNeighbourScorer is backed by faiss.IndexFlatL2, which returns SQUARED
+    # distances; sklearn returns plain Euclidean. A knowledge bank at the origin and a query at
+    # distance 3 must score 9, not 3. Two patches at clearly different distances (3 -> squared 9,
+    # 1 -> squared 1) also pin that the image score is the MAX over patches (9), not their mean
+    # (5) -- a 1x1 grid could not distinguish those, since max and mean coincide there.
+    model = UCAD(_config(n_neighbors=1))
+    model._grid_size = (1, 2)
+    model._task_memories.append(
+        UCADTaskMemory(
+            key=np.zeros((1, 4), dtype=np.float32), prompt=torch.zeros(1), knowledge=np.zeros((1, 4), dtype=np.float32)
+        )
+    )
+    model._key_indices.append(NearestNeighbors(n_neighbors=1).fit(np.zeros((1, 4), dtype=np.float32)))
+    model._knowledge_indices.append(NearestNeighbors(n_neighbors=1).fit(np.zeros((1, 4), dtype=np.float32)))
+    model._threshold = 0.0
+    model._patch_features = lambda images, prompt: (
+        np.array([[3.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], dtype=np.float32),
+        (1, 2),
+    )
+
+    result = model.predict(_images(1, 0.2))
+
+    assert result.anomaly_scores[0] == pytest.approx(9.0)
+
+
+def test_predict_before_fit_raises():
+    model = UCAD(_config())
+
+    with pytest.raises(RuntimeError, match="must learn at least one task"):
+        model.predict(_images(2, 0.2))
+
+
+def test_predict_handles_empty_input():
+    model = UCAD(_config(threshold=0.0))
+    model.fit(_images(2, 0.2))
+
+    result = model.predict(np.empty((0, 32, 32, 3), dtype=np.float32))
+
+    assert result.y_pred.shape == (0,)
+
+
+def test_additional_info_reports_the_memory_and_the_variant():
+    model = _two_task_model()
+
+    info = model.additional_info()
+
+    assert info["tasks_seen"] == 2
+    assert info["task_concepts"] == ["dark", "bright"]
+    assert info["variant"] == "CPM-only"
+    assert info["key_prompt_knowledge_bytes"] > 0
+
+
+def test_variant_is_cpm_only_when_epochs_is_zero_even_with_structure_mode_precomputed(tmp_path):
+    # structure_mode="precomputed" is configuration intent; epochs=0 makes _train_prompt return
+    # an untrained prompt regardless, so no SCL actually ran. The reported variant must say so.
+    from PIL import Image
+
+    directory = tmp_path / "bottle"
+    directory.mkdir(parents=True)
+    rng = np.random.default_rng(3)
+    for index in range(4):
+        regions = rng.integers(0, 3, size=(32, 32)).astype(np.uint8)
+        Image.fromarray(regions, mode="L").save(directory / f"{index:03d}.png")
+
+    model = UCAD(
+        _config(
+            structure_mode="precomputed",
+            structure_mask_root=str(tmp_path),
+            epochs=0,
+        )
+    )
+
+    model.set_current_concept("bottle")
+    model.fit(_images(4, 0.2))
+
+    assert model.task_memories[0].final_scl_loss is None
+    assert model.additional_info()["variant"] == "CPM-only"

--- a/tests/vision/models/test_ucad_config.py
+++ b/tests/vision/models/test_ucad_config.py
@@ -1,0 +1,60 @@
+import pytest
+
+from pyclad.vision.models.ucad.config import UCADConfig
+
+
+def test_defaults_match_the_reference_implementation():
+    config = UCADConfig()
+
+    assert config.backbone_name == "vit_base_patch16_224.augreg_in21k_ft_in1k"
+    assert config.input_size == (224, 224)
+    assert config.batch_size == 8
+    assert config.feature_layer == 6
+    assert config.prompt_depth == 6
+    assert config.prompt_length == 1
+    assert config.prompt_init == "uniform"
+    assert config.target_embed_dimension == 1024
+    assert config.key_size == 196
+    assert config.knowledge_size == 196
+    assert config.coreset_projection_dimension == 128
+    assert config.coreset_starting_points == 10
+    assert config.n_neighbors == 1
+    assert config.epochs == 25
+    assert config.learning_rate == pytest.approx(5e-4)
+    assert config.weight_decay == 0.0
+    assert config.gradient_clip_norm == pytest.approx(1.0)
+    assert config.contrastive_temperature == pytest.approx(0.5)
+    assert config.smoothing_sigma == pytest.approx(4.0)
+    assert config.score_mode == "max"
+    assert config.structure_mode == "none"
+    assert config.mask_interpolation == "bilinear"
+    assert config.routing_statistic == "mean"
+    assert config.normalize_mean == (0.485, 0.456, 0.406)
+
+
+def test_prompt_depth_may_exceed_feature_layer_like_the_reference():
+    # The reference prompts all 12 blocks while reading features after block index 5. Blocks
+    # past the read-out point receive no gradient, so this is wasteful but valid -- and it is
+    # the configuration the authors actually ran. Rejecting it would make fidelity unreachable.
+    config = UCADConfig(prompt_depth=12, feature_layer=6)
+
+    assert config.prompt_depth == 12
+
+
+def test_precomputed_mode_requires_an_existing_mask_root(tmp_path):
+    with pytest.raises(ValueError, match="structure_mask_root"):
+        UCADConfig(structure_mode="precomputed")
+
+    with pytest.raises(ValueError, match="does not exist"):
+        UCADConfig(structure_mode="precomputed", structure_mask_root=str(tmp_path / "nope"))
+
+    UCADConfig(structure_mode="precomputed", structure_mask_root=str(tmp_path))
+
+
+def test_sam_mode_requires_an_existing_checkpoint(tmp_path):
+    with pytest.raises(ValueError, match="sam_checkpoint"):
+        UCADConfig(structure_mode="sam")
+
+    checkpoint = tmp_path / "sam.pth"
+    checkpoint.write_bytes(b"stub")
+    UCADConfig(structure_mode="sam", sam_checkpoint=str(checkpoint))

--- a/tests/vision/models/test_ucad_no_leakage.py
+++ b/tests/vision/models/test_ucad_no_leakage.py
@@ -1,0 +1,309 @@
+"""Executable guarantees that UCAD never uses test data or test labels.
+
+The reference implementation (https://github.com/shirowalker/UCAD) picks the prompt and the
+knowledge bank by the best test AUROC over 25 epochs, reports a running ensemble of scores
+across epochs, min-max normalises over the whole test set, and routes one task id per test set.
+Each test below pins the property that makes one of those impossible here.
+"""
+
+import inspect
+from typing import Iterator, Tuple
+
+import numpy as np
+import pytest
+import torch
+
+from pyclad.vision.models.ucad.config import UCADConfig
+from pyclad.vision.models.ucad.ucad import UCAD
+from pyclad.vision.strategies.ucad.strategy import UCADStrategy
+
+pytest.importorskip("timm")
+
+
+def _config(**overrides) -> UCADConfig:
+    defaults = dict(
+        backbone_name="vit_tiny_patch16_224",
+        pretrained_backbone=False,
+        input_size=(32, 32),
+        input_range="float01",
+        batch_size=2,
+        feature_layer=3,
+        prompt_depth=3,
+        target_embed_dimension=16,
+        key_size=3,
+        knowledge_size=3,
+        coreset_projection_dimension=4,
+        coreset_starting_points=2,
+        epochs=1,
+        seed=0,
+    )
+    defaults.update(overrides)
+    return UCADConfig(**defaults)
+
+
+def _images(count: int, fill: float, seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return (rng.random((count, 32, 32, 3), dtype=np.float32) * 0.1 + fill).astype(np.float32)
+
+
+def _two_task_model(**overrides) -> UCAD:
+    model = UCAD(_config(**overrides))
+    model.set_current_concept("dark")
+    model.fit(_images(4, 0.05, seed=1))
+    model.set_current_concept("bright")
+    model.fit(_images(4, 0.85, seed=2))
+    return model
+
+
+def _candidate_state_values(state: dict) -> Iterator[Tuple[str, object]]:
+    """Yield every ``(qualified_name, value)`` reachable from a ``vars(...)`` snapshot.
+
+    Descends into list/tuple elements, dict values, and any plain object's own ``__dict__`` --
+    which is what makes ``UCADTaskMemory.key/knowledge/prompt`` (reached through
+    ``model._task_memories``) and a fitted ``NearestNeighbors._fit_X`` (reached through
+    ``model._key_indices``/``model._knowledge_indices``) discoverable, not just the top-level
+    attributes of whatever ``state`` was passed in.
+
+    It does not descend into ``torch.nn.Module`` instances (notably ``model.module``, the
+    frozen ViT backbone): that subtree is hundreds of parameters and buffers deep, none of
+    which UCAD ever refits, so walking it would add traversal cost without adding coverage.
+    """
+
+    def walk(name: str, value: object, seen: set) -> Iterator[Tuple[str, object]]:
+        yield name, value
+        if isinstance(value, (np.ndarray, torch.Tensor)) or isinstance(value, torch.nn.Module):
+            return
+        if id(value) in seen:
+            return
+        if isinstance(value, (list, tuple)):
+            seen.add(id(value))
+            for index, item in enumerate(value):
+                yield from walk(f"{name}[{index}]", item, seen)
+        elif isinstance(value, dict):
+            seen.add(id(value))
+            for key, item in value.items():
+                yield from walk(f"{name}[{key!r}]", item, seen)
+        elif hasattr(value, "__dict__"):
+            seen.add(id(value))
+            for attr_name, attr_value in vars(value).items():
+                yield from walk(f"{name}.{attr_name}", attr_value, seen)
+
+    seen: set = set()
+    for name, value in state.items():
+        yield from walk(name, value, seen)
+
+
+def test_fit_accepts_training_data_and_nothing_else():
+    # A tripwire against someone adding `test_data=` or `labels=` to reach the reference's
+    # best-epoch-on-test selection.
+    fit_params = inspect.signature(UCAD.fit).parameters
+    assert list(fit_params) == ["self", "data"]
+    # Name-only comparison above would also be satisfied by `def fit(self, **data)`, which keeps
+    # the same parameter name while accepting arbitrary extra kwargs; confirm `data` is an
+    # ordinary positional parameter, not a disguised catch-all.
+    assert fit_params["data"].kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+
+    learn_params = inspect.signature(UCADStrategy.learn).parameters
+    assert list(learn_params) == ["self", "data", "concept_id", "kwargs"]
+    # Name-only comparison above would also be satisfied by an ordinary parameter literally
+    # named `kwargs`; confirm it is actually the catch-all `**kwargs` and not a disguised
+    # extra field that would let `learn(train, concept_id="a", kwargs={"test_data": X})` in.
+    assert learn_params["kwargs"].kind == inspect.Parameter.VAR_KEYWORD
+
+
+def test_learn_discards_unknown_keyword_arguments():
+    # The signature tripwire above cannot fire on `**kwargs`, which is exactly the route by
+    # which `learn(train, concept_id="a", test_data=X)` would arrive. Two separate properties
+    # must hold for the kwargs to be harmless: they must not have changed what was learned
+    # (checked below by comparing thresholds/memories against a clean run), AND they must not
+    # have been kept anywhere at all. A `learn` that stashed `self._leak = kwargs` or
+    # `self._model._leak = kwargs["test_data"]` would pass the comparison untouched -- nothing
+    # it changed -- while still having let test data reach `fit()`. The walk below asserts
+    # non-storage directly instead of inferring it from non-influence.
+    data = _images(4, 0.05, seed=101)
+    # 20 is distinct from every other array length used in this file (batch sizes, key/knowledge
+    # sizes, per-task image counts), so a leading dimension of 20 anywhere in the learned state
+    # can only have come from this leak.
+    leak = _images(20, 0.95, seed=102)
+
+    clean_strategy = UCADStrategy(UCAD(_config()))
+    clean_strategy.learn(data, concept_id="dark")
+
+    leaked_strategy = UCADStrategy(UCAD(_config()))
+    leaked_strategy.learn(data, concept_id="dark", test_data=leak, labels=np.ones(len(leak)))
+
+    clean_model, leaked_model = clean_strategy._model, leaked_strategy._model
+    assert clean_model._threshold == leaked_model._threshold
+    assert len(clean_model.task_memories) == len(leaked_model.task_memories) == 1
+    for clean_memory, leaked_memory in zip(clean_model.task_memories, leaked_model.task_memories):
+        np.testing.assert_array_equal(clean_memory.key, leaked_memory.key)
+        np.testing.assert_array_equal(clean_memory.knowledge, leaked_memory.knowledge)
+        torch.testing.assert_close(clean_memory.prompt, leaked_memory.prompt)
+
+    for owner_name, owner in (("strategy", leaked_strategy), ("model", leaked_model)):
+        for name, value in _candidate_state_values(vars(owner)):
+            if isinstance(value, (np.ndarray, torch.Tensor)) and value.ndim > 0 and value.shape[0] == len(leak):
+                raise AssertionError(f"UCAD kept the leaked kwarg on {owner_name}.{name}")
+
+
+def test_scores_do_not_depend_on_how_the_batch_is_composed():
+    # The strongest structural guarantee available: if any statistic were pooled over the
+    # evaluated set (the reference's per-test-set min-max normalisation and per-test-set task
+    # routing), splitting or reordering the same images would move their scores.
+    model = _two_task_model(batch_size=8)
+    data = np.concatenate([_images(3, 0.05, seed=31), _images(3, 0.85, seed=32)])
+
+    whole = model.predict(data).anomaly_scores
+    # A constant scorer would make every assert_allclose below pass vacuously; rule it out.
+    assert len(np.unique(whole)) > 1, "fixture is degenerate: scores must vary"
+
+    model.config.batch_size = 1
+    one_at_a_time = model.predict(data).anomaly_scores
+
+    order = np.array([4, 0, 5, 2, 1, 3])
+    model.config.batch_size = 8
+    shuffled = model.predict(data[order]).anomaly_scores
+
+    np.testing.assert_allclose(whole, one_at_a_time, rtol=1e-5, atol=1e-6)
+    np.testing.assert_allclose(whole[order], shuffled, rtol=1e-5, atol=1e-6)
+
+
+def test_routing_does_not_depend_on_how_the_batch_is_composed():
+    model = _two_task_model(batch_size=8)
+    data = np.concatenate([_images(3, 0.05, seed=33), _images(3, 0.85, seed=34)])
+
+    whole = model.selected_task_indices(data)
+
+    model.config.batch_size = 1
+    one_at_a_time = model.selected_task_indices(data)
+    # This test's sensitivity depends on the fixture actually exercising more than one task: if
+    # every image routed to the same task, a batch-pooled argmin would coincidentally agree with
+    # a per-image argmin and this test would pass even against the leak it is meant to catch.
+    # Assert that on `one_at_a_time`, not on `whole`: `one_at_a_time` runs one image per batch and
+    # so is structurally unpoolable, whereas `whole` is exactly the batch-pooled path under test.
+    # That way a real pooling leak fails on the comparison below, with an honest message, instead
+    # of failing here with a misleading "fixture is degenerate".
+    assert len(np.unique(one_at_a_time)) > 1, "fixture is degenerate: routing must visit more than one task"
+
+    np.testing.assert_array_equal(whole, one_at_a_time)
+
+
+def test_predict_does_not_mutate_any_learned_state():
+    model = _two_task_model()
+    before_threshold = model._threshold
+    before_keys = [memory.key.copy() for memory in model.task_memories]
+    before_knowledge = [memory.knowledge.copy() for memory in model.task_memories]
+    before_prompts = [memory.prompt.clone() for memory in model.task_memories]
+    # NearestNeighbors.fit(...)'s own training data -- catches a refit-on-test-features leak
+    # that would leave key/knowledge/prompt themselves untouched. `_fit_X` is a private sklearn
+    # attribute (no leading underscore in the public API), so a scikit-learn version bump that
+    # renames or removes it turns this guarantee into a loud `AttributeError` here rather than
+    # a silent pass.
+    before_key_index_data = [index._fit_X.copy() for index in model._key_indices]
+    before_knowledge_index_data = [index._fit_X.copy() for index in model._knowledge_indices]
+
+    model.predict(_images(5, 0.9, seed=41))
+    model.predict(_images(5, 0.02, seed=42))
+
+    assert model._threshold == before_threshold
+    assert len(model.task_memories) == 2
+    for memory, key, knowledge, prompt in zip(model.task_memories, before_keys, before_knowledge, before_prompts):
+        np.testing.assert_array_equal(memory.key, key)
+        np.testing.assert_array_equal(memory.knowledge, knowledge)
+        torch.testing.assert_close(memory.prompt, prompt)
+    for index, fit_data in zip(model._key_indices, before_key_index_data):
+        np.testing.assert_array_equal(index._fit_X, fit_data)
+    for index, fit_data in zip(model._knowledge_indices, before_knowledge_index_data):
+        np.testing.assert_array_equal(index._fit_X, fit_data)
+
+
+def test_threshold_is_a_quantile_of_training_scores_only():
+    model = UCAD(_config(threshold_quantile=0.9))
+    train = _images(6, 0.2, seed=51)
+    model.fit(train)
+
+    expected = float(np.quantile(model._score_data(train), 0.9))
+
+    assert model._threshold == pytest.approx(expected, rel=1e-5)
+
+
+def test_scoring_test_data_never_moves_the_threshold():
+    model = UCAD(_config())
+    model.fit(_images(6, 0.2, seed=61))
+    before = model._threshold
+    before_resolved = model._resolve_threshold()
+
+    model.predict(_images(20, 0.95, seed=62))  # wildly out-of-distribution
+
+    # `_resolve_threshold()` is what actually gates `y_pred`; `config.threshold` overrides
+    # `_threshold` there, so a leak that wrote `config.threshold` from test scores would move
+    # every prediction while leaving `_threshold` itself untouched and this test green.
+    assert model._threshold == before
+    assert model._resolve_threshold() == before_resolved
+
+
+def test_repeated_prediction_is_deterministic():
+    model = _two_task_model()
+    data = _images(4, 0.5, seed=71)
+
+    first = model.predict(data)
+    second = model.predict(data)
+
+    np.testing.assert_array_equal(first.anomaly_scores, second.anomaly_scores)
+    np.testing.assert_array_equal(first.y_pred, second.y_pred)
+
+
+def test_strategy_predict_cannot_be_steered_by_the_concept_id():
+    strategy = UCADStrategy(UCAD(_config()))
+    strategy.learn(_images(4, 0.05, seed=81), concept_id="dark")
+    strategy.learn(_images(4, 0.85, seed=82), concept_id="bright")
+    data = _images(4, 0.05, seed=83)
+
+    baseline = strategy.predict(data, concept_id="dark").anomaly_scores
+    # A scorer that returns a constant would trivially pass every comparison below; rule it out.
+    assert len(np.unique(baseline)) > 1, "fixture is degenerate: baseline scores must vary"
+
+    for wrong in ("bright", "does-not-exist", None):
+        np.testing.assert_array_equal(strategy.predict(data, concept_id=wrong).anomaly_scores, baseline)
+
+    # Every predict() above left `_current_concept_id` pinned to "bright" (the last-learned
+    # concept), so a `_route` that consulted `self._current_concept_id` instead of the learned
+    # keys could still have passed. Move the model's own current-concept state mid-stream and
+    # check the predicted concept_id argument still cannot move the scores. This additionally
+    # assumes the "dark" and "bright" task memories don't coincidentally score `data` identically
+    # -- if they did, a `_route` that leaked `_current_concept_id` into task selection would
+    # still land on a different task yet report the same score, and this check would not catch it.
+    strategy._model.set_current_concept("dark")
+    np.testing.assert_array_equal(strategy.predict(data, concept_id="dark").anomaly_scores, baseline)
+
+    strategy._model.set_current_concept("does-not-exist")
+    np.testing.assert_array_equal(strategy.predict(data, concept_id="dark").anomaly_scores, baseline)
+
+
+def test_the_model_holds_no_reference_to_evaluated_data_after_predict():
+    model = _two_task_model()
+    probe = _images(5, 0.42, seed=91)
+    # 5 does not collide with this model's key_size/knowledge_size (3) or either task's fit image
+    # count (4), so a leading dimension of 5 anywhere in the model's state can only have come
+    # from the probe -- there is no legitimate array this model could hold with that shape.
+    # config.batch_size is set to exactly len(probe) below so the whole probe arrives in a single
+    # batch; a single batch preserves the leading dimension, so anything retained from it keeps
+    # that leading dimension even after the preprocessor resizes/reshapes it.
+    model.config.batch_size = len(probe)
+
+    model.predict(probe)
+
+    for name, value in _candidate_state_values(vars(model)):
+        if not (isinstance(value, (np.ndarray, torch.Tensor)) and value.ndim > 0 and value.shape[0] == len(probe)):
+            continue
+        # The leading-dimension match alone is already damning given the collision-free probe
+        # size above, but where the full shape also matches the raw probe, confirm the content
+        # actually is the probe -- so the failure message can say "retained the evaluated batch"
+        # and mean it literally, rather than resting on a shape coincidence.
+        as_array = value.detach().cpu().numpy() if isinstance(value, torch.Tensor) else value
+        if as_array.shape == probe.shape and np.array_equal(as_array, probe):
+            raise AssertionError(f"UCAD retained the evaluated batch verbatim in '{name}'")
+        raise AssertionError(
+            f"UCAD retained data shaped like the evaluated batch in '{name}' (leading dim == {len(probe)})"
+        )
+    assert model._cached_image_scores is None

--- a/tests/vision/models/test_ucad_structure.py
+++ b/tests/vision/models/test_ucad_structure.py
@@ -1,0 +1,137 @@
+import numpy as np
+import pytest
+from PIL import Image
+
+from pyclad.vision.models.ucad.config import UCADConfig
+from pyclad.vision.models.ucad.structure import (
+    NoStructureMaskProvider,
+    PrecomputedStructureMaskProvider,
+    build_structure_mask_provider,
+    category_of,
+)
+
+
+def _write_label_map(path, values):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(np.asarray(values, dtype=np.uint8), mode="L").save(path)
+
+
+def test_category_of_strips_a_multidataset_prefix():
+    assert category_of("mvtec__bottle") == "bottle"
+    assert category_of("bottle") == "bottle"
+
+
+def test_no_provider_returns_none():
+    provider = NoStructureMaskProvider()
+
+    assert provider.masks_for("bottle", np.zeros((2, 4, 4, 3), dtype=np.uint8)) is None
+
+
+def test_precomputed_provider_loads_in_sorted_order(tmp_path):
+    directory = tmp_path / "bottle" / "train" / "good"
+    _write_label_map(directory / "001.png", [[2, 2], [2, 2]])
+    _write_label_map(directory / "000.png", [[1, 1], [1, 1]])
+
+    provider = PrecomputedStructureMaskProvider(tmp_path)
+    masks = provider.masks_for("bottle", np.zeros((2, 2, 2, 3), dtype=np.uint8))
+
+    assert masks.shape == (2, 2, 2)
+    assert masks.dtype == np.int64
+    assert masks[0].max() == 1  # 000.png sorts first
+    assert masks[1].max() == 2
+
+
+def test_precomputed_provider_resolves_a_multidataset_concept_id(tmp_path):
+    _write_label_map(tmp_path / "bottle" / "train" / "good" / "000.png", [[3, 3], [3, 3]])
+
+    provider = PrecomputedStructureMaskProvider(tmp_path)
+    masks = provider.masks_for("mvtec__bottle", np.zeros((1, 2, 2, 3), dtype=np.uint8))
+
+    assert masks[0].max() == 3
+
+
+def test_precomputed_provider_resizes_to_the_image_grid(tmp_path):
+    _write_label_map(tmp_path / "bottle" / "000.png", [[1, 1], [1, 1]])
+
+    provider = PrecomputedStructureMaskProvider(tmp_path)
+    masks = provider.masks_for("bottle", np.zeros((1, 8, 6, 3), dtype=np.uint8))
+
+    assert masks.shape == (1, 8, 6)
+
+
+def test_precomputed_provider_reads_channel_0_not_luma_for_rgb_label_maps(tmp_path):
+    # Pins the reference's cv2.imread(...)[:, :, 0] semantics: ids must come from channel 0
+    # untouched, not from an RGB->luma blend with the other two channels.
+    directory = tmp_path / "bottle"
+    directory.mkdir(parents=True, exist_ok=True)
+    ids = np.array([[10, 200], [50, 1]], dtype=np.uint8)
+    other = np.full_like(ids, 128)  # far enough from channel 0 that luma blending is obvious
+    rgb = np.stack([ids, other, other], axis=-1)
+    Image.fromarray(rgb, mode="RGB").save(directory / "000.png")
+
+    provider = PrecomputedStructureMaskProvider(tmp_path)
+    masks = provider.masks_for("bottle", np.zeros((1, 2, 2, 3), dtype=np.uint8))
+
+    assert np.array_equal(masks[0], ids.astype(np.int64))
+
+
+def test_precomputed_provider_nearest_interpolation_preserves_source_ids(tmp_path):
+    # Nearest neighbor must not blend adjacent distinct ids into interpolated in-between
+    # values the way bilinear does when upsampling.
+    _write_label_map(tmp_path / "bottle" / "000.png", [[1, 1], [200, 200]])
+
+    nearest_provider = PrecomputedStructureMaskProvider(tmp_path, interpolation="nearest")
+    nearest_masks = nearest_provider.masks_for("bottle", np.zeros((1, 8, 2, 3), dtype=np.uint8))
+
+    assert nearest_masks.shape == (1, 8, 2)
+    assert set(np.unique(nearest_masks[0])) == {1, 200}
+
+    # Sanity check that this scenario actually exercises interpolation: the default
+    # bilinear path introduces values absent from the source, unlike nearest above.
+    bilinear_provider = PrecomputedStructureMaskProvider(tmp_path)
+    bilinear_masks = bilinear_provider.masks_for("bottle", np.zeros((1, 8, 2, 3), dtype=np.uint8))
+
+    assert not set(np.unique(bilinear_masks[0])) <= {1, 200}
+
+
+def test_precomputed_provider_rejects_a_count_mismatch(tmp_path):
+    _write_label_map(tmp_path / "bottle" / "000.png", [[1, 1], [1, 1]])
+
+    provider = PrecomputedStructureMaskProvider(tmp_path)
+
+    with pytest.raises(ValueError, match="1 structure mask"):
+        provider.masks_for("bottle", np.zeros((3, 2, 2, 3), dtype=np.uint8))
+
+
+def test_precomputed_provider_reports_the_directories_it_tried(tmp_path):
+    provider = PrecomputedStructureMaskProvider(tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="Checked:"):
+        provider.masks_for("bottle", np.zeros((1, 2, 2, 3), dtype=np.uint8))
+
+
+def test_precomputed_provider_rejects_a_missing_concept_id(tmp_path):
+    # Reachable by running UCADStrategy under ConceptIncrementalScenario (which it declares
+    # support for) with structure_mode="precomputed": no concept id ever reaches fit(), so
+    # `names` would stay empty and produce an uninformative "Checked: " with nothing after it.
+    provider = PrecomputedStructureMaskProvider(tmp_path)
+
+    with pytest.raises(ValueError, match="needs a concept id"):
+        provider.masks_for(None, np.zeros((1, 2, 2, 3), dtype=np.uint8))
+
+
+def test_precomputed_provider_rejects_an_unknown_interpolation_mode(tmp_path):
+    with pytest.raises(ValueError, match="interpolation"):
+        PrecomputedStructureMaskProvider(tmp_path, interpolation="cubic")
+
+
+def test_builder_returns_the_no_op_provider_for_the_cpm_only_ablation():
+    provider = build_structure_mask_provider(UCADConfig(structure_mode="none"), "cpu")
+
+    assert isinstance(provider, NoStructureMaskProvider)
+
+
+def test_builder_returns_the_precomputed_provider(tmp_path):
+    config = UCADConfig(structure_mode="precomputed", structure_mask_root=str(tmp_path))
+
+    assert isinstance(build_structure_mask_provider(config, "cpu"), PrecomputedStructureMaskProvider)

--- a/tests/vision/strategies/ucad/test_strategy.py
+++ b/tests/vision/strategies/ucad/test_strategy.py
@@ -1,0 +1,75 @@
+import numpy as np
+import pytest
+
+from pyclad.vision.models.ucad.config import UCADConfig
+from pyclad.vision.models.ucad.ucad import UCAD
+from pyclad.vision.prediction_results import VisionPredictionResults
+from pyclad.vision.strategies.ucad.strategy import UCADStrategy
+
+pytest.importorskip("timm")
+
+
+def _model() -> UCAD:
+    return UCAD(
+        UCADConfig(
+            backbone_name="vit_tiny_patch16_224",
+            pretrained_backbone=False,
+            input_size=(32, 32),
+            input_range="float01",
+            batch_size=2,
+            feature_layer=3,
+            prompt_depth=3,
+            target_embed_dimension=16,
+            key_size=3,
+            knowledge_size=3,
+            coreset_projection_dimension=4,
+            coreset_starting_points=2,
+            epochs=1,
+            seed=0,
+        )
+    )
+
+
+def _images(count: int, fill: float, seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return (rng.random((count, 32, 32, 3), dtype=np.float32) * 0.1 + fill).astype(np.float32)
+
+
+def test_learn_forwards_the_concept_id_to_the_model():
+    strategy = UCADStrategy(_model())
+
+    strategy.learn(_images(4, 0.2), concept_id="bottle")
+
+    assert [memory.concept_id for memory in strategy._model.task_memories] == ["bottle"]
+
+
+def test_learn_accumulates_tasks_across_the_stream():
+    strategy = UCADStrategy(_model())
+
+    strategy.learn(_images(4, 0.05, seed=1), concept_id="dark")
+    strategy.learn(_images(4, 0.85, seed=2), concept_id="bright")
+
+    assert len(strategy._model.task_memories) == 2
+    assert strategy.additional_info()["tasks_seen"] == 2
+
+
+def test_predict_ignores_the_concept_id_it_is_given():
+    strategy = UCADStrategy(_model())
+    strategy.learn(_images(4, 0.05, seed=1), concept_id="dark")
+    strategy.learn(_images(4, 0.85, seed=2), concept_id="bright")
+    data = _images(3, 0.05, seed=3)
+
+    honest = strategy.predict(data, concept_id="dark")
+    misleading = strategy.predict(data, concept_id="bright")
+    absent = strategy.predict(data)
+
+    np.testing.assert_array_equal(honest.anomaly_scores, misleading.anomaly_scores)
+    np.testing.assert_array_equal(honest.anomaly_scores, absent.anomaly_scores)
+    assert isinstance(honest, VisionPredictionResults)
+
+
+def test_strategy_reports_itself():
+    strategy = UCADStrategy(_model())
+
+    assert strategy.name() == "UCAD"
+    assert strategy.additional_info()["task_agnostic_inference"] is True

--- a/tests/vision/test_docs_references.py
+++ b/tests/vision/test_docs_references.py
@@ -1,0 +1,79 @@
+"""Every ``docs/*.md`` pointer in the source must name a section, and that section must exist.
+
+Docstrings that promise documentation ("recorded in ``docs/vision.md``") outlive the paragraph
+they were written against: the doc gets restructured, the promised list is never written, and
+nothing fails. So a pointer has to name its target -- ``"Data leakage" in docs/vision.md`` --
+and this test resolves that name against the file's actual headings.
+"""
+
+import pathlib
+import re
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCANNED_TREES = ("src/pyclad", "examples")
+
+# A pointer that names its section: `"Some heading" in docs/whatever.md`, with optional
+# reST/Markdown backticks around the path. Whitespace is normalised first, so the phrase is
+# still matched when a docstring wraps it across lines.
+NAMED_REFERENCE = re.compile(
+    r"[\"'`]{1,2}(?P<section>[^\"'`\n]+?)[\"'`]{1,2}\s+in\s+`{0,2}(?P<doc>docs/[\w./-]+\.md)`{0,2}"
+)
+ANY_REFERENCE = re.compile(r"docs/[\w./-]+\.md")
+MARKDOWN_HEADING = re.compile(r"^#{1,6}\s+(?P<title>.+?)\s*$", re.MULTILINE)
+# Headings carry inline markup (`**bold**`, `` `code` ``) that a prose pointer will not repeat.
+HEADING_MARKUP = re.compile(r"[*_`]")
+
+
+def _python_sources():
+    for tree in SCANNED_TREES:
+        for path in sorted((REPO_ROOT / tree).rglob("*.py")):
+            yield path
+
+
+def _normalised(text: str) -> str:
+    return re.sub(r"\s+", " ", text)
+
+
+def _headings_of(doc: pathlib.Path) -> set:
+    return {
+        HEADING_MARKUP.sub("", m.group("title")).strip().casefold()
+        for m in MARKDOWN_HEADING.finditer(doc.read_text(encoding="utf-8"))
+    }
+
+
+def test_every_docs_pointer_names_a_section():
+    unnamed = []
+    for path in _python_sources():
+        text = _normalised(path.read_text(encoding="utf-8"))
+        named_spans = [m.span("doc") for m in NAMED_REFERENCE.finditer(text)]
+        for match in ANY_REFERENCE.finditer(text):
+            if not any(start <= match.start() and match.end() <= end for start, end in named_spans):
+                unnamed.append(f"{path.relative_to(REPO_ROOT)}: {match.group()}")
+
+    assert not unnamed, (
+        "These pointers name a doc file but no section inside it, so nothing can verify the "
+        "promised content exists. Write them as '\"Section heading\" in docs/<file>.md':\n  " + "\n  ".join(unnamed)
+    )
+
+
+def test_every_referenced_section_exists():
+    missing = []
+    for path in _python_sources():
+        for match in NAMED_REFERENCE.finditer(_normalised(path.read_text(encoding="utf-8"))):
+            doc = REPO_ROOT / match.group("doc")
+            section = match.group("section").strip()
+            if not doc.is_file():
+                missing.append(f"{path.relative_to(REPO_ROOT)}: {match.group('doc')} does not exist")
+            elif section.casefold() not in _headings_of(doc):
+                missing.append(f"{path.relative_to(REPO_ROOT)}: {match.group('doc')} has no heading {section!r}")
+
+    assert not missing, "Referenced documentation sections are missing:\n  " + "\n  ".join(missing)
+
+
+def test_the_check_would_catch_a_broken_pointer(tmp_path):
+    """Guard against the regexes silently matching nothing and the tests above passing vacuously."""
+    text = _normalised('promised under "Nonexistent Heading" in ``docs/vision.md``.')
+    match = NAMED_REFERENCE.search(text)
+    assert match is not None and match.group("doc") == "docs/vision.md"
+    assert match.group("section") == "Nonexistent Heading"
+    assert match.group("section").casefold() not in _headings_of(REPO_ROOT / "docs/vision.md")


### PR DESCRIPTION
Ports UCAD as a vision model plus its own continual strategy.

Each concept appends one entry to a memory that is never reset: a **key** coreset of frozen-ViT patch features, a **prompt** of learned attention prefixes trained with structure-based contrastive learning over SAM region maps, and a **knowledge** coreset. At inference an image is routed to a task by its nearest key and scored against that task's knowledge bank, so task identity is inferred from the data and never supplied by the caller. Hyperparameters follow the reference code rather than the paper prose where the two disagree. `docs/vision.md` records each value's provenance.

## How it differs from the reference implementation

The published numbers depend on test-set leakage, so results here are lower **by design** and are not comparable to the paper's Tables 1–4:

| Reference (`run_ucad.py`) | Here |
|---|---|
| prompt and knowledge bank kept from the best test-AUROC epoch (262–264) | fixed 25 epochs, last one kept, no selection criterion |
| reported score is a running ensemble across epochs (128 vs 149) | one evaluation |
| min-max normalisation over the whole test set (190–211) | none |
| continual evaluation loop commented out (410–509) | pyCLAD's concept × concept matrix |
| "FM" = gap between two memory budgets | `ForgettingMeasure` / `BackwardTransfer` |
| one task id per test set | per image, following Eq. 4 |

Two smaller deliberate deviations: distances are squared to match the reference's faiss index, and routing takes the mean over patches rather than the max — a max is dominated by the anomaly itself and would systematically misroute defective images.

## Tests

`tests/vision/models/test_ucad_no_leakage.py` pins the no-leakage guarantee as executable assertions: scores must not change when the evaluated batch is regrouped or reordered, `predict()` must not mutate learned state, the threshold must come only from training scores, unknown kwargs must not be stored, and the strategy must ignore the concept id it is handed.